### PR TITLE
fix(runner): retry transient model endpoint failures

### DIFF
--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -107,6 +107,15 @@ def _parser() -> argparse.ArgumentParser:
     )
     run.add_argument("--sandbox-image-tag", default="latest", help="Docker tag for sandbox images (default: latest)")
     run.add_argument(
+        "--max-transient-retries",
+        type=int,
+        default=_env_int("BENCHLOCAL_MAX_TRANSIENT_RETRIES", 3),
+        help=(
+            "retry transient model endpoint failures this many times before failing "
+            "a scenario (default: 3; env BENCHLOCAL_MAX_TRANSIENT_RETRIES)"
+        ),
+    )
+    run.add_argument(
         "--sandbox-log-dir",
         help=(
             "capture sandbox container stdout/stderr to <dir>/sandbox-<pack-id>.log "
@@ -277,6 +286,16 @@ def _load_extra_body(value: str | None) -> dict | None:
     return data
 
 
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+
 def _pack_ids_include_sandboxed(pack_ids: list[str]) -> bool:
     for pack_id in pack_ids:
         try:
@@ -369,6 +388,7 @@ def main(argv: list[str] | None = None) -> int:
                 pack_ids=pack_ids,
                 sandboxed_enabled=sandboxed_enabled,
             ),
+            max_transient_retries=args.max_transient_retries,
         )
         result = runner.run(pack_ids, mode=mode, repeat=max(1, args.repeat))
 

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -155,6 +155,36 @@ def _chat_url(endpoint: str) -> str:
     return f"{endpoint}/v1/chat/completions"
 
 
+class _TransientPostFailure(Exception):
+    def __init__(self, failure_mode: str, detail: str, trace: dict) -> None:
+        super().__init__(detail)
+        self.failure_mode = failure_mode
+        self.detail = detail
+        self.trace = trace
+
+
+def _transient_trace(errors: list[str], attempt: int) -> dict | None:
+    if not errors:
+        return None
+    return {
+        "transient_retries": max(0, attempt - 1),
+        "transient_errors": list(errors),
+    }
+
+
+def _merge_transient_trace(existing: dict | None, new: dict | None) -> dict | None:
+    if not new:
+        return existing
+    if not existing:
+        return dict(new)
+    return {
+        "transient_retries": int(existing.get("transient_retries") or 0)
+        + int(new.get("transient_retries") or 0),
+        "transient_errors": list(existing.get("transient_errors") or [])
+        + list(new.get("transient_errors") or []),
+    }
+
+
 def _latency(values: list[float]) -> dict[str, float | None]:
     if not values:
         return {"p50": None, "p95": None, "mean": None}
@@ -181,6 +211,7 @@ class Runner:
         extra_body: dict | None = None,
         sandbox_image_tag: str = "latest",
         sandbox_log_dir: str | None = None,
+        max_transient_retries: int = 3,
     ) -> None:
         self.endpoint = endpoint
         self.model = model
@@ -195,6 +226,7 @@ class Runner:
         # `<sandbox_log_dir>/sandbox-<pack_id>.log` before container teardown.
         # See SandboxClient.stop(log_dir=...) for the snapshot.
         self.sandbox_log_dir = sandbox_log_dir
+        self.max_transient_retries = max(0, int(max_transient_retries))
         self._sandbox_clients: dict[str, SandboxClient] = {}
 
     def run(self, pack_ids: list[str], *, mode: str = "custom", repeat: int = 1) -> RunResult:
@@ -418,6 +450,7 @@ class Runner:
         started = time.perf_counter()
         status_code: int | None = None
         raw_response: dict | None = None
+        transient_trace: dict | None = None
 
         sandbox_client = self._sandbox_clients.get(scenario.get("pack_id"))
         if (
@@ -442,20 +475,20 @@ class Runner:
             latency = 0.0
         else:
             try:
-                with httpx.Client(timeout=timeout) as client:
-                    response = client.post(_chat_url(self.endpoint), json=request)
+                status_code, raw_response, transient_trace = self._post_chat(request, timeout)
                 latency = time.perf_counter() - started
-                status_code = response.status_code
-                try:
-                    raw_response = response.json()
-                except ValueError:
-                    raw_response = {"text": response.text}
-                if response.status_code >= 500:
-                    result = ScenarioResult(scenario["id"], False, "server_error", f"HTTP {response.status_code}", latency)
+                if status_code >= 500:
+                    result = ScenarioResult(scenario["id"], False, "server_error", f"HTTP {status_code}", latency)
+                    result = self._inject_transient_trace(result, transient_trace)
                     return self._scenario_run(scenario, raw_response, request, sampling, status_code, result, repeat_index)
-                if response.status_code >= 400:
-                    result = ScenarioResult(scenario["id"], False, "http_error", f"HTTP {response.status_code}", latency)
+                if status_code >= 400:
+                    result = ScenarioResult(scenario["id"], False, "http_error", f"HTTP {status_code}", latency)
                     return self._scenario_run(scenario, raw_response, request, sampling, status_code, result, repeat_index)
+            except _TransientPostFailure as exc:
+                latency = time.perf_counter() - started
+                result = ScenarioResult(scenario["id"], False, exc.failure_mode, exc.detail, latency)
+                result = self._inject_transient_trace(result, exc.trace)
+                return self._scenario_run(scenario, None, request, sampling, None, result, repeat_index)
             except httpx.TimeoutException:
                 latency = time.perf_counter() - started
                 result = ScenarioResult(scenario["id"], False, "timeout", f"timed out after {timeout}s", latency)
@@ -487,6 +520,7 @@ class Runner:
         if isinstance(usage, dict) and isinstance(usage.get("completion_tokens"), int):
             tokens = usage["completion_tokens"]
         result = replace(result, latency_seconds=latency, tokens_completion=tokens)
+        result = self._inject_transient_trace(result, transient_trace)
         if sandboxed_path:
             result = self._inject_sandbox_log_file(result, scenario.get("pack_id"))
         return self._scenario_run(
@@ -521,14 +555,57 @@ class Runner:
             return 20
         return 15
 
-    def _post_chat(self, request: dict, timeout: float) -> tuple[int, dict]:
-        with httpx.Client(timeout=timeout) as client:
-            response = client.post(_chat_url(self.endpoint), json=request)
-        try:
-            raw_response = response.json()
-        except ValueError:
-            raw_response = {"text": response.text}
-        return response.status_code, raw_response
+    def _post_chat(self, request: dict, timeout: float) -> tuple[int, dict, dict | None]:
+        transient_errors: list[str] = []
+        max_attempts = self.max_transient_retries + 1
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                with httpx.Client(timeout=timeout) as client:
+                    response = client.post(_chat_url(self.endpoint), json=request)
+            except httpx.TimeoutException as exc:
+                transient_errors.append(f"attempt {attempt}: {type(exc).__name__}: {exc}")
+                if attempt >= max_attempts:
+                    trace = _transient_trace(transient_errors, attempt) or {}
+                    raise _TransientPostFailure("timeout", f"timed out after {timeout}s", trace) from exc
+                self._sleep_before_transient_retry(attempt)
+                continue
+            except (httpx.ConnectError, httpx.RemoteProtocolError) as exc:
+                transient_errors.append(f"attempt {attempt}: {type(exc).__name__}: {exc}")
+                if attempt >= max_attempts:
+                    trace = _transient_trace(transient_errors, attempt) or {}
+                    raise _TransientPostFailure("http_error", str(exc), trace) from exc
+                self._sleep_before_transient_retry(attempt)
+                continue
+
+            try:
+                raw_response = response.json()
+            except ValueError:
+                raw_response = {"text": response.text}
+
+            if response.status_code >= 500:
+                transient_errors.append(f"attempt {attempt}: HTTP {response.status_code}")
+                if attempt < max_attempts:
+                    self._sleep_before_transient_retry(attempt)
+                    continue
+
+            return response.status_code, raw_response, _transient_trace(transient_errors, attempt)
+
+        raise AssertionError("unreachable transient retry loop exit")
+
+    @staticmethod
+    def _inject_transient_trace(result: ScenarioResult, trace: dict | None) -> ScenarioResult:
+        if not trace:
+            return result
+        existing = dict(result.verifier_trace) if isinstance(result.verifier_trace, dict) else {}
+        existing.update(trace)
+        return replace(result, verifier_trace=existing)
+
+    @staticmethod
+    def _sleep_before_transient_retry(attempt: int) -> None:
+        delay = 2 ** (attempt - 1)
+        if delay > 0:
+            time.sleep(delay)
 
     @staticmethod
     def _message_from_response(raw_response: dict) -> dict:
@@ -564,6 +641,7 @@ class Runner:
         started = time.perf_counter()
         status_code: int | None = None
         raw_responses: list[dict] = []
+        transient_trace: dict | None = None
         assistant_messages: list[dict] = []
         tool_calls: list[dict] = []
         tokens_total = 0
@@ -679,7 +757,12 @@ class Runner:
             for _turn in range(1, max_turns + 1):
                 request = build_chat_request(history, sampling, self.model, tools=tools)
                 try:
-                    status_code, raw_response = self._post_chat(request, timeout)
+                    status_code, raw_response, turn_transient_trace = self._post_chat(request, timeout)
+                    transient_trace = _merge_transient_trace(transient_trace, turn_transient_trace)
+                except _TransientPostFailure as exc:
+                    transient_trace = _merge_transient_trace(transient_trace, exc.trace)
+                    result = ScenarioResult(scenario["id"], False, exc.failure_mode, exc.detail)
+                    break
                 except httpx.TimeoutException:
                     result = ScenarioResult(scenario["id"], False, "timeout", f"timed out after {timeout}s")
                     break
@@ -763,6 +846,7 @@ class Runner:
             tokens_completion=tokens_total if tokens_total else None,
             verifier_trace=verifier_trace,
         )
+        result = self._inject_transient_trace(result, transient_trace)
         result = self._inject_sandbox_log_file(result, scenario.get("pack_id"))
         raw_response: dict = {
             "multi_turn": True,

--- a/tests/test_transient_retries.py
+++ b/tests/test_transient_retries.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import httpx
+
+from benchlocal_cli.runner import Runner
+from benchlocal_cli.types import ScenarioResult
+
+
+class FakeHTTPResponse:
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self.payload = payload
+        self.status_code = status_code
+        self.text = "text-body"
+
+    def json(self) -> dict:
+        return self.payload
+
+
+class SequenceHTTPClient:
+    events: list[object] = []
+    calls = 0
+
+    def __init__(self, timeout: float) -> None:
+        self.timeout = timeout
+
+    def __enter__(self) -> "SequenceHTTPClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def post(self, url: str, json: dict) -> FakeHTTPResponse:
+        cls = type(self)
+        event = cls.events[cls.calls]
+        cls.calls += 1
+        if isinstance(event, BaseException):
+            raise event
+        status, payload = event
+        return FakeHTTPResponse(payload, status_code=status)
+
+
+class FakeSandbox:
+    config = type("FakeConfig", (), {"multi_turn": False})()
+
+    def __init__(self, *, passed: bool = True, failure_mode: str = "passed") -> None:
+        self.calls = 0
+        self.passed = passed
+        self.failure_mode = failure_mode
+
+    def verify(self, scenario: dict, response: dict, messages: list[dict]) -> ScenarioResult:
+        self.calls += 1
+        return ScenarioResult(
+            scenario_id=scenario["id"],
+            passed=self.passed,
+            failure_mode=self.failure_mode,
+            detail="fake verifier",
+        )
+
+
+class FakeMultiTurnConfig:
+    multi_turn = True
+
+
+class FakeMultiTurnSandbox:
+    config = FakeMultiTurnConfig()
+
+    def verify_multiturn_start(self, scenario: dict, **kwargs) -> dict:
+        return {"scenario_state_id": "state-1", "prompt": scenario["messages"], "tools": []}
+
+    def verify_multiturn_turn(self, scenario_state_id: str, model_response: dict) -> dict:
+        return {
+            "action": "verify-final",
+            "passed": True,
+            "failure_mode": "passed",
+            "detail": "multi-turn pass",
+            "trace": {"turn_count": 1},
+        }
+
+    def verify_multiturn_end(self, scenario_state_id: str) -> dict:
+        raise AssertionError("not expected")
+
+
+def _sandbox_meta() -> dict:
+    return {"supports_sandboxed_only": True, "default_max_seconds": 60, "sampling_defaults": {"max_tokens": 16}}
+
+
+def _single_scenario() -> dict:
+    return {
+        "id": "BF-01",
+        "pack_id": "bugfind-15",
+        "messages": [{"role": "user", "content": "fix it"}],
+        "verifier": {"type": "_stub", "asserts": []},
+    }
+
+
+def _multi_scenario() -> dict:
+    return {
+        "id": "CLI-01",
+        "pack_id": "cli-40",
+        "messages": [{"role": "user", "content": "run a command"}],
+        "raw_scenario": {"kind": "multiround"},
+        "verifier": {"type": "_stub", "asserts": []},
+    }
+
+
+def _ok_payload(content: str = "ok") -> dict:
+    return {"choices": [{"message": {"role": "assistant", "content": content}}], "usage": {"completion_tokens": 3}}
+
+
+def _install_sequence_client(monkeypatch, runner_module, events: list[object]) -> None:
+    SequenceHTTPClient.events = events
+    SequenceHTTPClient.calls = 0
+    monkeypatch.setattr(runner_module.httpx, "Client", SequenceHTTPClient)
+    monkeypatch.setattr(runner_module.time, "sleep", lambda delay: None)
+
+
+def test_single_turn_retries_connect_error_then_passes(monkeypatch):
+    import benchlocal_cli.runner as runner_module
+
+    _install_sequence_client(monkeypatch, runner_module, [httpx.ConnectError("refused"), (200, _ok_payload())])
+    runner = Runner(endpoint="http://localhost:9999", model="fake", enable_sandboxed_packs=True, max_transient_retries=2)
+    runner._sandbox_clients["bugfind-15"] = FakeSandbox()
+
+    run = runner.run_scenario(_sandbox_meta(), _single_scenario())
+
+    assert run.result.passed is True
+    assert SequenceHTTPClient.calls == 2
+    assert run.result.verifier_trace is not None
+    assert run.result.verifier_trace["transient_retries"] == 1
+    assert "ConnectError" in run.result.verifier_trace["transient_errors"][0]
+
+
+def test_single_turn_retries_5xx_then_passes(monkeypatch):
+    import benchlocal_cli.runner as runner_module
+
+    _install_sequence_client(monkeypatch, runner_module, [(503, {"error": "busy"}), (200, _ok_payload())])
+    runner = Runner(endpoint="http://localhost:9999", model="fake", enable_sandboxed_packs=True, max_transient_retries=2)
+    runner._sandbox_clients["bugfind-15"] = FakeSandbox()
+
+    run = runner.run_scenario(_sandbox_meta(), _single_scenario())
+
+    assert run.result.passed is True
+    assert SequenceHTTPClient.calls == 2
+    assert run.result.verifier_trace is not None
+    assert run.result.verifier_trace["transient_retries"] == 1
+    assert run.result.verifier_trace["transient_errors"] == ["attempt 1: HTTP 503"]
+
+
+def test_single_turn_exhausted_remote_protocol_error_fails_with_trace(monkeypatch):
+    import benchlocal_cli.runner as runner_module
+
+    _install_sequence_client(
+        monkeypatch,
+        runner_module,
+        [httpx.RemoteProtocolError("disconnect"), httpx.RemoteProtocolError("disconnect again")],
+    )
+    runner = Runner(endpoint="http://localhost:9999", model="fake", enable_sandboxed_packs=True, max_transient_retries=1)
+    runner._sandbox_clients["bugfind-15"] = FakeSandbox()
+
+    run = runner.run_scenario(_sandbox_meta(), _single_scenario())
+
+    assert run.result.passed is False
+    assert run.result.failure_mode == "http_error"
+    assert SequenceHTTPClient.calls == 2
+    assert run.result.verifier_trace is not None
+    assert run.result.verifier_trace["transient_retries"] == 1
+    assert len(run.result.verifier_trace["transient_errors"]) == 2
+
+
+def test_single_turn_retries_timeout_then_passes(monkeypatch):
+    import benchlocal_cli.runner as runner_module
+
+    _install_sequence_client(monkeypatch, runner_module, [httpx.ReadTimeout("slow read"), (200, _ok_payload())])
+    runner = Runner(endpoint="http://localhost:9999", model="fake", enable_sandboxed_packs=True, max_transient_retries=1)
+    runner._sandbox_clients["bugfind-15"] = FakeSandbox()
+
+    run = runner.run_scenario(_sandbox_meta(), _single_scenario())
+
+    assert run.result.passed is True
+    assert SequenceHTTPClient.calls == 2
+    assert run.result.verifier_trace is not None
+    assert run.result.verifier_trace["transient_retries"] == 1
+    assert "ReadTimeout" in run.result.verifier_trace["transient_errors"][0]
+
+
+def test_single_turn_4xx_is_not_retried(monkeypatch):
+    import benchlocal_cli.runner as runner_module
+
+    _install_sequence_client(monkeypatch, runner_module, [(400, {"error": "bad request"}), (200, _ok_payload())])
+    runner = Runner(endpoint="http://localhost:9999", model="fake", enable_sandboxed_packs=True, max_transient_retries=3)
+    runner._sandbox_clients["bugfind-15"] = FakeSandbox()
+
+    run = runner.run_scenario(_sandbox_meta(), _single_scenario())
+
+    assert run.result.passed is False
+    assert run.result.failure_mode == "http_error"
+    assert SequenceHTTPClient.calls == 1
+    assert run.result.verifier_trace is None
+
+
+def test_verifier_fail_is_not_retried(monkeypatch):
+    import benchlocal_cli.runner as runner_module
+
+    _install_sequence_client(monkeypatch, runner_module, [(200, _ok_payload())])
+    runner = Runner(endpoint="http://localhost:9999", model="fake", enable_sandboxed_packs=True, max_transient_retries=3)
+    fake = FakeSandbox(passed=False, failure_mode="verifier_fail")
+    runner._sandbox_clients["bugfind-15"] = fake
+
+    run = runner.run_scenario(_sandbox_meta(), _single_scenario())
+
+    assert run.result.passed is False
+    assert run.result.failure_mode == "verifier_fail"
+    assert SequenceHTTPClient.calls == 1
+    assert fake.calls == 1
+    assert run.result.verifier_trace is None
+
+
+def test_multiturn_retries_transient_post_and_preserves_trace(monkeypatch):
+    import benchlocal_cli.runner as runner_module
+
+    _install_sequence_client(monkeypatch, runner_module, [httpx.RemoteProtocolError("disconnect"), (200, _ok_payload())])
+    runner = Runner(endpoint="http://localhost:9999", model="fake", enable_sandboxed_packs=True, max_transient_retries=1)
+    runner._sandbox_clients["cli-40"] = FakeMultiTurnSandbox()
+
+    run = runner.run_scenario(_sandbox_meta(), _multi_scenario())
+
+    assert run.result.passed is True
+    assert run.turn_count == 1
+    assert SequenceHTTPClient.calls == 2
+    assert run.result.verifier_trace is not None
+    assert run.result.verifier_trace["trace"] == {"turn_count": 1}
+    assert run.result.verifier_trace["transient_retries"] == 1
+    assert "RemoteProtocolError" in run.result.verifier_trace["transient_errors"][0]


### PR DESCRIPTION
## Summary
- retry transient model POST failures for single-turn and multi-turn runner paths
- cover ConnectError, RemoteProtocolError, TimeoutException, and HTTP 5xx with bounded exponential backoff
- keep 4xx responses and verifier failures non-retryable
- expose transient_retries and transient_errors in verifier_trace
- add --max-transient-retries and BENCHLOCAL_MAX_TRANSIENT_RETRIES

Fixes #11.

## Tests
- .venv/bin/python -m pytest -q