### PR TITLE
Auto-resolve Hermes loopback endpoints

### DIFF
--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -516,7 +516,8 @@ class Runner:
                         pack_id,
                         self.sandbox_image_tag,
                         batch_timeout_s=self._timeout_budget_for_meta(meta),
-                    )
+                    ),
+                    model_endpoint=self.endpoint,
                 )
                 # #6: when --sandbox-log-dir is set, give the sandbox a writable
                 # host run-dir so per-unit artifacts persist live (survive --rm/
@@ -993,16 +994,16 @@ class Runner:
                 # Sampling is included so upstream's request_overrides
                 # (temperature, top_p, max_tokens, etc.) match runner defaults.
                 #
-                # Endpoint resolution: opt-in via BENCHLOCAL_HERMES_RESOLVE_LOCALHOST=1.
-                # When set, rewrites localhost/127.x/[::1] → host.docker.internal so
-                # the hermes-agent inside the sandbox container can reach the runner's
-                # host-side vLLM. Pairs with the --add-host flag already added by
-                # sandbox.py:290-294. Default-off preserves existing hermes deployments
-                # where service-name resolution (k8s, docker-compose internal) already
-                # works without rewrite.
+                # Endpoint resolution: loopback endpoints can never be Docker
+                # or k8s service names, so rewrite them unconditionally. Keep
+                # BENCHLOCAL_HERMES_RESOLVE_LOCALHOST as the opt-in for
+                # non-loopback hosts where deployment topology is ambiguous.
+                from benchlocal_cli.sandbox import endpoint_is_loopback, resolve_endpoint_for_container
                 hermes_endpoint = self.endpoint
-                if os.environ.get("BENCHLOCAL_HERMES_RESOLVE_LOCALHOST") == "1":
-                    from benchlocal_cli.sandbox import resolve_endpoint_for_container
+                if (
+                    endpoint_is_loopback(self.endpoint)
+                    or os.environ.get("BENCHLOCAL_HERMES_RESOLVE_LOCALHOST") == "1"
+                ):
                     hermes_endpoint = resolve_endpoint_for_container(self.endpoint)
                 start_kwargs = {
                     "model_endpoint": hermes_endpoint,

--- a/benchlocal_cli/sandbox.py
+++ b/benchlocal_cli/sandbox.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -121,6 +122,18 @@ SANDBOX_REGISTRY = {
 }
 
 
+_LOOPBACK_ENDPOINT_RE = re.compile(
+    r"^https?://(?:[^/@]+@)?(?:localhost(?::|/|$)|127\.|\[::1\](?::|/|$)|\[::\](?::|/|$))",
+    re.IGNORECASE,
+)
+
+
+def endpoint_is_loopback(endpoint: str) -> bool:
+    """Return True for HTTP(S) loopback endpoints that need host-gateway
+    routing when called from inside a Docker sandbox container."""
+    return bool(endpoint and _LOOPBACK_ENDPOINT_RE.search(endpoint))
+
+
 def resolve_endpoint_for_container(endpoint: str) -> str:
     """v0.9.0 helper (Codex 2nd-pass #2): rewrite host-side endpoint URLs to
     container-reachable form when a sandbox needs to call out to the runner's
@@ -137,7 +150,8 @@ def resolve_endpoint_for_container(endpoint: str) -> str:
     Linux note: `host.docker.internal` only resolves inside a container that
     was started with `--add-host=host.docker.internal:host-gateway`. The
     runner adds that flag to docker run for sandboxes that opt into this
-    rewrite (default-on for aider-polyglot, opt-in via env for hermes).
+    rewrite (default-on for aider-polyglot and loopback Hermes endpoints;
+    env-gated for non-loopback Hermes endpoints).
     """
     if not endpoint:
         return endpoint
@@ -149,12 +163,7 @@ def resolve_endpoint_for_container(endpoint: str) -> str:
             "endpoint host is 0.0.0.0 (bind-only, not a routable target). "
             "Pass a real host or use 127.0.0.1/localhost."
         )
-    is_loopback = (
-        host == "localhost"
-        or host == "::1"
-        or host.startswith("127.")
-    )
-    if not is_loopback:
+    if not endpoint_is_loopback(endpoint):
         return endpoint
     # Reassemble with the new host. preserve port + path + query + fragment.
     port_suffix = f":{parsed.port}" if parsed.port else ""
@@ -297,8 +306,9 @@ class SandboxClient:
             result = client.verify(...)
     """
 
-    def __init__(self, config: SandboxConfig) -> None:
+    def __init__(self, config: SandboxConfig, *, model_endpoint: str = "") -> None:
         self.config = config
+        self.model_endpoint = model_endpoint
         self._container_id: str | None = None
 
     def _build_docker_run_argv(self, name: str, run_dir: str | None) -> list[str]:
@@ -328,14 +338,14 @@ class SandboxClient:
             cmd.extend(["-v", f"{run_dir}:{self.config.run_output_dir}"])
             for key, value in self.config.run_mount_env:
                 cmd.extend(["-e", f"{key}={value}"])
-        # v0.9.0: aider-polyglot needs to call out to the runner's model
-        # endpoint from inside the container. On Linux, host.docker.internal
-        # only resolves with this --add-host flag (Codex 2nd-pass #2).
-        # Default-on for aider-polyglot; opt-in for hermes (preserves
-        # existing hermes deployments where service-name resolution
-        # already works).
+        # v0.9.0: agentic sandboxes may need to call back to the runner's
+        # host-side model endpoint. On Linux, host.docker.internal only
+        # resolves with this --add-host flag. Aider always uses the rewrite;
+        # Hermes auto-enables it for loopback endpoints and keeps the env gate
+        # for non-loopback hosts where service-name deployments are ambiguous.
         if (
             self.config.pack_id == "aider-polyglot-30"
+            or (self.config.pack_id == "hermesagent-20" and endpoint_is_loopback(self.model_endpoint))
             or os.environ.get("BENCHLOCAL_HERMES_RESOLVE_LOCALHOST") == "1"
         ):
             cmd.extend(["--add-host", "host.docker.internal:host-gateway"])

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from benchlocal_cli.runner import Runner
 from benchlocal_cli.types import ScenarioResult
 
@@ -538,6 +540,114 @@ class FakeHermesEarlyOutSandbox:
         self.end_called = True
         return {"action": "verify-final", "passed": False, "failure_mode": "timeout", "detail": "", "trace": {}}
 
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "http://localhost:9999",
+        "http://127.0.0.1:9999/v1",
+        "http://127.1.2.3:9999",
+        "http://[::1]:9999/v1/chat/completions",
+        "http://[::]:9999",
+    ],
+)
+def test_endpoint_is_loopback_covers_local_variants(endpoint):
+    from benchlocal_cli.sandbox import endpoint_is_loopback
+
+    assert endpoint_is_loopback(endpoint) is True
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "http://example.com:9999",
+        "http://host.docker.internal:9999",
+        "http://10.0.0.5:9999",
+        "https://model.internal/v1",
+    ],
+)
+def test_endpoint_is_loopback_rejects_non_loopback(endpoint):
+    from benchlocal_cli.sandbox import endpoint_is_loopback
+
+    assert endpoint_is_loopback(endpoint) is False
+
+
+def test_hermes_docker_argv_adds_host_gateway_for_loopback_without_env(monkeypatch):
+    from benchlocal_cli.sandbox import SandboxClient, config_for_pack
+
+    monkeypatch.delenv("BENCHLOCAL_HERMES_RESOLVE_LOCALHOST", raising=False)
+    client = SandboxClient(config_for_pack("hermesagent-20"), model_endpoint="http://localhost:9999/v1")
+    argv = client._build_docker_run_argv("test-name", None)
+
+    assert "--add-host" in argv
+    assert "host.docker.internal:host-gateway" in argv
+
+
+def test_hermes_docker_argv_keeps_non_loopback_env_gated(monkeypatch):
+    from benchlocal_cli.sandbox import SandboxClient, config_for_pack
+
+    monkeypatch.delenv("BENCHLOCAL_HERMES_RESOLVE_LOCALHOST", raising=False)
+    client = SandboxClient(config_for_pack("hermesagent-20"), model_endpoint="http://host.docker.internal:9999/v1")
+    argv = client._build_docker_run_argv("test-name", None)
+
+    assert "--add-host" not in argv
+    assert "host.docker.internal:host-gateway" not in argv
+
+
+def test_runner_rewrites_hermes_loopback_endpoint_without_env(monkeypatch):
+    monkeypatch.delenv("BENCHLOCAL_HERMES_RESOLVE_LOCALHOST", raising=False)
+    runner = Runner(
+        endpoint="http://localhost:9999/v1/chat/completions",
+        model="qwen3.6-27b-autoround",
+        enable_sandboxed_packs=True,
+    )
+    fake = FakeHermesEarlyOutSandbox()
+    runner._sandbox_clients["hermesagent-20"] = fake
+    meta = {
+        "supports_sandboxed_only": True,
+        "default_max_seconds": 60,
+        "sampling_defaults": {"max_tokens": 256, "temperature": 0.0},
+    }
+    scenario = {
+        "id": "HA-01",
+        "pack_id": "hermesagent-20",
+        "messages": [{"role": "user", "content": "remember CockroachDB"}],
+        "raw_scenario": {"kind": "memory_replace_contradiction"},
+        "verifier": {"type": "_stub", "asserts": []},
+    }
+
+    run = runner.run_scenario(meta, scenario)
+
+    assert run.result.passed is True
+    assert fake.start_kwargs["model_endpoint"] == "http://host.docker.internal:9999/v1/chat/completions"
+
+
+def test_runner_preserves_hermes_non_loopback_endpoint_without_env(monkeypatch):
+    monkeypatch.delenv("BENCHLOCAL_HERMES_RESOLVE_LOCALHOST", raising=False)
+    runner = Runner(
+        endpoint="http://host.docker.internal:9999/v1",
+        model="qwen3.6-27b-autoround",
+        enable_sandboxed_packs=True,
+    )
+    fake = FakeHermesEarlyOutSandbox()
+    runner._sandbox_clients["hermesagent-20"] = fake
+    meta = {
+        "supports_sandboxed_only": True,
+        "default_max_seconds": 60,
+        "sampling_defaults": {"max_tokens": 256, "temperature": 0.0},
+    }
+    scenario = {
+        "id": "HA-01",
+        "pack_id": "hermesagent-20",
+        "messages": [{"role": "user", "content": "remember CockroachDB"}],
+        "raw_scenario": {"kind": "memory_replace_contradiction"},
+        "verifier": {"type": "_stub", "asserts": []},
+    }
+
+    run = runner.run_scenario(meta, scenario)
+
+    assert run.result.passed is True
+    assert fake.start_kwargs["model_endpoint"] == "http://host.docker.internal:9999/v1"
 
 def test_runner_uses_hermes_verify_start_early_out_and_passes_endpoint():
     runner = Runner(


### PR DESCRIPTION
## Summary
- add shared endpoint_is_loopback() detection for localhost, 127.x, [::1], and [::]
- auto-rewrite hermesagent-20 loopback endpoints to host.docker.internal without requiring BENCHLOCAL_HERMES_RESOLVE_LOCALHOST
- pass the runner endpoint into SandboxClient so Hermes loopback runs add host.docker.internal:host-gateway automatically
- preserve non-loopback Hermes behavior unless the existing env var is set

Fixes #49.

## Validation
- python3 -m py_compile benchlocal_cli/sandbox.py benchlocal_cli/runner.py
- .venv/bin/python -m pytest -q tests/test_sandbox_runner.py tests/test_aider_polyglot.py
- .venv/bin/python -m pytest -q

## Notes
No pack data changed; generator parity is not applicable.