### PR TITLE
fix(cli): default sandbox logs for sandboxed runs

### DIFF
--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -36,6 +36,7 @@ import argparse
 import json
 import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 from benchlocal_cli.runner import PACK_MODES, SANDBOX_MODES, Runner, list_packs, load_pack
@@ -107,8 +108,11 @@ def _parser() -> argparse.ArgumentParser:
     run.add_argument("--sandbox-image-tag", default="latest", help="Docker tag for sandbox images (default: latest)")
     run.add_argument(
         "--sandbox-log-dir",
-        help="capture sandbox container stdout/stderr to <dir>/sandbox-<pack-id>.log "
-             "before container teardown (useful for post-run forensics)",
+        help=(
+            "capture sandbox container stdout/stderr to <dir>/sandbox-<pack-id>.log "
+            "before container teardown; defaults next to --save-json for sandboxed runs, "
+            "or use none to disable"
+        ),
     )
     run.add_argument("--enable-thinking", action="store_true", help="run with reasoning/thinking enabled (default: off)")
     run.add_argument("--thinking-max-tokens", type=int, default=4096)
@@ -273,6 +277,39 @@ def _load_extra_body(value: str | None) -> dict | None:
     return data
 
 
+def _pack_ids_include_sandboxed(pack_ids: list[str]) -> bool:
+    for pack_id in pack_ids:
+        try:
+            meta, _ = load_pack(pack_id)
+        except Exception:
+            continue
+        if meta.get("supports_sandboxed_only"):
+            return True
+    return False
+
+
+def _resolve_sandbox_log_dir(
+    *,
+    requested: str | None,
+    save_json: str | None,
+    pack_ids: list[str],
+    sandboxed_enabled: bool,
+) -> str | None:
+    if requested is not None:
+        if requested.strip().lower() == "none":
+            return None
+        return requested
+
+    if not sandboxed_enabled or not _pack_ids_include_sandboxed(pack_ids):
+        return None
+
+    if save_json:
+        return str(Path(save_json).parent / "sandbox-logs")
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%SZ")
+    return str(Path("benchlocal-runs") / timestamp / "sandbox-logs")
+
+
 def main(argv: list[str] | None = None) -> int:
     """Entry point. Returns process exit code."""
     parser = _parser()
@@ -326,7 +363,12 @@ def main(argv: list[str] | None = None) -> int:
             thinking_max_tokens=args.thinking_max_tokens,
             extra_body=_load_extra_body(args.extra_body),
             sandbox_image_tag=args.sandbox_image_tag,
-            sandbox_log_dir=args.sandbox_log_dir,
+            sandbox_log_dir=_resolve_sandbox_log_dir(
+                requested=args.sandbox_log_dir,
+                save_json=args.save_json,
+                pack_ids=pack_ids,
+                sandboxed_enabled=sandboxed_enabled,
+            ),
         )
         result = runner.run(pack_ids, mode=mode, repeat=max(1, args.repeat))
 

--- a/tests/test_cli_sandbox_log_dir.py
+++ b/tests/test_cli_sandbox_log_dir.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import re
+
+from benchlocal_cli.cli import _resolve_sandbox_log_dir
+
+
+def test_default_sandbox_log_dir_uses_save_json_sibling(tmp_path):
+    save_json = tmp_path / "runs" / "qwen.json"
+
+    resolved = _resolve_sandbox_log_dir(
+        requested=None,
+        save_json=str(save_json),
+        pack_ids=["bugfind-15"],
+        sandboxed_enabled=True,
+    )
+
+    assert resolved == str(tmp_path / "runs" / "sandbox-logs")
+
+
+def test_default_sandbox_log_dir_disabled_for_deterministic_only(tmp_path):
+    resolved = _resolve_sandbox_log_dir(
+        requested=None,
+        save_json=str(tmp_path / "medium.json"),
+        pack_ids=["toolcall-15"],
+        sandboxed_enabled=True,
+    )
+
+    assert resolved is None
+
+
+def test_default_sandbox_log_dir_disabled_when_sandboxing_disabled(tmp_path):
+    resolved = _resolve_sandbox_log_dir(
+        requested=None,
+        save_json=str(tmp_path / "full.json"),
+        pack_ids=["bugfind-15"],
+        sandboxed_enabled=False,
+    )
+
+    assert resolved is None
+
+
+def test_sandbox_log_dir_none_is_explicit_opt_out(tmp_path):
+    resolved = _resolve_sandbox_log_dir(
+        requested="none",
+        save_json=str(tmp_path / "full.json"),
+        pack_ids=["bugfind-15"],
+        sandboxed_enabled=True,
+    )
+
+    assert resolved is None
+
+
+def test_explicit_sandbox_log_dir_is_preserved(tmp_path):
+    explicit = tmp_path / "custom-logs"
+
+    resolved = _resolve_sandbox_log_dir(
+        requested=str(explicit),
+        save_json=str(tmp_path / "full.json"),
+        pack_ids=["bugfind-15"],
+        sandboxed_enabled=True,
+    )
+
+    assert resolved == str(explicit)
+
+
+def test_default_sandbox_log_dir_without_save_json_uses_run_directory():
+    resolved = _resolve_sandbox_log_dir(
+        requested=None,
+        save_json=None,
+        pack_ids=["bugfind-15"],
+        sandboxed_enabled=True,
+    )
+
+    assert resolved is not None
+    assert re.fullmatch(r"benchlocal-runs/\d{8}-\d{6}Z/sandbox-logs", resolved)


### PR DESCRIPTION
Fixes #9.

## What changed

Sandbox forensic logs are now default-on for runs that actually include sandboxed packs.

Behavior:

- If `--sandbox-log-dir DIR` is passed, behavior is unchanged.
- If `--sandbox-log-dir=none` is passed, sandbox log persistence is disabled explicitly.
- If sandboxed packs are selected and sandboxing is enabled, and no log dir is provided:
  - with `--save-json path/to/result.json`, logs default to `path/to/sandbox-logs/`
  - without `--save-json`, logs default to `benchlocal-runs/<timestamp>/sandbox-logs/`
- Deterministic-only runs do not get a default sandbox log dir.

This plugs into the existing runner/sandbox persistence path, so per-pack run directories and container logs continue to use the same mechanics as explicit `--sandbox-log-dir`.

## Validation

- `.venv/bin/python -m pytest -q tests/test_cli_sandbox_log_dir.py tests/test_sandbox_runner.py tests/test_inspect.py` -> `49 passed`
- `.venv/bin/python -m pytest -q` -> `121 passed`
