### PR TITLE
fix(scoring): sanitize leaked reasoning tags

### DIFF
--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -17,7 +17,7 @@ import httpx
 
 from benchlocal_cli import __version__
 from benchlocal_cli.sandbox import SandboxClient, config_for_pack
-from benchlocal_cli.scoring.common import content_with_source
+from benchlocal_cli.scoring.common import content_with_source, sanitize_response_text_fields
 from benchlocal_cli.types import PackResult, RunResult, ScenarioResult, ScenarioRun
 
 PACK_MODES = {
@@ -466,6 +466,7 @@ class Runner:
                 return self._scenario_run(scenario, None, request, sampling, None, result, repeat_index)
 
         assert raw_response is not None
+        raw_response = sanitize_response_text_fields(raw_response)
         response_field_used = content_with_source(raw_response)[1]
         sandboxed_path = (
             meta.get("supports_sandboxed_only")
@@ -687,6 +688,7 @@ class Runner:
                     result = ScenarioResult(scenario["id"], False, "http_error", str(exc))
                     break
 
+                raw_response = sanitize_response_text_fields(raw_response)
                 raw_responses.append(raw_response)
                 if status_code >= 500:
                     result = ScenarioResult(scenario["id"], False, "server_error", f"HTTP {status_code}")

--- a/benchlocal_cli/scoring/common.py
+++ b/benchlocal_cli/scoring/common.py
@@ -9,6 +9,31 @@ from typing import Any
 from benchlocal_cli.types import ScenarioResult
 
 
+_REASONING_TEXT_FIELDS = {"content", "reasoning_content", "reasoning"}
+_THINK_BLOCK_RE = re.compile(r"<think\b[^>]*>.*?</think\s*>", re.IGNORECASE | re.DOTALL)
+_THINK_TAG_RE = re.compile(r"</?think\b[^>]*>", re.IGNORECASE)
+
+
+def sanitize_reasoning_tags(text: str) -> str:
+    """Strip leaked reasoning tags while leaving clean text byte-identical."""
+    cleaned = _THINK_BLOCK_RE.sub("", text)
+    cleaned = _THINK_TAG_RE.sub("", cleaned)
+    return text if cleaned == text else cleaned.strip()
+
+
+def sanitize_response_text_fields(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: sanitize_reasoning_tags(item)
+            if key in _REASONING_TEXT_FIELDS and isinstance(item, str)
+            else sanitize_response_text_fields(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [sanitize_response_text_fields(item) for item in value]
+    return value
+
+
 def result(
     scenario: dict,
     passed: bool,
@@ -40,12 +65,12 @@ def content_with_source(response: dict) -> tuple[str, str | None]:
     for field in ("content", "reasoning_content", "reasoning"):
         value = response.get(field)
         if isinstance(value, str) and value:
-            return value, field
+            return sanitize_reasoning_tags(value), field
     msg = message(response)
     for field in ("content", "reasoning_content", "reasoning"):
         value = msg.get(field)
         if isinstance(value, str) and value:
-            return value, f"message.{field}"
+            return sanitize_reasoning_tags(value), f"message.{field}"
     return "", None
 
 

--- a/tests/test_reasoning_handling.py
+++ b/tests/test_reasoning_handling.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from benchlocal_cli.runner import Runner, build_request
-from benchlocal_cli.scoring.common import content_with_source
+from benchlocal_cli.scoring.common import content_with_source, sanitize_reasoning_tags
 
 
 def _meta() -> dict:
@@ -65,6 +65,33 @@ def test_extra_body_wins_over_defaults_but_loses_to_scenario_overrides():
 
     assert request["foo"] == "scenario"
     assert request["bar"] == "extra"
+
+
+def test_sanitize_reasoning_tags_strips_well_formed_blocks():
+    assert sanitize_reasoning_tags("<think>hidden reasoning</think><solution>done</solution>") == "<solution>done</solution>"
+
+
+def test_sanitize_reasoning_tags_strips_orphan_closing_tags():
+    assert sanitize_reasoning_tags("</think> </think> <solution>done</solution>") == "<solution>done</solution>"
+
+
+def test_sanitize_reasoning_tags_strips_orphan_opening_tags():
+    assert sanitize_reasoning_tags("<think> <solution>done</solution>") == "<solution>done</solution>"
+
+
+def test_sanitize_reasoning_tags_keeps_clean_content_byte_identical():
+    clean = "  hello <not-think> world  "
+    assert sanitize_reasoning_tags(clean) == clean
+
+
+def test_sanitize_reasoning_tags_all_tags_yields_empty():
+    assert sanitize_reasoning_tags("</think> </think> <think></think>") == ""
+
+
+def test_content_with_source_sanitizes_leaked_think_tags():
+    response = {"choices": [{"message": {"content": "<think>hidden</think>hello"}}]}
+
+    assert content_with_source(response) == ("hello", "message.content")
 
 
 def test_content_fallback_reads_reasoning_content():

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -93,6 +93,36 @@ def test_runner_dispatches_sandboxed_scenario_to_client():
     assert len(fake.calls) == 1
 
 
+def test_runner_sanitizes_sandboxed_single_turn_response_before_verify():
+    runner = Runner(
+        endpoint="http://localhost:9999",
+        model="fake",
+        enable_sandboxed_packs=True,
+        mock_responses={"CLI-30": {"choices": [{"message": {"content": "</think> </think> <solution>done</solution>"}}]}},
+    )
+    fake = FakeSandbox()
+    runner._sandbox_clients["cli-40"] = fake
+    meta = {
+        "supports_sandboxed_only": True,
+        "default_max_seconds": 60,
+        "sampling_defaults": {"max_tokens": 16},
+    }
+    scenario = {
+        "id": "CLI-30",
+        "pack_id": "cli-40",
+        "messages": [{"role": "user", "content": "write solution"}],
+        "verifier": {"type": "_stub", "asserts": []},
+    }
+
+    run = runner.run_scenario(meta, scenario)
+
+    assert run.result.passed is True
+    assert len(fake.calls) == 1
+    forwarded = fake.calls[0][1]
+    assert forwarded["choices"][0]["message"]["content"] == "<solution>done</solution>"
+    assert run.raw_response["choices"][0]["message"]["content"] == "<solution>done</solution>"
+
+
 def test_runner_skips_sandboxed_pack_without_flag():
     runner = Runner(endpoint="http://localhost:9999", model="fake")
 


### PR DESCRIPTION
## Summary
- add a shared engine-agnostic sanitizer for leaked <think> tags
- sanitize deterministic scorer content extraction
- sanitize runner-ingested model responses before sandbox verifiers see them
- preserve clean content byte-for-byte
- cover well-formed blocks, orphan opening/closing tags, all-tags output, and sandbox forwarding

Fixes #13.

## Tests
- .venv/bin/python -m pytest -q