### PR TITLE
fix(sandbox): pin jest@29.7.0 so .toThrowError resolves

### DIFF
--- a/sandboxes/aider-polyglot/Dockerfile
+++ b/sandboxes/aider-polyglot/Dockerfile
@@ -70,7 +70,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     mkdir -p /npm-install && cd /npm-install && \
     npm init -y && \
     npm install \
-      jest \
+      jest@29.7.0 \
       @babel/core@7.25.2 \
       @exercism/babel-preset-javascript@0.2.1 \
       @exercism/eslint-config-javascript@0.6.0 \


### PR DESCRIPTION
## Summary
- Pin `jest@29.7.0` in `sandboxes/aider-polyglot/Dockerfile` (was unpinned, floated to **v30.4.2**).
- Jest 30 removed the `.toThrowError` matcher alias; the canonical polyglot specs still call it, so `affine-cipher` and `resistor-color-trio` threw `TypeError: expect(...).toThrowError is not a function` and could **never pass, regardless of the model**.
- 29.7.0 matches the already-pinned `babel-jest@29.6.4` / `@types/jest@29.5.12` toolchain. Vendored specs are untouched (canonical clone from `Aider-AI/polyglot-benchmark`).

Fixes #4

## Validation
- [ ] Rebuild sandbox image
- [ ] `npm ls jest` → `29.7.0`
- [ ] `.toThrowError(...)` resolves in-image (no `is not a function`)
- [ ] Re-run aider-polyglot-30 → affine-cipher reaches its tests