### PR TITLE
Scale timeouts for thinking token budgets

### DIFF
--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -7,6 +7,7 @@ import json
 import os
 import signal
 import statistics
+import sys
 import time
 from collections.abc import Callable
 from contextlib import suppress
@@ -351,6 +352,7 @@ class Runner:
         self.timeout_scale_down = bool(timeout_scale_down)
         self._measured_decode_tps: float | None = self.measured_tps_override
         self._timeout_scaling_note: str | None = None
+        self._timeout_scaling_note_emitted = False
         self.enable_sandboxed_packs = enable_sandboxed_packs
         self.mock_responses = mock_responses or {}
         self.thinking_override = thinking_enabled
@@ -595,11 +597,42 @@ class Runner:
         if not self.timeout_scale_down:
             scale = max(1.0, scale)
         budget = base_seconds * scale
-        self._timeout_scaling_note = (
-            f"timeout scaling active: measured_decode_tps={measured_tps:.1f}, "
-            f"reference_tps={reference_tps:.1f}, scale={scale:.2f}"
-        )
+        note_parts = [
+            f"timeout scaling active: measured_decode_tps={measured_tps:.1f}",
+            f"reference_tps={reference_tps:.1f}",
+            f"scale={scale:.2f}",
+        ]
+        multiplier = self._thinking_timeout_multiplier(meta)
+        if multiplier > 1.0:
+            budget *= multiplier
+            nominal_max = self._nominal_thinking_max_tokens(meta)
+            note_parts.append(
+                f"thinking-budget-multiplier={self.thinking_max_tokens}/{nominal_max}={multiplier:.2f}"
+            )
+        self._timeout_scaling_note = ", ".join(note_parts)
+        self._emit_timeout_scaling_note_once()
         return budget
+
+    def _emit_timeout_scaling_note_once(self) -> None:
+        if self._timeout_scaling_note_emitted or not self._timeout_scaling_note:
+            return
+        print(f"[runner] {self._timeout_scaling_note}", file=sys.stderr, flush=True)
+        self._timeout_scaling_note_emitted = True
+
+    def _nominal_thinking_max_tokens(self, meta: dict) -> int:
+        sampling_defaults = meta.get("sampling_defaults") or {}
+        try:
+            return int(sampling_defaults.get("max_tokens") or 1024)
+        except (TypeError, ValueError):
+            return 1024
+
+    def _thinking_timeout_multiplier(self, meta: dict) -> float:
+        if not resolve_thinking_enabled(meta, self.thinking_override):
+            return 1.0
+        nominal_max = self._nominal_thinking_max_tokens(meta)
+        if nominal_max <= 0 or self.thinking_max_tokens <= nominal_max:
+            return 1.0
+        return float(self.thinking_max_tokens) / float(nominal_max)
 
     def _timeout_measured_tps(self) -> float | None:
         if self._measured_decode_tps is not None:
@@ -624,6 +657,7 @@ class Runner:
                 "temperature": 0,
                 "top_p": 1,
                 "max_tokens": 200,
+                "chat_template_kwargs": {"enable_thinking": False},
             }
             started = time.perf_counter()
             _status, response, _trace = self._post_chat(request, 120.0)

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -291,6 +291,93 @@ def test_runner_explicit_timeout_per_case_disables_dynamic_scaling(monkeypatch):
     assert runner._timeout_budget_for_meta({"timeout_per_case_default": 300, "timeout_reference_tps": 100}) == 45
 
 
+def test_probe_sends_enable_thinking_false(monkeypatch):
+    runner = Runner(endpoint="http://localhost:9999", model="fake")
+    requests = []
+
+    def fake_post_chat(request, timeout):
+        requests.append(request)
+        return 200, {"choices": [{"message": {"content": "ok"}}], "usage": {"completion_tokens": 100}}, None
+
+    monkeypatch.setattr(runner, "_post_chat", fake_post_chat)
+    monkeypatch.setattr("benchlocal_cli.runner.time.perf_counter", iter([0.0, 2.0, 2.0, 4.0, 4.0, 6.0]).__next__)
+
+    assert runner._probe_decode_tps() == 50.0
+    assert len(requests) == 3
+    assert all(req["chat_template_kwargs"] == {"enable_thinking": False} for req in requests)
+
+
+def test_scaled_budget_with_thinking_multiplier():
+    runner = Runner(
+        endpoint="http://localhost:9999",
+        model="fake",
+        measured_tps=24,
+        thinking_enabled=True,
+        thinking_max_tokens=16384,
+    )
+    meta = {
+        "timeout_per_case_default": 60,
+        "timeout_reference_tps": 100,
+        "sampling_defaults": {"max_tokens": 1024},
+        "default_thinking": "off",
+    }
+
+    budget = runner._timeout_budget_for_meta(meta)
+
+    assert budget == 60 * (100 / 24) * (16384 / 1024)
+    assert "measured_decode_tps=24.0" in runner._timeout_scaling_note
+    assert runner._timeout_scaling_note_emitted is True
+
+
+def test_timeout_scaling_note_emits_once_to_stderr(capsys):
+    runner = Runner(endpoint="http://localhost:9999", model="fake", measured_tps=50)
+    meta = {"timeout_per_case_default": 300, "timeout_reference_tps": 100}
+
+    assert runner._timeout_budget_for_meta(meta) == 600
+    assert runner._timeout_budget_for_meta(meta) == 600
+
+    captured = capsys.readouterr()
+    assert captured.err.count("[runner] timeout scaling active") == 1
+    assert "measured_decode_tps=50.0" in captured.err
+
+
+def test_scaled_budget_no_thinking_multiplier_when_thinking_off():
+    runner = Runner(
+        endpoint="http://localhost:9999",
+        model="fake",
+        measured_tps=24,
+        thinking_enabled=False,
+        thinking_max_tokens=16384,
+    )
+    meta = {
+        "timeout_per_case_default": 60,
+        "timeout_reference_tps": 100,
+        "sampling_defaults": {"max_tokens": 1024},
+        "default_thinking": "on",
+    }
+
+    assert runner._timeout_budget_for_meta(meta) == 60 * (100 / 24)
+    assert "thinking-budget-multiplier" not in runner._timeout_scaling_note
+
+
+def test_scaled_budget_no_multiplier_when_thinking_max_below_nominal():
+    runner = Runner(
+        endpoint="http://localhost:9999",
+        model="fake",
+        measured_tps=24,
+        thinking_enabled=True,
+        thinking_max_tokens=512,
+    )
+    meta = {
+        "timeout_per_case_default": 60,
+        "timeout_reference_tps": 100,
+        "sampling_defaults": {"max_tokens": 1024},
+        "default_thinking": "off",
+    }
+
+    assert runner._timeout_budget_for_meta(meta) == 60 * (100 / 24)
+    assert "thinking-budget-multiplier" not in runner._timeout_scaling_note
+
 def test_runner_uses_pack_timeout_default_when_cli_timeout_unset(monkeypatch):
     import benchlocal_cli.runner as runner_module
 


### PR DESCRIPTION
## Summary
- force the dynamic timeout TPS probe to send chat_template_kwargs.enable_thinking=false
- scale timeout budgets by the thinking max-token ratio when thinking is active and the thinking budget exceeds the pack's nominal max_tokens
- emit the timeout-scaling telemetry line to stderr once, while preserving the final warning text

Fixes #54.

## Validation
- python3 -m py_compile benchlocal_cli/runner.py
- .venv/bin/python -m pytest -q tests/test_sandbox_runner.py
- .venv/bin/python -m pytest -q