### PR TITLE
Disambiguate CLI agent loop exhaustion

### DIFF
--- a/benchlocal_cli/types.py
+++ b/benchlocal_cli/types.py
@@ -16,6 +16,7 @@ FailureMode = Literal[
     "schema_violation",
     "wrong_structure",
     "timeout",
+    "agent_loop_exhausted",
     "http_error",
     "server_error",
     "verifier_not_implemented",

--- a/docs/SANDBOX_PROTOCOL.md
+++ b/docs/SANDBOX_PROTOCOL.md
@@ -121,7 +121,8 @@ POST /verify-end       # explicit "model gave up" or runner hit turn limit
 | `verifier_fail` | Real test failure (e.g., pytest red, command output mismatch, trace mismatch) |
 | `wrong_answer` | Model emitted unexpected response shape (e.g., text instead of tool call) |
 | `invalid_json` | Tool call arguments didn't parse, or fix wasn't valid Python, etc |
-| `timeout` | Hit per-scenario time limit (10s for CLI commands; 20-turn limit for HermesAgent) |
+| `timeout` | Hit a real wall-clock/subprocess/command time limit. |
+| `agent_loop_exhausted` | Multi-turn agent loop ended without a successful solution before any wall-clock timeout fired. |
 | `agent_runner_timeout` | (Hermes v0.7.3) upstream subprocess exceeded wall-clock cap (default 900s) |
 | `agent_runner_crashed` | (Hermes v0.7.3) upstream exited nonzero or didn't write `result.json` |
 | `result_json_malformed` | (Hermes v0.7.3) upstream's `result.json` couldn't be parsed |

--- a/sandboxes/cli/README.md
+++ b/sandboxes/cli/README.md
@@ -23,6 +23,7 @@ Container runs:
 - Working dir limited to `/tmp/cli-sandbox/` (tmpfs-backed; cleared between requests)
 - Per-command timeout: 10s (configurable per scenario)
 - Output capped at 64 KB
+- Multi-round agent loop exhaustion reports `failure_mode: agent_loop_exhausted`; `timeout` is reserved for real command or wall-clock timeout paths.
 
 ## In a benchlocal-cli run
 

--- a/sandboxes/cli/server.py
+++ b/sandboxes/cli/server.py
@@ -479,7 +479,7 @@ def _multiturn_end(state_id: str) -> dict:
     result = _verify_multiround_commands(state["scenario_id"], state["commands"])
     result["action"] = "verify-final"
     if not result.get("passed"):
-        result["failure_mode"] = "timeout"
+        result["failure_mode"] = "agent_loop_exhausted"
         result["detail"] = f"{state['scenario_id']}: agent loop ended before success"
     result.setdefault("trace", {}).update({"turn_count": state["turn_count"], "commands": state["commands"], "tool_results": state["tool_results"]})
     return result

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -276,6 +276,154 @@ def test_runner_explicit_timeout_per_case_wins_over_pack_default(monkeypatch):
     assert FakeHTTPClient.timeouts == [45, 45]
 
 
+class FakeAlwaysToolHTTPClient:
+    timeouts: list[float] = []
+
+    def __init__(self, timeout: float) -> None:
+        self.timeout = timeout
+        self.timeouts.append(timeout)
+
+    def __enter__(self) -> "FakeAlwaysToolHTTPClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def post(self, url: str, json: dict) -> FakeHTTPResponse:
+        return FakeHTTPResponse(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "",
+                            "tool_calls": [
+                                {
+                                    "id": "call-loop",
+                                    "type": "function",
+                                    "function": {"name": "bash", "arguments": "{\"command\":\"pwd\"}"},
+                                }
+                            ],
+                        }
+                    }
+                ],
+                "usage": {"completion_tokens": 1},
+            }
+        )
+
+
+class FakeTimeoutHTTPClient:
+    def __init__(self, timeout: float) -> None:
+        self.timeout = timeout
+
+    def __enter__(self) -> "FakeTimeoutHTTPClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def post(self, url: str, json: dict) -> FakeHTTPResponse:
+        import benchlocal_cli.runner as runner_module
+
+        raise runner_module.httpx.TimeoutException("read timed out")
+
+
+class FakeCliLoopExhaustedSandbox:
+    config = FakeMultiTurnConfig()
+
+    def __init__(self) -> None:
+        self.ended = False
+
+    def verify_multiturn_start(self, scenario: dict) -> dict:
+        return {
+            "scenario_state_id": "state-loop",
+            "prompt": scenario["messages"],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {"name": "bash", "parameters": {"type": "object", "properties": {}}},
+                }
+            ],
+        }
+
+    def verify_multiturn_turn(self, scenario_state_id: str, model_response: dict) -> dict:
+        assert scenario_state_id == "state-loop"
+        return {
+            "action": "next-prompt",
+            "prompt": [{"role": "tool", "tool_call_id": "call-loop", "name": "bash", "content": "{}"}],
+            "tools": [],
+        }
+
+    def verify_multiturn_end(self, scenario_state_id: str) -> dict:
+        assert scenario_state_id == "state-loop"
+        self.ended = True
+        return {
+            "action": "verify-final",
+            "passed": False,
+            "failure_mode": "agent_loop_exhausted",
+            "detail": "CLI-21: agent loop ended before success",
+            "trace": {"turn_count": 1},
+        }
+
+
+def test_cli_multiturn_agent_loop_exhausted_is_not_timeout(monkeypatch):
+    import benchlocal_cli.runner as runner_module
+
+    FakeAlwaysToolHTTPClient.timeouts = []
+    monkeypatch.setattr(runner_module.httpx, "Client", FakeAlwaysToolHTTPClient)
+    runner = Runner(endpoint="http://localhost:9999", model="fake", enable_sandboxed_packs=True)
+    fake = FakeCliLoopExhaustedSandbox()
+    runner._sandbox_clients["cli-40"] = fake
+    meta = {
+        "supports_sandboxed_only": True,
+        "timeout_per_case_default": 300,
+        "sampling_defaults": {"max_tokens": 16},
+    }
+    scenario = {
+        "id": "CLI-21",
+        "pack_id": "cli-40",
+        "messages": [{"role": "user", "content": "use the shell"}],
+        "raw_scenario": {"kind": "multiround", "max_turns": 1},
+        "verifier": {"type": "_stub", "asserts": []},
+    }
+
+    run = runner.run_scenario(meta, scenario)
+
+    assert run.result.passed is False
+    assert run.result.failure_mode == "agent_loop_exhausted"
+    assert "agent loop ended before success" in run.result.detail
+    assert FakeAlwaysToolHTTPClient.timeouts == [300]
+    assert fake.ended is True
+
+
+def test_cli_multiturn_wall_clock_timeout_remains_timeout(monkeypatch):
+    import benchlocal_cli.runner as runner_module
+
+    monkeypatch.setattr(runner_module.httpx, "Client", FakeTimeoutHTTPClient)
+    runner = Runner(endpoint="http://localhost:9999", model="fake", enable_sandboxed_packs=True)
+    fake = FakeCliLoopExhaustedSandbox()
+    runner._sandbox_clients["cli-40"] = fake
+    meta = {
+        "supports_sandboxed_only": True,
+        "timeout_per_case_default": 300,
+        "sampling_defaults": {"max_tokens": 16},
+    }
+    scenario = {
+        "id": "CLI-21",
+        "pack_id": "cli-40",
+        "messages": [{"role": "user", "content": "use the shell"}],
+        "raw_scenario": {"kind": "multiround", "max_turns": 1},
+        "verifier": {"type": "_stub", "asserts": []},
+    }
+
+    run = runner.run_scenario(meta, scenario)
+
+    assert run.result.passed is False
+    assert run.result.failure_mode == "timeout"
+    assert "timed out after 300" in run.result.detail
+    assert fake.ended is True
+
+
 class FakeHermesEarlyOutSandbox:
     """Hermes v0.7.3 sandbox: /verify-start returns verify-final directly,
     no /verify-turn loop. Captures the start kwargs so we can assert the


### PR DESCRIPTION
## Summary
- rename cli-40 multi-turn agent loop exhaustion from failure_mode=timeout to failure_mode=agent_loop_exhausted
- keep failure_mode=timeout reserved for real command/subprocess/wall-clock timeout paths
- document the failure-mode distinction in sandbox protocol docs and the cli sandbox README

Fixes #45.

## Validation
- python3 -m py_compile sandboxes/cli/server.py benchlocal_cli/types.py
- .venv/bin/python -m pytest -q tests/test_sandbox_runner.py
- .venv/bin/python -m pytest -q