### PR TITLE
Stream Aider per-exercise progress

### DIFF
--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -267,6 +267,20 @@ def _pack_line(pack: PackResult) -> str:
     return f"{pack.pack_id} (v{pack.version}) | {pack.passed} / {pack.total} | {score} | {p50} | {status}"
 
 
+
+def _sandbox_progress_event(event: dict) -> None:
+    pack_id = event.get("pack_id") or "sandbox"
+    exercise_id = event.get("id") or "?"
+    index = event.get("index") or "?"
+    total = event.get("total") or "?"
+    passed = bool(event.get("passed"))
+    result_char = "✓" if passed else "✗"
+    duration = event.get("duration_s")
+    latency = f"{float(duration):.1f}s" if isinstance(duration, (int, float)) else "?"
+    mode = "pass" if passed else "fail"
+    print(f"  [{index}/{total}] {pack_id}/{exercise_id} {result_char} {mode} ({latency})", file=sys.stderr, flush=True)
+
+
 def _scenario_progress(run: ScenarioRun, index: int, total: int) -> None:
     """Print per-scenario progress line to stderr (#23)."""
     result_char = "✓" if run.result.passed else "✗"
@@ -585,9 +599,11 @@ def main(argv: list[str] | None = None) -> int:
         # Build progress callbacks (#23)
         on_pack_complete = None
         on_scenario_complete = None
+        on_progress_event = None
 
         if args.progress:
             on_scenario_complete = _scenario_progress
+            on_progress_event = _sandbox_progress_event
 
         # For incremental output, we need to track state for partial JSON saves
         incremental_state = {
@@ -673,6 +689,7 @@ def main(argv: list[str] | None = None) -> int:
             thinking_sampler=_load_thinking_sampler(args.thinking_sampler),
             on_pack_complete=on_pack_complete,
             on_scenario_complete=on_scenario_complete,
+            on_progress_event=on_progress_event,
         )
         result = runner.run(pack_ids, mode=mode, repeat=max(1, args.repeat))
 

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -343,6 +343,7 @@ class Runner:
         thinking_sampler: dict | None = None,
         on_pack_complete: Callable[[PackResult], None] | None = None,
         on_scenario_complete: Callable[[ScenarioRun, int, int], None] | None = None,
+        on_progress_event: Callable[[dict], None] | None = None,
     ) -> None:
         self.endpoint = endpoint
         self.model = model
@@ -380,6 +381,8 @@ class Runner:
         # Callbacks for incremental progress (#23)
         self._on_pack_complete = on_pack_complete
         self._on_scenario_complete = on_scenario_complete
+        self._on_progress_event = on_progress_event
+        self.aider_progress_poll_s = float(os.environ.get("BENCHLOCAL_AIDER_PROGRESS_POLL_S", "5"))
 
     def run(self, pack_ids: list[str], *, mode: str = "custom", repeat: int = 1) -> RunResult:
         started_at = _utc_now()
@@ -1000,6 +1003,61 @@ class Runner:
 
         raise AssertionError("unreachable transient retry loop exit")
 
+
+    def _verify_aider_start_with_progress(
+        self,
+        sandbox_client: SandboxClient,
+        scenario: dict,
+        start_kwargs: dict,
+    ) -> dict:
+        import threading
+
+        done = threading.Event()
+        holder: dict = {}
+
+        def _target() -> None:
+            try:
+                holder["payload"] = sandbox_client.verify_multiturn_start(scenario, **start_kwargs)
+            except BaseException as exc:  # noqa: BLE001
+                holder["exc"] = exc
+            finally:
+                done.set()
+
+        thread = threading.Thread(target=_target, daemon=True)
+        thread.start()
+        seen: set[str] = set()
+        while not done.wait(self.aider_progress_poll_s):
+            self._poll_aider_progress(sandbox_client, seen)
+        self._poll_aider_progress(sandbox_client, seen)
+        thread.join()
+        if "exc" in holder:
+            raise holder["exc"]
+        return holder.get("payload") or {}
+
+    def _poll_aider_progress(self, sandbox_client: SandboxClient, seen: set[str]) -> None:
+        if self._on_progress_event is None:
+            return
+        try:
+            payload = sandbox_client.verify_progress()
+        except Exception:  # noqa: BLE001
+            return
+        completed = payload.get("completed_exercises")
+        if not isinstance(completed, list):
+            return
+        total = int(payload.get("total_expected") or 0)
+        for item in completed:
+            if not isinstance(item, dict):
+                continue
+            exercise_id = str(item.get("id") or "")
+            if not exercise_id or exercise_id in seen:
+                continue
+            seen.add(exercise_id)
+            event = dict(item)
+            event.setdefault("pack_id", "aider-polyglot-30")
+            event["index"] = len(seen)
+            event["total"] = total
+            self._on_progress_event(event)
+
     @staticmethod
     def _inject_transient_trace(result: ScenarioResult, trace: dict | None) -> ScenarioResult:
         if not trace:
@@ -1092,7 +1150,10 @@ class Runner:
                     "model_api_key": "benchlocal-cli-aider-polyglot",  # non-empty placeholder
                     "sampling": dict(sampling),
                 }
-            start_payload = sandbox_client.verify_multiturn_start(scenario, **start_kwargs)
+            if pack_id == "aider-polyglot-30" and self._on_progress_event is not None:
+                start_payload = self._verify_aider_start_with_progress(sandbox_client, scenario, start_kwargs)
+            else:
+                start_payload = sandbox_client.verify_multiturn_start(scenario, **start_kwargs)
             if start_payload.get("action") == "verify-final":
                 latency = time.perf_counter() - started
                 # Preserve upstream forensics in the early-out path too —

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -382,7 +382,15 @@ class Runner:
         self._on_pack_complete = on_pack_complete
         self._on_scenario_complete = on_scenario_complete
         self._on_progress_event = on_progress_event
-        self.aider_progress_poll_s = float(os.environ.get("BENCHLOCAL_AIDER_PROGRESS_POLL_S", "5"))
+        self.aider_progress_poll_s = self._aider_progress_poll_interval()
+
+    @staticmethod
+    def _aider_progress_poll_interval() -> float:
+        try:
+            value = float(os.environ.get("BENCHLOCAL_AIDER_PROGRESS_POLL_S", "5"))
+        except (TypeError, ValueError):
+            return 5.0
+        return max(0.25, value)
 
     def run(self, pack_ids: list[str], *, mode: str = "custom", repeat: int = 1) -> RunResult:
         started_at = _utc_now()

--- a/benchlocal_cli/sandbox.py
+++ b/benchlocal_cli/sandbox.py
@@ -468,6 +468,11 @@ class SandboxClient:
         """Explicit 'model gave up' or turn-limit completion."""
         return self._post("/verify-end", {"scenario_state_id": scenario_state_id})
 
+    def verify_progress(self, scenario_state_id: str | None = None) -> dict:
+        """Fetch sandbox-specific live progress, if supported."""
+        payload = {} if scenario_state_id is None else {"scenario_state_id": scenario_state_id}
+        return self._post("/verify-progress", payload, timeout_s=5.0)
+
     # Back-compat aliases kept for existing Hermes tests/callers.
     def verify_hermes_start(self, scenario: dict) -> dict:
         return self.verify_multiturn_start(scenario)

--- a/sandboxes/aider-polyglot/server.py
+++ b/sandboxes/aider-polyglot/server.py
@@ -585,6 +585,8 @@ def _verify_start(req: dict) -> dict:
     job_id = str(uuid.uuid4())
     job_dir = Path("/tmp") / "aider-polyglot-runs" / job_id
     job_dir.mkdir(parents=True, exist_ok=True)
+    progress_active = False
+    progress_finalized = False
     try:
         _stage_exercises_workspace(job_dir)
 
@@ -678,6 +680,7 @@ def _verify_start(req: dict) -> dict:
             total_expected=CANONICAL_TOTAL,
             started_at=time.time(),
         )
+        progress_active = True
 
         # Spawn with process-group isolation (same hardening as v0.7.3 hermes)
         started = time.monotonic()
@@ -715,6 +718,7 @@ def _verify_start(req: dict) -> dict:
         per_exercise = _walk_per_exercise_results(run_dir)
         final_progress = _progress_items_from_run_dir(run_dir)
         _set_progress_state(active=False, run_dir=str(run_dir), completed_exercises=final_progress)
+        progress_finalized = True
 
         if timed_out:
             # Recover partial per-exercise data. Aider's benchmark.py writes
@@ -817,6 +821,8 @@ def _verify_start(req: dict) -> dict:
             },
         }
     finally:
+        if progress_active and not progress_finalized:
+            _set_progress_state(active=False)
         # Best-effort job dir cleanup. Hard-linked exercises so cheap to remove.
         # Set BENCHLOCAL_AIDER_KEEP_JOBDIRS=1 to retain for forensic inspection.
         if os.environ.get("BENCHLOCAL_AIDER_KEEP_JOBDIRS") != "1":

--- a/sandboxes/aider-polyglot/server.py
+++ b/sandboxes/aider-polyglot/server.py
@@ -23,11 +23,12 @@ import os
 import re
 import shutil
 import signal
+import threading
 import subprocess
 import sys
 import time
 import uuid
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 PORT = 9000
@@ -106,6 +107,53 @@ def _load_canonical_exercises() -> list[dict]:
 
 CANONICAL_EXERCISES = _load_canonical_exercises()
 CANONICAL_KEYS = sorted({(e["language"], e["name"]) for e in CANONICAL_EXERCISES})
+CANONICAL_TOTAL = len(CANONICAL_EXERCISES)
+
+_BATCH_PROGRESS_LOCK = threading.Lock()
+_BATCH_PROGRESS_STATE: dict = {
+    "active": False,
+    "completed_exercises": [],
+    "total_expected": CANONICAL_TOTAL,
+}
+
+
+def _progress_items_from_run_dir(run_dir: Path) -> list[dict]:
+    per_exercise = _walk_per_exercise_results(run_dir) if run_dir.exists() else {}
+    items = []
+    for key, summary in sorted(
+        _grade_aider_batch_result(per_exercise, DEFAULT_PASS_THRESHOLD)["per_exercise"].items()
+    ):
+        items.append({
+            "id": key,
+            "passed": bool(summary.get("passed")),
+            "duration_s": summary.get("duration"),
+            "tries": summary.get("tries"),
+            "prompt_tokens": summary.get("prompt_tokens"),
+            "completion_tokens": summary.get("completion_tokens"),
+        })
+    return items
+
+
+def _set_progress_state(**updates) -> None:
+    with _BATCH_PROGRESS_LOCK:
+        _BATCH_PROGRESS_STATE.update(updates)
+
+
+def _resolve_progress() -> dict:
+    with _BATCH_PROGRESS_LOCK:
+        state = dict(_BATCH_PROGRESS_STATE)
+    run_dir_value = state.get("run_dir")
+    if state.get("active") and run_dir_value:
+        run_dir = Path(str(run_dir_value))
+        completed = _progress_items_from_run_dir(run_dir)
+        state["completed_exercises"] = completed
+        state["completed_count"] = len(completed)
+    else:
+        completed = state.get("completed_exercises") or []
+        state["completed_count"] = len(completed) if isinstance(completed, list) else 0
+    state.setdefault("total_expected", CANONICAL_TOTAL)
+    return state
+
 
 
 def _resolve_exercise_dirs() -> tuple[list[Path], list[tuple[str, str]]]:
@@ -619,6 +667,18 @@ def _verify_start(req: dict) -> dict:
         # and writes results to <stage>/tmp.benchmarks/<run_name>/.
         env["AIDER_BENCHMARK_DIR"] = str(job_dir / "tmp.benchmarks")
 
+        tmp_benchmarks = job_dir / "tmp.benchmarks"
+        expected_run_dir = tmp_benchmarks / run_name
+        _set_progress_state(
+            active=True,
+            scenario_id=scenario_id,
+            run_name=run_name,
+            run_dir=str(expected_run_dir),
+            completed_exercises=[],
+            total_expected=CANONICAL_TOTAL,
+            started_at=time.time(),
+        )
+
         # Spawn with process-group isolation (same hardening as v0.7.3 hermes)
         started = time.monotonic()
         proc = subprocess.Popen(
@@ -653,6 +713,8 @@ def _verify_start(req: dict) -> dict:
         run_dir = run_dirs[-1] if run_dirs else tmp_benchmarks
 
         per_exercise = _walk_per_exercise_results(run_dir)
+        final_progress = _progress_items_from_run_dir(run_dir)
+        _set_progress_state(active=False, run_dir=str(run_dir), completed_exercises=final_progress)
 
         if timed_out:
             # Recover partial per-exercise data. Aider's benchmark.py writes
@@ -808,7 +870,7 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_POST(self) -> None:
-        if self.path not in ("/verify", "/verify-start", "/verify-turn", "/verify-end"):
+        if self.path not in ("/verify", "/verify-start", "/verify-turn", "/verify-end", "/verify-progress"):
             self.send_response(404)
             self.end_headers()
             return
@@ -823,6 +885,8 @@ class Handler(BaseHTTPRequestHandler):
         try:
             if self.path == "/verify-start":
                 result = _verify_start(req)
+            elif self.path == "/verify-progress":
+                result = _resolve_progress()
             else:
                 result = {
                     "action": "verify-final",
@@ -863,7 +927,7 @@ class Handler(BaseHTTPRequestHandler):
 
 
 def main() -> None:
-    server = HTTPServer(("0.0.0.0", PORT), Handler)
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
     sys.stderr.write(
         f"[aider-polyglot-sandbox] listening on :{PORT} "
         f"(stage=v0.9.0, aider={AIDER_PINNED_COMMIT[:12]}, polyglot={POLYGLOT_PINNED_COMMIT[:12]}, "

--- a/tests/test_aider_polyglot.py
+++ b/tests/test_aider_polyglot.py
@@ -343,6 +343,40 @@ def test_aider_progress_endpoint_returns_final_state_after_subprocess_exits(monk
     assert out["completed_count"] == 1
     assert out["completed_exercises"] == final
 
+def test_aider_progress_state_clears_active_when_verify_start_raises(monkeypatch):
+    server = _server()
+    monkeypatch.setattr(server, "_detect_aider_git_contract", lambda: {"ok": True, "head": "abc123"})
+    monkeypatch.setattr(server, "_detect_benchmark_cli_signature", lambda: {"ok": True})
+    monkeypatch.setattr(
+        server,
+        "_exercise_count_status",
+        lambda: {"canonical_count": 30, "resolved_count": 30, "missing": [], "exact_match": True},
+    )
+    monkeypatch.setattr(server, "_stage_exercises_workspace", lambda _job_dir: None)
+    monkeypatch.setattr(server, "_build_benchmark_args", lambda **_kwargs: ["python3", "benchmark.py", "run"])
+    monkeypatch.setattr(
+        server,
+        "_BATCH_PROGRESS_STATE",
+        {"active": False, "completed_exercises": [], "total_expected": 30},
+    )
+
+    def fail_popen(*_args, **_kwargs):
+        raise RuntimeError("boom after progress activation")
+
+    monkeypatch.setattr(server.subprocess, "Popen", fail_popen)
+
+    with pytest.raises(RuntimeError, match="boom after progress activation"):
+        server._verify_start(
+            {
+                "scenario_id": "aider-polyglot-30-batch",
+                "scenario": {"messages": []},
+                "model_endpoint": "http://host.docker.internal:8010/v1",
+                "model_name": "local-model",
+            }
+        )
+
+    assert server._BATCH_PROGRESS_STATE["active"] is False
+
 
 # ============================================================================
 # _qualify_aider_model — litellm provider routing

--- a/tests/test_aider_polyglot.py
+++ b/tests/test_aider_polyglot.py
@@ -295,6 +295,56 @@ def test_verify_start_runs_benchmark_from_aider_checkout(tmp_path, monkeypatch):
 
 
 # ============================================================================
+# /verify-progress — live single-scoreboard progress
+# ============================================================================
+
+
+def _write_aider_result(path, passed=True, duration=12.5):
+    path.mkdir(parents=True, exist_ok=True)
+    (path / ".aider.results.json").write_text(
+        '{"tests_outcomes":[%s],"duration":%s,"cost":0,"model_errors":0,"edit_format":"whole","commands":1}'
+        % ("true" if passed else "false", duration)
+    )
+
+
+def test_aider_progress_endpoint_returns_empty_before_first_exercise(tmp_path, monkeypatch):
+    server = _server()
+    monkeypatch.setattr(server, "_BATCH_PROGRESS_STATE", {"active": True, "run_dir": str(tmp_path / "run"), "completed_exercises": [], "total_expected": 30})
+
+    out = server._resolve_progress()
+
+    assert out["completed_count"] == 0
+    assert out["completed_exercises"] == []
+    assert out["total_expected"] == 30
+
+
+def test_aider_progress_endpoint_accumulates_completed_exercises(tmp_path, monkeypatch):
+    server = _server()
+    run_dir = tmp_path / "run"
+    _write_aider_result(run_dir / "python" / "exercises" / "practice" / "two-sum", passed=True, duration=10)
+    _write_aider_result(run_dir / "rust" / "exercises" / "practice" / "parser", passed=False, duration=20)
+    monkeypatch.setattr(server, "_BATCH_PROGRESS_STATE", {"active": True, "run_dir": str(run_dir), "completed_exercises": [], "total_expected": 30})
+
+    out = server._resolve_progress()
+
+    assert out["completed_count"] == 2
+    ids = {item["id"] for item in out["completed_exercises"]}
+    assert ids == {"python/two-sum", "rust/parser"}
+    assert any(item["passed"] is False for item in out["completed_exercises"])
+
+
+def test_aider_progress_endpoint_returns_final_state_after_subprocess_exits(monkeypatch):
+    server = _server()
+    final = [{"id": "python/two-sum", "passed": True, "duration_s": 10}]
+    monkeypatch.setattr(server, "_BATCH_PROGRESS_STATE", {"active": False, "completed_exercises": final, "total_expected": 30})
+
+    out = server._resolve_progress()
+
+    assert out["completed_count"] == 1
+    assert out["completed_exercises"] == final
+
+
+# ============================================================================
 # _qualify_aider_model — litellm provider routing
 # ============================================================================
 

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -408,6 +408,43 @@ def test_no_multiplier_when_thinking_max_below_nominal():
 
     assert runner._timeout_budget_for_meta(meta) == 60 * (100 / 24)
     assert "thinking-budget-multiplier" not in runner._timeout_scaling_note
+class FakeAiderProgressSandbox:
+    def __init__(self) -> None:
+        self.progress_calls = 0
+
+    def verify_multiturn_start(self, scenario: dict, **kwargs) -> dict:
+        import time
+
+        time.sleep(0.03)
+        return {"action": "verify-final", "passed": True, "failure_mode": "passed", "detail": "done"}
+
+    def verify_progress(self, scenario_state_id=None) -> dict:
+        self.progress_calls += 1
+        completed = []
+        if self.progress_calls >= 1:
+            completed.append({"id": "python/two-sum", "passed": True, "duration_s": 10})
+        if self.progress_calls >= 2:
+            completed.append({"id": "rust/parser", "passed": False, "duration_s": 20})
+        return {"total_expected": 30, "completed_exercises": completed}
+
+
+def test_runner_polls_progress_for_aider_during_verify_start():
+    events = []
+    runner = Runner(endpoint="http://localhost:9999", model="fake", on_progress_event=events.append)
+    runner.aider_progress_poll_s = 0.01
+    sandbox = FakeAiderProgressSandbox()
+
+    out = runner._verify_aider_start_with_progress(
+        sandbox,
+        {"id": "aider-polyglot-30-batch", "pack_id": "aider-polyglot-30"},
+        {},
+    )
+
+    assert out["passed"] is True
+    assert [event["id"] for event in events] == ["python/two-sum", "rust/parser"]
+    assert events[0]["index"] == 1
+    assert events[1]["index"] == 2
+    assert all(event["total"] == 30 for event in events)
 
 
 def test_runner_uses_pack_timeout_default_when_cli_timeout_unset(monkeypatch):

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -446,6 +446,19 @@ def test_runner_polls_progress_for_aider_during_verify_start():
     assert events[1]["index"] == 2
     assert all(event["total"] == 30 for event in events)
 
+def test_runner_clamps_aider_progress_poll_interval(monkeypatch):
+    monkeypatch.setenv("BENCHLOCAL_AIDER_PROGRESS_POLL_S", "0")
+    assert Runner(endpoint="http://localhost:9999", model="fake").aider_progress_poll_s == 0.25
+
+    monkeypatch.setenv("BENCHLOCAL_AIDER_PROGRESS_POLL_S", "-10")
+    assert Runner(endpoint="http://localhost:9999", model="fake").aider_progress_poll_s == 0.25
+
+    monkeypatch.setenv("BENCHLOCAL_AIDER_PROGRESS_POLL_S", "garbage")
+    assert Runner(endpoint="http://localhost:9999", model="fake").aider_progress_poll_s == 5.0
+
+    monkeypatch.setenv("BENCHLOCAL_AIDER_PROGRESS_POLL_S", "1.5")
+    assert Runner(endpoint="http://localhost:9999", model="fake").aider_progress_poll_s == 1.5
+
 
 def test_runner_uses_pack_timeout_default_when_cli_timeout_unset(monkeypatch):
     import benchlocal_cli.runner as runner_module


### PR DESCRIPTION
Fixes #33.

## Summary
- add a sandbox progress endpoint/client method for long-running Aider batches
- stream completed aider-polyglot-30 exercises to `--progress` while `/verify-start` is still running
- switch the Aider sandbox to `ThreadingHTTPServer` so `/verify-progress` can respond during batch execution
- derive progress from Aider `.aider.results.json` outputs instead of scraping stdout, keeping final scoring and live progress on the same source of truth

## Validation
- `python3 -m py_compile benchlocal_cli/runner.py benchlocal_cli/cli.py benchlocal_cli/sandbox.py sandboxes/aider-polyglot/server.py`
- `.venv/bin/python -m pytest -q tests/test_aider_polyglot.py tests/test_sandbox_runner.py` → 89 passed
- `.venv/bin/python -m pytest -q` → 211 passed

## Notes
- `--incremental` per-exercise JSON persistence remains out of scope for this PR; this only adds live stderr progress for completed exercises.