### PR TITLE
fix(aider): qualify only known litellm providers

### DIFF
--- a/sandboxes/aider-polyglot/server.py
+++ b/sandboxes/aider-polyglot/server.py
@@ -69,6 +69,18 @@ SUBPROCESS_TIMEOUT_S = float(os.environ.get("AIDER_BENCHMARK_TIMEOUT_S", "2700")
 
 # Per-pack threshold: pass if >= this fraction of exercises pass.
 DEFAULT_PASS_THRESHOLD = 0.5
+_LITELLM_PROVIDERS = {
+    "openai",
+    "anthropic",
+    "azure",
+    "vertex_ai",
+    "gemini",
+    "huggingface",
+    "together_ai",
+    "openrouter",
+    "bedrock",
+    "ollama",
+}
 
 # Default edit format. `whole` is the broadest model-compat choice; the
 # runner can override via raw_scenario / sampling_overrides.
@@ -217,6 +229,13 @@ def _build_benchmark_args(
     if extra_args:
         argv.extend(extra_args)
     return argv
+
+
+def _qualify_aider_model(model_name: str) -> str:
+    head = model_name.split("/", 1)[0]
+    if not model_name.startswith("/") and head in _LITELLM_PROVIDERS:
+        return model_name
+    return f"openai/{model_name}"
 
 
 def _link_or_copy(src: str, dst: str) -> None:
@@ -470,7 +489,10 @@ def _verify_start(req: dict) -> dict:
         # against its built-in catalog → no match → silent fallback that
         # makes zero model calls (duration ~0.02s/exercise, cost $0.00).
         # Don't double-prefix if user already passed e.g. "openai/<name>".
-        aider_model = model_name if "/" in model_name else f"openai/{model_name}"
+        # A slash alone is not enough: llama.cpp/ik_llama often reports a
+        # GGUF path (/models/...) as the model id, and bare HF repo ids
+        # (org/model) are not litellm provider-qualified either.
+        aider_model = _qualify_aider_model(model_name)
 
         # Disable Qwen3-style thinking via per-request `extra_body`.
         # vLLM doesn't accept --chat-template-kwargs at the CLI; the

--- a/tests/test_aider_polyglot.py
+++ b/tests/test_aider_polyglot.py
@@ -123,6 +123,32 @@ def test_build_benchmark_args_num_tests_optional():
 
 
 # ============================================================================
+# _qualify_aider_model — litellm provider routing
+# ============================================================================
+
+
+def test_qualify_aider_model_prefixes_slash_free_alias():
+    server = _server()
+    assert server._qualify_aider_model("my-model") == "openai/my-model"
+
+
+def test_qualify_aider_model_prefixes_gguf_path():
+    server = _server()
+    assert server._qualify_aider_model("/models/repo/model.gguf") == "openai//models/repo/model.gguf"
+
+
+def test_qualify_aider_model_prefixes_bare_hf_repo_id():
+    server = _server()
+    assert server._qualify_aider_model("org/model") == "openai/org/model"
+
+
+def test_qualify_aider_model_preserves_known_provider_prefix():
+    server = _server()
+    assert server._qualify_aider_model("openai/qwen") == "openai/qwen"
+    assert server._qualify_aider_model("anthropic/claude-sonnet-4") == "anthropic/claude-sonnet-4"
+
+
+# ============================================================================
 # _grade_aider_batch_result — single-scoreboard aggregation
 # ============================================================================
 


### PR DESCRIPTION
## Summary
- replace the loose slash heuristic for aider-polyglot model names
- preserve model names only when the first path segment is a known litellm provider
- prefix GGUF paths and bare repo-style ids with openai/ for OpenAI-compatible local endpoints
- add regression coverage for aliases, /models/*.gguf paths, org/model ids, and provider-qualified names

Fixes #15.

## Tests
- .venv/bin/python -m pytest -q tests/test_aider_polyglot.py
- .venv/bin/python -m pytest -q
- python3 -m py_compile sandboxes/aider-polyglot/server.py