### PR TITLE
feat(cli): add --max-tokens global length cap (#28)

### DIFF
--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -157,8 +157,9 @@ def _parser() -> argparse.ArgumentParser:
     run.add_argument(
         "--thinking-max-tokens",
         type=int,
-        default=16384,
-        help="max_tokens to request when thinking is enabled (default: 16384)",
+        default=None,
+        help="max_tokens to request when thinking is enabled "
+             "(default: --max-tokens if set, else 16384)",
     )
     # v0.9.1: opt-in sampling overrides (#19) — evaluate models at their
     # recommended temperature. Default behavior (per-pack temp=0) unchanged.
@@ -168,6 +169,12 @@ def _parser() -> argparse.ArgumentParser:
     run.add_argument("--top-k", type=int, default=None, help="override top-k sampling (default: per-pack)")
     run.add_argument("--min-p", type=float, default=None, help="override min-p sampling (default: per-pack)")
     run.add_argument("--repeat-penalty", type=float, default=None, help="override repeat/frequency penalty (default: per-pack)")
+    # #28: global length cap for both arms. Overrides the per-pack max_tokens
+    # default for the base/no-think arm; also becomes the thinking-arm budget
+    # unless --thinking-max-tokens is given (which wins for that arm). Lets a
+    # thinking-vs-no-think A/B be pinned symmetric with one flag (e.g.
+    # `--max-tokens 16384`). Tags the run non-canonical like other overrides.
+    run.add_argument("--max-tokens", type=int, default=None, help="override max_tokens / length budget for both arms (default: per-pack; thinking arm uses --thinking-max-tokens if set)")
     # v0.9.2: inherit sampling from server (#21) — omit all sampling params
     # from the request so the server applies its own configured defaults.
     # Mutually exclusive with --temperature/--top-p/--top-k/--min-p/--repeat-penalty.
@@ -518,9 +525,26 @@ def main(argv: list[str] | None = None) -> int:
             sampling_overrides["min_p"] = args.min_p
         if args.repeat_penalty is not None:
             sampling_overrides["repeat_penalty"] = args.repeat_penalty
+        # #28: --max-tokens caps the base/no-think arm (flows through as a
+        # sampling override) and, below, the thinking arm too unless
+        # --thinking-max-tokens overrides it.
+        if args.max_tokens is not None:
+            sampling_overrides["max_tokens"] = args.max_tokens
 
-        # --sampling-from-server is mutually exclusive with explicit overrides (#21)
-        if args.sampling_from_server and sampling_overrides:
+        # --thinking-max-tokens (arm-specific) wins for the thinking arm; else
+        # fall back to --max-tokens (global cap); else the historical 16384.
+        effective_thinking_max = (
+            args.thinking_max_tokens if args.thinking_max_tokens is not None
+            else args.max_tokens if args.max_tokens is not None
+            else 16384
+        )
+
+        # --sampling-from-server is mutually exclusive with explicit sampling-
+        # distribution overrides (#21). --max-tokens is a length budget, not a
+        # distribution param, and is preserved under --sampling-from-server, so
+        # it's allowed alongside it.
+        _distribution_overrides = {k: v for k, v in sampling_overrides.items() if k != "max_tokens"}
+        if args.sampling_from_server and _distribution_overrides:
             print(
                 "benchlocal-cli: --sampling-from-server is mutually exclusive with "
                 "--temperature/--top-p/--top-k/--min-p/--repeat-penalty. "
@@ -610,7 +634,7 @@ def main(argv: list[str] | None = None) -> int:
             enable_sandboxed_packs=sandboxed_enabled,
             mock_responses=_load_mock(args.mock_responses_from_json),
             thinking_enabled=args.thinking_override,
-            thinking_max_tokens=args.thinking_max_tokens,
+            thinking_max_tokens=effective_thinking_max,
             extra_body=_load_extra_body(args.extra_body),
             sandbox_image_tag=args.sandbox_image_tag,
             sandbox_log_dir=_resolve_sandbox_log_dir(

--- a/tests/test_reasoning_handling.py
+++ b/tests/test_reasoning_handling.py
@@ -69,6 +69,36 @@ def test_build_request_enable_thinking_overrides_scenario_token_budget():
     assert request["max_tokens"] == 4096
 
 
+def test_sampling_override_caps_base_arm_max_tokens():
+    # #28: --max-tokens flows through sampling_overrides and caps the
+    # base/no-think arm (overrides the per-pack default).
+    request, _ = build_request(
+        _scenario(),
+        _meta(),
+        "fake",
+        sampling_overrides={"max_tokens": 512},
+    )
+
+    assert request["chat_template_kwargs"] == {"enable_thinking": False}
+    assert request["max_tokens"] == 512  # pack default 1024 overridden
+
+
+def test_thinking_budget_wins_over_sampling_override_max_tokens():
+    # #28: the thinking arm always uses thinking_max_tokens, even when a smaller
+    # --max-tokens was set for the base arm. The CLI resolves the precedence so
+    # an explicit --thinking-max-tokens wins for the thinking arm.
+    request, _ = build_request(
+        _scenario(),
+        _meta(default_thinking="on"),
+        "fake",
+        thinking_max_tokens=16384,
+        sampling_overrides={"max_tokens": 4096},
+    )
+
+    assert request["chat_template_kwargs"] == {"enable_thinking": True}
+    assert request["max_tokens"] == 16384
+
+
 def test_extra_body_wins_over_defaults_but_loses_to_scenario_overrides():
     request, _ = build_request(
         _scenario({"foo": "scenario"}),


### PR DESCRIPTION
Closes #28.

Adds a `--max-tokens N` run flag that caps the length budget for **both** arms, mirroring the #19 sampling overrides:

| arm | budget |
|---|---|
| base / no-think | `N` if set, else per-pack default |
| thinking | `--thinking-max-tokens` if set, else `N`, else 16384 |

So one flag pins a thinking-vs-no-think A/B **symmetric** (`--max-tokens 16384`), while `--max-tokens 4096 --thinking-max-tokens 16384` gives an **asymmetric** pin. `--thinking-max-tokens`'s default flips `16384`→`None` so the fallback can tell "explicitly set" from "defaulted" (no behavior change when neither flag is passed).

**Motivation.** GPQA-Diamond's no-think arm reasons in `content` as heavily as the thinking channel, so it needs ~the same budget. Per-pack base tuning (#29 bumped GPQA 2048→4096) can't express "pin both arms equal for one A/B" without editing the pack. Fairness wants each arm *adequate* not *equal* — but when they coincide (GPQA), one flag should set both.

**Scope.** Wiring is entirely in `cli.py`; `runner.py` is untouched. `--max-tokens` is a length budget (not a sampling-distribution param) and is preserved under `--sampling-from-server`, so it's allowed alongside it — the existing mutual-exclusion still blocks `--temperature/--top-p/--top-k/--min-p/--repeat-penalty`. Tags the run non-canonical and blocks `--exit-on-regression` like other overrides.

**Tests.** 2 runner-contract tests (base-arm cap; thinking budget wins over a smaller base cap). Full suite **126 passed, 30 deselected** (aider — needs Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)