### PR TITLE
fix(aider): default to single-thread and score partial timeouts

### DIFF
--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -390,7 +390,7 @@ class Runner:
         # results on timeout (18/30 shown as "0/1 = 0%").
         if meta.get("_architecture") == "single-scoreboard" and counted:
             sr = counted[0].result
-            if sr.total_count:
+            if sr.total_count is not None:
                 sb_passed = sr.passed_count or 0
                 sb_total = sr.total_count
                 sb_score = sr.pass_rate if sr.pass_rate is not None else (

--- a/benchlocal_cli/sandbox.py
+++ b/benchlocal_cli/sandbox.py
@@ -523,10 +523,10 @@ def config_for_pack(
     env: tuple[tuple[str, str], ...] = config.env
     request_timeout_s = config.request_timeout_s
     if pack_id == "aider-polyglot-30":
-        # v0.9.0: parallelize aider's batch across N threads. Default 4 to
-        # match the vLLM gemma-mtp compose's --max-num-seqs 4. Override
-        # via BENCHLOCAL_AIDER_THREADS env on the runner side.
-        threads = os.environ.get("BENCHLOCAL_AIDER_THREADS", "4")
+        # v0.9.0: parallelize aider's batch across N threads. Default 1 is
+        # conservative for llama.cpp/ik_llama single-slot (-np 1) servers;
+        # users with multi-slot endpoints can raise BENCHLOCAL_AIDER_THREADS.
+        threads = os.environ.get("BENCHLOCAL_AIDER_THREADS", "1")
         env = env + (("AIDER_BENCHMARK_THREADS", threads),)
         # #3: the whole 30-exercise batch runs inside one /verify-start call,
         # so the per-case timeout governs the BATCH budget here. Slow rigs

--- a/sandboxes/aider-polyglot/server.py
+++ b/sandboxes/aider-polyglot/server.py
@@ -338,15 +338,26 @@ def _summarize_exercise_result(data: dict) -> dict:
     }
 
 
-def _grade_aider_batch_result(per_exercise: dict[str, dict], threshold: float) -> dict:
+def _grade_aider_batch_result(
+    per_exercise: dict[str, dict],
+    threshold: float,
+    *,
+    score_completed_only: bool = False,
+) -> dict:
     """Aggregate per-exercise outcomes into pass_rate + summary. Pure;
-    tested without docker."""
+    tested without docker.
+
+    Full runs score against the canonical 30-exercise denominator. Timeout-
+    truncated runs can score only completed exercises while still surfacing the
+    canonical denominator separately for traceability.
+    """
     canonical_keys = {f"{e['language']}/{e['name']}" for e in CANONICAL_EXERCISES}
     summaries = {k: _summarize_exercise_result(v) for k, v in per_exercise.items()}
     passed = sum(1 for s in summaries.values() if s["passed"])
-    total = len(canonical_keys)
+    canonical_total = len(canonical_keys)
     found = len(summaries)
-    pass_rate = passed / total if total > 0 else 0.0
+    score_total = found if score_completed_only else canonical_total
+    pass_rate = passed / score_total if score_total > 0 else 0.0
 
     missing_results = sorted(canonical_keys - set(summaries))
     extra_results = sorted(set(summaries) - canonical_keys)
@@ -359,8 +370,10 @@ def _grade_aider_batch_result(per_exercise: dict[str, dict], threshold: float) -
         "failure_mode": failure_mode,
         "pass_rate": pass_rate,
         "passed_count": passed,
-        "total_count": total,
+        "total_count": score_total,
         "found_count": found,
+        "canonical_total_count": canonical_total,
+        "score_completed_only": score_completed_only,
         "threshold": threshold,
         "missing_results": missing_results,
         "extra_results": extra_results,
@@ -566,25 +579,27 @@ def _verify_start(req: dict) -> dict:
             # Recover partial per-exercise data. Aider's benchmark.py writes
             # one .aider.results.json per exercise as it completes, so even if
             # we SIGKILL'd mid-batch, exercises that finished BEFORE the kill
-            # have data on disk. Surface that instead of throwing it away.
+            # have data on disk. Score the completed subset only; unrun
+            # exercises are reported as missing/incomplete, not as failures.
             graded_partial = _grade_aider_batch_result(
-                per_exercise, threshold=threshold
-            ) if per_exercise else None
-            partial_pass_count = graded_partial["passed_count"] if graded_partial else 0
-            partial_total = graded_partial["total_count"] if graded_partial else len(CANONICAL_EXERCISES)
-            partial_found = graded_partial["found_count"] if graded_partial else 0
+                per_exercise, threshold=threshold, score_completed_only=True
+            )
+            partial_pass_count = graded_partial["passed_count"]
+            partial_total = graded_partial["total_count"]
+            partial_found = graded_partial["found_count"]
+            canonical_total = graded_partial["canonical_total_count"]
             return {
                 "action": "verify-final",
                 "passed": False,
                 "failure_mode": "agent_runner_timeout",
                 "detail": (
                     f"{scenario_id}: aider benchmark.py exceeded {SUBPROCESS_TIMEOUT_S:.0f}s "
-                    f"(killed at {elapsed:.0f}s; {partial_found}/{partial_total} exercises "
-                    f"completed before kill, {partial_pass_count} passed)"
+                    f"(killed at {elapsed:.0f}s; {partial_found}/{canonical_total} exercises "
+                    f"completed before kill; partial score {partial_pass_count}/{partial_total})"
                 ),
                 # Surface partial counts as first-class fields so the runner can
                 # log progress even on timeout — matches the success path shape.
-                "pass_rate": (graded_partial["pass_rate"] if graded_partial else None),
+                "pass_rate": graded_partial["pass_rate"],
                 "passed_count": partial_pass_count,
                 "total_count": partial_total,
                 "trace": {
@@ -598,9 +613,11 @@ def _verify_start(req: dict) -> dict:
                     "threshold": threshold,
                     "timed_out": True,
                     "found_count": partial_found,
-                    "upstream_per_exercise": (
-                        graded_partial["per_exercise"] if graded_partial else {}
-                    ),
+                    "canonical_total_count": canonical_total,
+                    "score_completed_only": True,
+                    "missing_results": graded_partial["missing_results"],
+                    "extra_results": graded_partial["extra_results"],
+                    "upstream_per_exercise": graded_partial["per_exercise"],
                     "stderr_tail": (stderr or "")[-2000:],
                 },
             }

--- a/tests/test_aider_polyglot.py
+++ b/tests/test_aider_polyglot.py
@@ -203,6 +203,24 @@ def test_grade_surfaces_missing_results():
     assert out["passed"] is True
 
 
+def test_grade_timeout_partial_scores_completed_only():
+    server = _server()
+    canonical_keys = [f"{e['language']}/{e['name']}" for e in server.CANONICAL_EXERCISES]
+    per = {}
+    for i, key in enumerate(canonical_keys[:26]):
+        per[key] = _fixture_result(passed=(i < 17))
+
+    out = server._grade_aider_batch_result(per, threshold=0.5, score_completed_only=True)
+
+    assert out["passed_count"] == 17
+    assert out["total_count"] == 26
+    assert out["canonical_total_count"] == 30
+    assert out["found_count"] == 26
+    assert abs(out["pass_rate"] - (17 / 26)) < 1e-12
+    assert out["score_completed_only"] is True
+    assert len(out["missing_results"]) == 4
+
+
 def test_grade_surfaces_extra_results():
     """If upstream ran exercises NOT in our canonical 30 (substring keyword
     collision), the canonical_keys denominator catches it."""

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -554,8 +554,17 @@ def test_non_runmount_pack_ignores_run_dir(tmp_path):
 def test_config_for_pack_aider_default_batch_timeout():
     from benchlocal_cli import sandbox as sandbox_module
     config = sandbox_module.config_for_pack("aider-polyglot-30")
-    assert dict(config.env)["AIDER_BENCHMARK_TIMEOUT_S"] == "3600"
+    env = dict(config.env)
+    assert env["AIDER_BENCHMARK_THREADS"] == "1"
+    assert env["AIDER_BENCHMARK_TIMEOUT_S"] == "3600"
     assert config.request_timeout_s == 3900.0
+
+
+def test_config_for_pack_aider_threads_env_override(monkeypatch):
+    from benchlocal_cli import sandbox as sandbox_module
+    monkeypatch.setenv("BENCHLOCAL_AIDER_THREADS", "4")
+    config = sandbox_module.config_for_pack("aider-polyglot-30")
+    assert dict(config.env)["AIDER_BENCHMARK_THREADS"] == "4"
 
 
 def test_config_for_pack_aider_raises_batch_timeout_from_per_case():
@@ -634,6 +643,23 @@ def test_run_pack_single_scoreboard_success_shows_real_fraction(monkeypatch):
     assert pack.status == "ok"
 
 
+def test_run_pack_single_scoreboard_timeout_with_zero_completed_stays_scoreboard(monkeypatch):
+    from benchlocal_cli import runner as runner_module
+    meta, scenarios = _single_scoreboard_fixture()
+    monkeypatch.setattr(runner_module, "load_pack", lambda pid: (meta, scenarios))
+    r = runner_module.Runner(endpoint="http://h:8000", model="m", enable_sandboxed_packs=True)
+    r._sandbox_clients["aider-polyglot-30"] = FakeSingleScoreboardSandbox(
+        passed=False, failure_mode="agent_runner_timeout",
+        passed_count=0, total_count=0, pass_rate=0.0)
+
+    pack = r.run_pack("aider-polyglot-30")
+
+    assert pack.passed == 0
+    assert pack.total == 0
+    assert pack.score == 0.0
+    assert pack.status == "agent_runner_timeout"
+
+
 def test_run_pack_single_scoreboard_timeout_surfaces_partial(monkeypatch):
     from benchlocal_cli import runner as runner_module
     meta, scenarios = _single_scoreboard_fixture()
@@ -641,11 +667,11 @@ def test_run_pack_single_scoreboard_timeout_surfaces_partial(monkeypatch):
     r = runner_module.Runner(endpoint="http://h:8000", model="m", enable_sandboxed_packs=True)
     r._sandbox_clients["aider-polyglot-30"] = FakeSingleScoreboardSandbox(
         passed=False, failure_mode="agent_runner_timeout",
-        passed_count=18, total_count=30, pass_rate=18 / 30)
+        passed_count=17, total_count=26, pass_rate=17 / 26)
 
     pack = r.run_pack("aider-polyglot-30")
 
-    assert pack.passed == 18          # partial surfaced, NOT 0
-    assert pack.total == 30
-    assert abs(pack.score - 18 / 30) < 1e-9
+    assert pack.passed == 17          # partial surfaced, NOT 0
+    assert pack.total == 26           # completed denominator, NOT canonical 30
+    assert abs(pack.score - 17 / 26) < 1e-9
     assert pack.status == "agent_runner_timeout"   # not masked as "ok"


### PR DESCRIPTION
## Summary
- default aider-polyglot to AIDER_BENCHMARK_THREADS=1 for single-slot llama.cpp/ik_llama endpoints
- keep BENCHLOCAL_AIDER_THREADS as the explicit override for multi-slot endpoints
- score timeout-truncated aider batches as passed/completed rather than passed/canonical-total
- keep canonical_total_count, missing_results, and score_completed_only in the trace so incomplete runs stay visible
- preserve single-scoreboard reporting even when a timeout completes zero exercises

Fixes #17.

## Tests
- .venv/bin/python -m pytest -q tests/test_aider_polyglot.py tests/test_sandbox_runner.py
- .venv/bin/python -m pytest -q
- python3 -m py_compile sandboxes/aider-polyglot/server.py