### PR TITLE
feat(cli): add opt-in --temperature/--top-p sampling overrides (#19)

### DIFF
--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -125,6 +125,14 @@ def _parser() -> argparse.ArgumentParser:
     )
     run.add_argument("--enable-thinking", action="store_true", help="run with reasoning/thinking enabled (default: off)")
     run.add_argument("--thinking-max-tokens", type=int, default=4096)
+    # v0.9.1: opt-in sampling overrides (#19) — evaluate models at their
+    # recommended temperature. Default behavior (per-pack temp=0) unchanged.
+    # Any override tags the run as non-canonical in output + saved JSON.
+    run.add_argument("--temperature", type=float, default=None, help="override sampling temperature (default: per-pack, usually 0)")
+    run.add_argument("--top-p", type=float, default=None, help="override top-p / nucleus sampling (default: per-pack)")
+    run.add_argument("--top-k", type=int, default=None, help="override top-k sampling (default: per-pack)")
+    run.add_argument("--min-p", type=float, default=None, help="override min-p sampling (default: per-pack)")
+    run.add_argument("--repeat-penalty", type=float, default=None, help="override repeat/frequency penalty (default: per-pack)")
     run.add_argument("--extra-body", help="JSON object merged into each chat-completions request body")
     run.add_argument("--mock-responses-from-json", help="JSON object mapping scenario id to OpenAI response (testing only)")
     # v0.8 — diagnostic tooling
@@ -139,7 +147,8 @@ def _parser() -> argparse.ArgumentParser:
         "--exit-on-regression",
         action="store_true",
         help="exit code 3 when --previous-result delta has any regressions. CI-friendly. "
-             "Requires --previous-result to also be set.",
+             "Requires --previous-result to also be set. Blocked when sampling overrides "
+             "are active (non-canonical runs shouldn't gate CI).",
     )
     run.add_argument(
         "--history-file",
@@ -181,8 +190,14 @@ def _markdown(result: RunResult) -> str:
     if result.delta is not None:
         delta_pack_index = {p["pack_id"]: p for p in result.delta.get("by_pack") or []}
 
+    # v0.9.1: non-canonical banner when sampling overrides are active (#19)
+    canonical_tag = ""
+    if result.sampling_overrides:
+        override_str = ", ".join(f"{k}={v}" for k, v in result.sampling_overrides.items())
+        canonical_tag = f" ⚠ NON-CANONICAL (sampling: {override_str})"
+
     lines = [
-        f"=== benchlocal-cli --{result.mode}  (endpoint: {result.endpoint}, model: {result.model}, thinking={thinking}, {result.started_at}) ===",
+        f"=== benchlocal-cli --{result.mode}  (endpoint: {result.endpoint}, model: {result.model}, thinking={thinking}, {result.started_at}){canonical_tag} ===",
         "",
     ]
     if delta_pack_index is None:
@@ -372,6 +387,29 @@ def main(argv: list[str] | None = None) -> int:
                 pass  # let Runner surface the unknown-pack error
         if args.no_sandboxed_packs and not args.sandboxed_only:
             sandboxed_enabled = False
+        # Build sampling overrides from CLI flags (#19)
+        sampling_overrides: dict = {}
+        if args.temperature is not None:
+            sampling_overrides["temperature"] = args.temperature
+        if args.top_p is not None:
+            sampling_overrides["top_p"] = args.top_p
+        if args.top_k is not None:
+            sampling_overrides["top_k"] = args.top_k
+        if args.min_p is not None:
+            sampling_overrides["min_p"] = args.min_p
+        if args.repeat_penalty is not None:
+            sampling_overrides["repeat_penalty"] = args.repeat_penalty
+
+        # Block --exit-on-regression when sampling is non-canonical
+        if args.exit_on_regression and sampling_overrides:
+            print(
+                "benchlocal-cli: --exit-on-regression is blocked when sampling overrides "
+                "are active (non-canonical runs shouldn't gate CI). Run without overrides "
+                "for the reproducible baseline.",
+                file=sys.stderr,
+            )
+            return 1
+
         runner = Runner(
             endpoint=args.endpoint,
             model=args.model,
@@ -389,6 +427,7 @@ def main(argv: list[str] | None = None) -> int:
                 sandboxed_enabled=sandboxed_enabled,
             ),
             max_transient_retries=args.max_transient_retries,
+            sampling_overrides=sampling_overrides or None,
         )
         result = runner.run(pack_ids, mode=mode, repeat=max(1, args.repeat))
 

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -100,9 +100,15 @@ def build_request(
     thinking_enabled: bool = False,
     thinking_max_tokens: int = 4096,
     extra_body: dict | None = None,
+    sampling_overrides: dict | None = None,
 ) -> tuple[dict, dict]:
     sampling = dict(meta.get("sampling_defaults", {}))
     scenario_overrides = scenario.get("sampling_overrides") or {}
+    # CLI-level sampling overrides (--temperature, --top-p, etc.) take
+    # precedence over pack defaults and scenario overrides. Applied here
+    # (before scenario overrides) so per-scenario max_tokens still wins.
+    if sampling_overrides:
+        sampling.update(sampling_overrides)
     if extra_body:
         sampling.update(extra_body)
     if thinking_enabled:
@@ -212,6 +218,7 @@ class Runner:
         sandbox_image_tag: str = "latest",
         sandbox_log_dir: str | None = None,
         max_transient_retries: int = 3,
+        sampling_overrides: dict | None = None,
     ) -> None:
         self.endpoint = endpoint
         self.model = model
@@ -227,6 +234,9 @@ class Runner:
         # See SandboxClient.stop(log_dir=...) for the snapshot.
         self.sandbox_log_dir = sandbox_log_dir
         self.max_transient_retries = max(0, int(max_transient_retries))
+        # CLI-level sampling overrides (--temperature, --top-p, etc.).
+        # When set, the run is tagged as non-canonical in the output.
+        self.sampling_overrides = sampling_overrides or {}
         self._sandbox_clients: dict[str, SandboxClient] = {}
 
     def run(self, pack_ids: list[str], *, mode: str = "custom", repeat: int = 1) -> RunResult:
@@ -250,6 +260,13 @@ class Runner:
             total = sum(pack.total for pack in pack_results)
             passed = sum(pack.passed for pack in pack_results)
             finished_at = _utc_now()
+            # Tag non-canonical sampling runs
+            if self.sampling_overrides:
+                override_desc = ", ".join(f"{k}={v}" for k, v in self.sampling_overrides.items())
+                warnings.append(
+                    f"non-canonical sampling overrides active ({override_desc}) — "
+                    f"results are NOT comparable to the default temp=0 baseline"
+                )
             return RunResult(
                 schema_version="1",
                 runner_version=__version__,
@@ -262,6 +279,7 @@ class Runner:
                 totals={"passed": passed, "total": total, "score": (passed / total if total else 0.0)},
                 thinking_enabled=self.thinking_enabled,
                 warnings=warnings,
+                sampling_overrides=dict(self.sampling_overrides) if self.sampling_overrides else None,
             )
         finally:
             self._stop_sandboxes()
@@ -444,6 +462,7 @@ class Runner:
             thinking_enabled=self.thinking_enabled,
             thinking_max_tokens=self.thinking_max_tokens,
             extra_body=self.extra_body,
+            sampling_overrides=self.sampling_overrides or None,
         )
         scenario_timeout = scenario.get("max_seconds_override") or meta.get("default_max_seconds") or self.timeout_per_case
         timeout = min(float(scenario_timeout), float(self.timeout_per_case))

--- a/benchlocal_cli/types.py
+++ b/benchlocal_cli/types.py
@@ -131,6 +131,11 @@ class RunResult:
     # None means delta wasn't computed (the default; preserves saved-JSON
     # back-compat with v0.7.x readers per Codex review #9).
     delta: dict | None = None
+    # v0.9.1: CLI-level sampling overrides (--temperature, --top-p, etc.).
+    # None means the run used the pack's default sampling (canonical).
+    # Non-None means the run traded reproducibility for recommended-temp
+    # evaluation; results should NOT be compared to the temp=0 baseline.
+    sampling_overrides: dict | None = None
 
     def to_dict(self) -> dict:
         out = {
@@ -148,4 +153,6 @@ class RunResult:
         }
         if self.delta is not None:
             out["delta"] = self.delta
+        if self.sampling_overrides is not None:
+            out["sampling_overrides"] = self.sampling_overrides
         return out


### PR DESCRIPTION
## Summary

Closes #19.

Add opt-in sampling overrides to `benchlocal-cli run` so models can be evaluated at their recommended temperature instead of the hardcoded temp=0 baseline.

## New flags

```
--temperature N   --top-p N   --top-k N   --min-p N   --repeat-penalty N
```

All default to `None` (per-pack values, fully reproducible). Default behavior is **unchanged**.

## Non-canonical tagging

When any override is set, the run is clearly labelled as non-canonical:

**Markdown header:**
```
=== benchlocal-cli --medium  (...) ⚠ NON-CANONICAL (sampling: temperature=0.75, top_p=0.9) ===
```

**JSON output:** new `sampling_overrides` key + warning appended.

**CI safety:** `--exit-on-regression` is blocked when overrides are active — non-canonical runs shouldn't gate CI.

## Plumbing

| File | Change |
|---|---|
| `cli.py` | Parse 5 new flags → build `sampling_overrides` dict → pass to Runner |
| `runner.py` | Accept `sampling_overrides`, apply in `build_request()` after pack defaults but before scenario overrides (per-scenario `max_tokens` still wins) |
| `types.py` | Add `sampling_overrides: dict | None` field to `RunResult` |

## Use case

**Qwopus3.6-27B-v2** (Opus-trace SFT) recommends temp 0.75–1. At temp 0 it scores as a flat tie with base Qwen3.6 — but that's measuring it in the exact regime where an exploratory fine-tune is most suppressed. With `--temperature 0.75`, the eval runs at the regime the fine-tuner actually designed for.

## Testing

- All 135 existing tests pass
- Verified override flows through to `sampling_params` in per-scenario output
- Verified non-canonical warning appears in both markdown and JSON output
- Verified `--exit-on-regression` is blocked with overrides active