### PR TITLE
fix: durable sandbox logs (#6) + aider timeout/partial-headline (#3)

### DIFF
--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -180,7 +180,14 @@ def _markdown(result: RunResult) -> str:
         lines.append("---|---:|---:|---|---:|---:|---")
 
     for pack in result.packs:
-        status = "skipped" if pack.skipped else ("ok" if pack.total else pack.status)
+        if pack.skipped:
+            status = "skipped"
+        elif pack.status not in ("ok", "stubbed"):
+            # #3: surface a real failure mode (e.g. agent_runner_timeout) even
+            # when total>0, so a graceful partial (18/30) isn't masked as "ok".
+            status = pack.status
+        else:
+            status = "ok" if pack.total else pack.status
         score = f"{pack.score:.0%}" if pack.total else "-"
         p50 = "-" if pack.latency["p50"] is None else f"{pack.latency['p50']:.2f}s"
         p95 = "-" if pack.latency["p95"] is None else f"{pack.latency['p95']:.2f}s"

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -252,7 +252,16 @@ class Runner:
             if not meta.get("supports_sandboxed_only") or pack_id in self._sandbox_clients:
                 continue
             try:
-                client = SandboxClient(config_for_pack(pack_id, self.sandbox_image_tag))
+                # #3: pass the per-case budget through so the aider batch
+                # (one /verify-start spanning all 30 exercises) honors a raised
+                # --timeout-per-case on slow rigs instead of the default cap.
+                client = SandboxClient(
+                    config_for_pack(
+                        pack_id,
+                        self.sandbox_image_tag,
+                        batch_timeout_s=self.timeout_per_case,
+                    )
+                )
                 # #6: when --sandbox-log-dir is set, give the sandbox a writable
                 # host run-dir so per-unit artifacts persist live (survive --rm/
                 # crash/timeout). No-op for packs without a run_output_dir.
@@ -340,9 +349,48 @@ class Runner:
                 runs.append(self.run_scenario(meta, scenario, repeat_index=repeat_index))
 
         counted = [run for run in runs if run.result.failure_mode != "verifier_not_implemented"]
+        latencies = [run.result.latency_seconds for run in counted if run.result.latency_seconds > 0]
+
+        # #3: single-scoreboard packs (aider) run their entire sub-suite inside
+        # one scenario. Surface the real per-unit X/Y in the pack headline
+        # rather than collapsing to a binary 1/1 or 0/1 — which buried both the
+        # true success rate (16/30 shown as "1/1 = 100%") and graceful partial
+        # results on timeout (18/30 shown as "0/1 = 0%").
+        if meta.get("_architecture") == "single-scoreboard" and counted:
+            sr = counted[0].result
+            if sr.total_count:
+                sb_passed = sr.passed_count or 0
+                sb_total = sr.total_count
+                sb_score = sr.pass_rate if sr.pass_rate is not None else (
+                    sb_passed / sb_total if sb_total else 0.0
+                )
+                # Surface error failure modes (timeout/crash/unreachable) in the
+                # status column. A clean pass or a below-threshold "verifier_fail"
+                # both ran fine, so the score conveys the outcome (status "ok").
+                sb_status = (
+                    sr.failure_mode
+                    if sr.failure_mode in (
+                        "agent_runner_timeout", "agent_runner_crashed",
+                        "model_endpoint_unreachable", "server_error",
+                        "result_json_malformed",
+                    )
+                    else "ok"
+                )
+                return PackResult(
+                    pack_id=pack_id,
+                    version=meta["version"],
+                    upstream_commit=meta["upstream_commit"],
+                    scenario_count=len(scenarios),
+                    passed=sb_passed,
+                    total=sb_total,
+                    score=sb_score,
+                    latency=_latency(latencies),
+                    scenarios=runs,
+                    status=sb_status,
+                )
+
         passed = sum(1 for run in counted if run.result.passed)
         total = len(counted)
-        latencies = [run.result.latency_seconds for run in counted if run.result.latency_seconds > 0]
         return PackResult(
             pack_id=pack_id,
             version=meta["version"],

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -253,7 +253,14 @@ class Runner:
                 continue
             try:
                 client = SandboxClient(config_for_pack(pack_id, self.sandbox_image_tag))
-                client.start()
+                # #6: when --sandbox-log-dir is set, give the sandbox a writable
+                # host run-dir so per-unit artifacts persist live (survive --rm/
+                # crash/timeout). No-op for packs without a run_output_dir.
+                run_dir = (
+                    os.path.join(self.sandbox_log_dir, f"{pack_id}-run")
+                    if self.sandbox_log_dir else None
+                )
+                client.start(run_dir=run_dir)
                 self._sandbox_clients[pack_id] = client
             except Exception as exc:
                 msg = (

--- a/benchlocal_cli/sandbox.py
+++ b/benchlocal_cli/sandbox.py
@@ -35,6 +35,16 @@ class SandboxConfig:
     # Hermes runs upstream agent loops with real LLM calls and needs ~15min;
     # bugfind/cli stay at 60s.
     request_timeout_s: float = 60.0
+    # #6: container path where the pack writes its per-unit run artifacts. When
+    # the runner supplies a host run-dir (derived from --sandbox-log-dir), this
+    # path is bind-mounted WRITABLE so artifacts persist to the host as they're
+    # written — surviving `docker run --rm`, crashes, and timeouts. None means
+    # the pack opts out of the run mount.
+    run_output_dir: str | None = None
+    # Extra `-e KEY=VALUE` env applied ONLY when the writable run mount is
+    # active (e.g. tell the aider sandbox to keep its job dirs rather than
+    # rmtree-ing them so the mounted artifacts survive the verify call).
+    run_mount_env: tuple[tuple[str, str], ...] = ()
 
 
 # Default registry of sandbox configs (read by Runner when --enable-sandboxed-packs is set).
@@ -77,6 +87,12 @@ SANDBOX_REGISTRY = {
         # total, but contributors with slower hardware (e.g., 24 GB single
         # card, longer-context models) need this headroom on stress runs.
         request_timeout_s=3000.0,
+        # #6: persist per-exercise artifacts to the host when --sandbox-log-dir
+        # is set. server.py writes job dirs under /tmp/aider-polyglot-runs and
+        # rmtree's them in a `finally` unless BENCHLOCAL_AIDER_KEEP_JOBDIRS=1 —
+        # so the mount AND the keep-env are both needed for durability.
+        run_output_dir="/tmp/aider-polyglot-runs",
+        run_mount_env=(("BENCHLOCAL_AIDER_KEEP_JOBDIRS", "1"),),
     ),
 }
 
@@ -261,11 +277,10 @@ class SandboxClient:
         self.config = config
         self._container_id: str | None = None
 
-    def start(self, *, ready_timeout_s: float = 30.0) -> None:
-        """Start the container; block until /health returns 200 or ready_timeout_s expires."""
-        if self._container_id:
-            return
-        name = f"benchlocal-{self.config.pack_id}-{int(time.time() * 1000)}"
+    def _build_docker_run_argv(self, name: str, run_dir: str | None) -> list[str]:
+        """Assemble the `docker run` argv. Pure (no side effects beyond reading
+        config/env) so it can be unit-tested. `run_dir` is the host path to
+        bind-mount writable at `config.run_output_dir` (#6); None disables it."""
         cmd = [
             "docker",
             "run",
@@ -281,6 +296,14 @@ class SandboxClient:
             cmd.extend(["-v", f"{host_path}:{container_path}:ro"])
         for key, value in self.config.env:
             cmd.extend(["-e", f"{key}={value}"])
+        # #6: writable host run-dir mount — persists per-unit run artifacts to
+        # the host AS THEY'RE WRITTEN (survives --rm/crash/timeout, no docker cp
+        # / teardown-capture race). Only when the caller supplies a host dir AND
+        # this pack declares a run_output_dir. NOTE: deliberately NOT `:ro`.
+        if run_dir and self.config.run_output_dir:
+            cmd.extend(["-v", f"{run_dir}:{self.config.run_output_dir}"])
+            for key, value in self.config.run_mount_env:
+                cmd.extend(["-e", f"{key}={value}"])
         # v0.9.0: aider-polyglot needs to call out to the runner's model
         # endpoint from inside the container. On Linux, host.docker.internal
         # only resolves with this --add-host flag (Codex 2nd-pass #2).
@@ -293,6 +316,20 @@ class SandboxClient:
         ):
             cmd.extend(["--add-host", "host.docker.internal:host-gateway"])
         cmd.append(self.config.image_name)
+        return cmd
+
+    def start(self, *, ready_timeout_s: float = 30.0, run_dir: str | None = None) -> None:
+        """Start the container; block until /health returns 200 or ready_timeout_s expires.
+
+        When `run_dir` is supplied and the pack declares `run_output_dir`, the
+        host dir is created and bind-mounted writable so run artifacts persist
+        to the host live (#6)."""
+        if self._container_id:
+            return
+        name = f"benchlocal-{self.config.pack_id}-{int(time.time() * 1000)}"
+        if run_dir and self.config.run_output_dir:
+            Path(run_dir).mkdir(parents=True, exist_ok=True)
+        cmd = self._build_docker_run_argv(name, run_dir)
         try:
             proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
         except (FileNotFoundError, subprocess.CalledProcessError) as exc:
@@ -526,6 +563,8 @@ def config_for_pack(pack_id: str, image_tag: str = "latest") -> SandboxConfig:
         host_mounts=host_mounts,
         env=env,
         request_timeout_s=config.request_timeout_s,
+        run_output_dir=config.run_output_dir,
+        run_mount_env=config.run_mount_env,
     )
 
 

--- a/benchlocal_cli/sandbox.py
+++ b/benchlocal_cli/sandbox.py
@@ -47,6 +47,14 @@ class SandboxConfig:
     run_mount_env: tuple[tuple[str, str], ...] = ()
 
 
+# #3: aider batch timeout budget. The inner subprocess cap (server-side
+# AIDER_BENCHMARK_TIMEOUT_S) defaults here; --timeout-per-case can only RAISE
+# it (never lower it below this default). request_timeout_s tracks the inner
+# cap plus headroom so the outer HTTP read doesn't fire before the inner kill.
+_AIDER_DEFAULT_BATCH_TIMEOUT_S = 3600.0
+_AIDER_REQUEST_TIMEOUT_HEADROOM_S = 300.0
+
+
 # Default registry of sandbox configs (read by Runner when --enable-sandboxed-packs is set).
 SANDBOX_REGISTRY = {
     "bugfind-15": SandboxConfig(
@@ -79,14 +87,14 @@ SANDBOX_REGISTRY = {
         host_port=9004,
         network_isolated=False,  # aider needs to call out to model_endpoint
         multi_turn=True,         # uses /verify-start with verify-final early-out
-        # 50-min read timeout: the entire batch (30 exercises × multi-turn
-        # aider edit/test loops) lives inside one /verify-start call. The
-        # inner subprocess timeout is 2700s; this gives +5min headroom.
-        # First Qwen-with-thinking-on run hit the 1500s inner cap with 0
-        # exercises completed; thinking-off run paced ~40s/exercise = ~20min
-        # total, but contributors with slower hardware (e.g., 24 GB single
-        # card, longer-context models) need this headroom on stress runs.
-        request_timeout_s=3000.0,
+        # Read timeout: the entire batch (30 exercises × multi-turn aider
+        # edit/test loops) lives inside one /verify-start call. Tracks the inner
+        # subprocess cap (_AIDER_DEFAULT_BATCH_TIMEOUT_S = 3600s) plus headroom.
+        # config_for_pack recomputes this from --timeout-per-case so slow rigs
+        # (24 GB single card, low-power, long-context models) can raise it; the
+        # default was bumped from 2700→3600s after a PL250W rig hit the cap on
+        # the last exercise (#3).
+        request_timeout_s=3900.0,
         # #6: persist per-exercise artifacts to the host when --sandbox-log-dir
         # is set. server.py writes job dirs under /tmp/aider-polyglot-runs and
         # rmtree's them in a `finally` unless BENCHLOCAL_AIDER_KEEP_JOBDIRS=1 —
@@ -503,17 +511,34 @@ def _resolve_venv_python_root(host_install: str) -> tuple[str, str] | None:
     return (install_root, install_root)
 
 
-def config_for_pack(pack_id: str, image_tag: str = "latest") -> SandboxConfig:
+def config_for_pack(
+    pack_id: str,
+    image_tag: str = "latest",
+    *,
+    batch_timeout_s: float | None = None,
+) -> SandboxConfig:
     config = SANDBOX_REGISTRY[pack_id]
     base = config.image_name.split(":", 1)[0]
     host_mounts: tuple[tuple[str, str], ...] = config.host_mounts
     env: tuple[tuple[str, str], ...] = config.env
+    request_timeout_s = config.request_timeout_s
     if pack_id == "aider-polyglot-30":
         # v0.9.0: parallelize aider's batch across N threads. Default 4 to
         # match the vLLM gemma-mtp compose's --max-num-seqs 4. Override
         # via BENCHLOCAL_AIDER_THREADS env on the runner side.
         threads = os.environ.get("BENCHLOCAL_AIDER_THREADS", "4")
         env = env + (("AIDER_BENCHMARK_THREADS", threads),)
+        # #3: the whole 30-exercise batch runs inside one /verify-start call,
+        # so the per-case timeout governs the BATCH budget here. Slow rigs
+        # (low-power single card, long-context models) need more than the
+        # default. `--timeout-per-case` can only RAISE the inner subprocess
+        # cap (never drop it below the default); request_timeout_s tracks it
+        # with headroom so the outer HTTP read doesn't fire first.
+        inner = _AIDER_DEFAULT_BATCH_TIMEOUT_S
+        if batch_timeout_s and batch_timeout_s > inner:
+            inner = float(batch_timeout_s)
+        env = env + (("AIDER_BENCHMARK_TIMEOUT_S", str(int(inner))),)
+        request_timeout_s = inner + _AIDER_REQUEST_TIMEOUT_HEADROOM_S
 
     if pack_id == "hermesagent-20":
         # Per-scenario subprocess wall-clock cap inside the container. Default
@@ -562,7 +587,7 @@ def config_for_pack(pack_id: str, image_tag: str = "latest") -> SandboxConfig:
         multi_turn=config.multi_turn,
         host_mounts=host_mounts,
         env=env,
-        request_timeout_s=config.request_timeout_s,
+        request_timeout_s=request_timeout_s,
         run_output_dir=config.run_output_dir,
         run_mount_env=config.run_mount_env,
     )

--- a/sandboxes/aider-polyglot/server.py
+++ b/sandboxes/aider-polyglot/server.py
@@ -219,6 +219,20 @@ def _build_benchmark_args(
     return argv
 
 
+def _link_or_copy(src: str, dst: str) -> None:
+    """Hard-link a file (cheap, no disk duplication), falling back to a real
+    copy when the link would cross filesystems.
+
+    #6: when --sandbox-log-dir is set, the job dir lives on a host bind-mount,
+    so os.link from the container's overlayfs raises OSError (EXDEV, "Invalid
+    cross-device link"). The staged exercises are small text files, so copying
+    them is cheap. Without this fallback the whole batch fails at staging."""
+    try:
+        os.link(src, dst)
+    except OSError:
+        shutil.copy2(src, dst)
+
+
 def _stage_exercises_workspace(stage_dir: Path) -> Path:
     """Create a `polyglot-benchmark` tree under `stage_dir` containing
     ONLY the canonical 30 exercises. Avoids relying on --keywords substring
@@ -244,9 +258,10 @@ def _stage_exercises_workspace(stage_dir: Path) -> Path:
         dst.parent.mkdir(parents=True, exist_ok=True)
         if not src.is_dir():
             continue  # missing exercise — surfaced in _exercise_count_status()
-        # Hard-link individual files (cheap, doesn't duplicate disk).
-        # cp -al equivalent.
-        shutil.copytree(src, dst, copy_function=os.link, dirs_exist_ok=True)
+        # Hard-link individual files (cheap, doesn't duplicate disk); fall back
+        # to a copy when the job dir is a host bind-mount (#6) and links would
+        # cross devices. cp -al equivalent with EXDEV resilience.
+        shutil.copytree(src, dst, copy_function=_link_or_copy, dirs_exist_ok=True)
     # Stand up a minimal git repo so benchmark.py's git.Repo() succeeds.
     # benchmark.py reads repo.head.object.hexsha[:7] — needs an actual
     # commit, not just `git init`. Make one empty commit.

--- a/tests/test_aider_polyglot.py
+++ b/tests/test_aider_polyglot.py
@@ -302,3 +302,34 @@ def test_pack_loads_via_runner():
     assert meta.get("supports_sandboxed_only") is True
     assert len(scenarios) == 1
     assert scenarios[0]["id"] == "aider-polyglot-30-batch"
+
+
+# ============================================================================
+# _link_or_copy — #6 EXDEV resilience (job dir on a host bind-mount)
+# ============================================================================
+
+def test_link_or_copy_hardlinks_when_possible(tmp_path):
+    server = _server()
+    src = tmp_path / "a.txt"
+    src.write_text("exercise content")
+    dst = tmp_path / "b.txt"
+    server._link_or_copy(str(src), str(dst))
+    assert dst.read_text() == "exercise content"
+    assert src.stat().st_ino == dst.stat().st_ino  # same inode → hard link
+
+
+def test_link_or_copy_falls_back_on_cross_device(tmp_path, monkeypatch):
+    """When os.link raises EXDEV (job dir is a host bind-mount, #6), staging
+    must copy the file rather than fail the whole batch."""
+    server = _server()
+    src = tmp_path / "src.txt"
+    src.write_text("exercise content")
+    dst = tmp_path / "dst.txt"
+
+    def _raise_exdev(_s, _d):
+        raise OSError(18, "Invalid cross-device link")
+
+    monkeypatch.setattr(server.os, "link", _raise_exdev)
+    server._link_or_copy(str(src), str(dst))
+    assert dst.read_text() == "exercise content"
+    assert src.stat().st_ino != dst.stat().st_ino  # copied, not linked

--- a/tests/test_aider_polyglot.py
+++ b/tests/test_aider_polyglot.py
@@ -291,7 +291,7 @@ def test_pack_registered_in_sandbox_registry():
     cfg = SANDBOX_REGISTRY["aider-polyglot-30"]
     assert cfg.host_port == 9004
     assert cfg.multi_turn is True
-    assert cfg.request_timeout_s == 3000.0
+    assert cfg.request_timeout_s == 3900.0
 
 
 def test_pack_loads_via_runner():

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -466,3 +466,52 @@ def test_config_for_pack_non_hermes_no_bind_mount():
     assert config.host_mounts == ()
     assert config.env == ()
     assert config.request_timeout_s == 60.0
+
+
+# ---------------------------------------------------------------------------
+# #6: writable host run-dir bind-mount (durable sandbox artifacts)
+# ---------------------------------------------------------------------------
+
+def test_config_for_pack_aider_declares_run_output_dir():
+    from benchlocal_cli import sandbox as sandbox_module
+
+    config = sandbox_module.config_for_pack("aider-polyglot-30")
+    assert config.run_output_dir == "/tmp/aider-polyglot-runs"
+    # keep-jobdirs env is gated on the run mount being active
+    assert ("BENCHLOCAL_AIDER_KEEP_JOBDIRS", "1") in config.run_mount_env
+
+
+def test_aider_docker_argv_adds_writable_run_mount(tmp_path):
+    """With a host run-dir, aider's docker argv bind-mounts it WRITABLE (not :ro)
+    at the container run_output_dir and sets the keep-jobdirs env so server.py
+    doesn't rmtree the artifacts."""
+    from benchlocal_cli.sandbox import SandboxClient, config_for_pack
+
+    client = SandboxClient(config_for_pack("aider-polyglot-30"))
+    run_dir = str(tmp_path / "aider-run")
+    argv = client._build_docker_run_argv("test-name", run_dir)
+
+    assert f"{run_dir}:/tmp/aider-polyglot-runs" in argv          # writable mount present
+    assert f"{run_dir}:/tmp/aider-polyglot-runs:ro" not in " ".join(argv)  # NOT read-only
+    assert "BENCHLOCAL_AIDER_KEEP_JOBDIRS=1" in argv             # keep-jobdirs env present
+
+
+def test_aider_docker_argv_no_run_mount_without_run_dir():
+    from benchlocal_cli.sandbox import SandboxClient, config_for_pack
+
+    client = SandboxClient(config_for_pack("aider-polyglot-30"))
+    argv = client._build_docker_run_argv("test-name", None)
+
+    assert "/tmp/aider-polyglot-runs" not in " ".join(argv)
+    assert "BENCHLOCAL_AIDER_KEEP_JOBDIRS=1" not in argv
+
+
+def test_non_runmount_pack_ignores_run_dir(tmp_path):
+    """A pack without run_output_dir (bugfind) gets no run mount even when a
+    host run-dir is supplied."""
+    from benchlocal_cli.sandbox import SandboxClient, config_for_pack
+
+    client = SandboxClient(config_for_pack("bugfind-15"))
+    argv = client._build_docker_run_argv("test-name", str(tmp_path / "x"))
+
+    assert "-v" not in argv  # no host_mounts and no run_output_dir → no bind-mounts

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -515,3 +515,107 @@ def test_non_runmount_pack_ignores_run_dir(tmp_path):
     argv = client._build_docker_run_argv("test-name", str(tmp_path / "x"))
 
     assert "-v" not in argv  # no host_mounts and no run_output_dir → no bind-mounts
+
+
+# ---------------------------------------------------------------------------
+# #3-A: aider batch timeout honors --timeout-per-case (raises, never lowers)
+# ---------------------------------------------------------------------------
+
+def test_config_for_pack_aider_default_batch_timeout():
+    from benchlocal_cli import sandbox as sandbox_module
+    config = sandbox_module.config_for_pack("aider-polyglot-30")
+    assert dict(config.env)["AIDER_BENCHMARK_TIMEOUT_S"] == "3600"
+    assert config.request_timeout_s == 3900.0
+
+
+def test_config_for_pack_aider_raises_batch_timeout_from_per_case():
+    from benchlocal_cli import sandbox as sandbox_module
+    config = sandbox_module.config_for_pack("aider-polyglot-30", batch_timeout_s=7200)
+    assert dict(config.env)["AIDER_BENCHMARK_TIMEOUT_S"] == "7200"
+    assert config.request_timeout_s == 7500.0
+
+
+def test_config_for_pack_aider_per_case_never_lowers_default():
+    """A small per-case budget must NOT crush the batch below the default."""
+    from benchlocal_cli import sandbox as sandbox_module
+    config = sandbox_module.config_for_pack("aider-polyglot-30", batch_timeout_s=60)
+    assert dict(config.env)["AIDER_BENCHMARK_TIMEOUT_S"] == "3600"
+    assert config.request_timeout_s == 3900.0
+
+
+# ---------------------------------------------------------------------------
+# #3-B: single-scoreboard pack headline shows real X/Y, not binary 1/1 or 0/1
+# ---------------------------------------------------------------------------
+
+class FakeSingleScoreboardSandbox:
+    """Single-scoreboard pack (aider): /verify-start returns the aggregate
+    verify-final with pass_rate/passed_count/total_count first-class."""
+
+    def __init__(self, *, passed, failure_mode, passed_count, total_count, pass_rate):
+        self.config = FakeMultiTurnConfig()
+        self._p = dict(
+            passed=passed, failure_mode=failure_mode,
+            passed_count=passed_count, total_count=total_count, pass_rate=pass_rate,
+        )
+
+    def verify_multiturn_start(self, scenario: dict, **kwargs) -> dict:
+        return {"action": "verify-final", "detail": "batch", "trace": {}, **self._p}
+
+    def verify_multiturn_turn(self, *a, **k):  # pragma: no cover
+        raise AssertionError("single-scoreboard must early-out, not loop")
+
+    def verify_multiturn_end(self, *a, **k):  # pragma: no cover
+        raise AssertionError("single-scoreboard must early-out, not loop")
+
+
+def _single_scoreboard_fixture():
+    meta = {
+        "version": "1.0.0",
+        "upstream_commit": "deadbeef",
+        "supports_sandboxed_only": True,
+        "scenario_count": 1,
+        "_architecture": "single-scoreboard",
+        "default_max_seconds": 1800,
+        "sampling_defaults": {"max_tokens": 256, "temperature": 0.0},
+    }
+    scenarios = [{
+        "id": "aider-polyglot-30-batch",
+        "pack_id": "aider-polyglot-30",
+        "messages": [{"role": "user", "content": "batch"}],
+        "raw_scenario": {"kind": "aider-polyglot-batch"},
+        "verifier": {"type": "_stub", "asserts": []},
+    }]
+    return meta, scenarios
+
+
+def test_run_pack_single_scoreboard_success_shows_real_fraction(monkeypatch):
+    from benchlocal_cli import runner as runner_module
+    meta, scenarios = _single_scoreboard_fixture()
+    monkeypatch.setattr(runner_module, "load_pack", lambda pid: (meta, scenarios))
+    r = runner_module.Runner(endpoint="http://h:8000", model="m", enable_sandboxed_packs=True)
+    r._sandbox_clients["aider-polyglot-30"] = FakeSingleScoreboardSandbox(
+        passed=True, failure_mode="passed", passed_count=16, total_count=30, pass_rate=16 / 30)
+
+    pack = r.run_pack("aider-polyglot-30")
+
+    assert pack.passed == 16          # NOT 1
+    assert pack.total == 30           # NOT 1
+    assert abs(pack.score - 16 / 30) < 1e-9
+    assert pack.status == "ok"
+
+
+def test_run_pack_single_scoreboard_timeout_surfaces_partial(monkeypatch):
+    from benchlocal_cli import runner as runner_module
+    meta, scenarios = _single_scoreboard_fixture()
+    monkeypatch.setattr(runner_module, "load_pack", lambda pid: (meta, scenarios))
+    r = runner_module.Runner(endpoint="http://h:8000", model="m", enable_sandboxed_packs=True)
+    r._sandbox_clients["aider-polyglot-30"] = FakeSingleScoreboardSandbox(
+        passed=False, failure_mode="agent_runner_timeout",
+        passed_count=18, total_count=30, pass_rate=18 / 30)
+
+    pack = r.run_pack("aider-polyglot-30")
+
+    assert pack.passed == 18          # partial surfaced, NOT 0
+    assert pack.total == 30
+    assert abs(pack.score - 18 / 30) < 1e-9
+    assert pack.status == "agent_runner_timeout"   # not masked as "ok"


### PR DESCRIPTION
Fixes #6 and #3 — both aider/sandbox observability + graceful-degradation, validated together on a live RTX 3090 / ik_llama IQ4_KS run.

## #6 — persist sandbox run artifacts to a writable host bind-mount
- Sandboxed packs wrote per-unit artifacts to the ephemeral `--rm` container fs, so a crash/timeout — or even a clean finish — left only a teardown stdout snapshot; the rich per-unit results needed a manual `docker cp` to recover.
- When `--sandbox-log-dir DIR` is set, mount `DIR/<pack_id>-run` **writable** at the pack's `run_output_dir` so artifacts land on the host as they're written. For aider, also inject `BENCHLOCAL_AIDER_KEEP_JOBDIRS=1` (the sandbox otherwise `rmtree`s its job dirs).
- The mount made the sandbox's hard-link staging cross devices (`EXDEV`); added a link-or-copy fallback in `server.py` (rebuilt the aider image).

## #3 — aider timeout + buried partial results
- **#3-A:** the 30-exercise batch runs in one `/verify-start`, so `--timeout-per-case` now governs the batch budget (`config_for_pack` derives the inner subprocess cap + `request_timeout_s`). The knob only *raises* the cap; default bumped 2700→3600s after a PL250W rig hit the cap on the last exercise.
- **#3-B:** single-scoreboard packs collapsed to a binary `1/1` (success shown as 100% when really 16/30) or `0/1` (a graceful timeout at 18/30 shown as 0%). `run_pack` now derives the headline from the scenario's `pass_rate` metrics, and the renderer surfaces the real failure mode (`agent_runner_timeout`) instead of masking it as `ok`.

## Validation
- 115 unit tests pass (+11 new).
- Live: container shows `AIDER_BENCHMARK_TIMEOUT_S=3600`, `KEEP_JOBDIRS=1`, mount `rw=true` at `/tmp/aider-polyglot-runs`; exercises run with **zero `EXDEV`** and per-exercise artifacts appear on the host run-dir live. Full-run headline acceptance for #3-B completing.