### PR TITLE
Fail fast on timeouts + unreachable-endpoint probe in _post_chat (#58)

### DIFF
--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -134,6 +134,16 @@ def _parser() -> argparse.ArgumentParser:
         ),
     )
     run.add_argument(
+        "--retry-on-timeout",
+        action="store_true",
+        default=_env_bool("BENCHLOCAL_RETRY_ON_TIMEOUT", False),
+        help=(
+            "retry per-request timeouts as transient failures (default: off; a timeout "
+            "means the budget was genuinely exceeded, so retrying just burns another full "
+            "budget — env BENCHLOCAL_RETRY_ON_TIMEOUT)"
+        ),
+    )
+    run.add_argument(
         "--sandbox-log-dir",
         help=(
             "capture sandbox container stdout/stderr to <dir>/sandbox-<pack-id>.log "
@@ -458,6 +468,13 @@ def _env_int(name: str, default: int) -> int:
         raise ValueError(f"{name} must be an integer") from exc
 
 
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _pack_ids_include_sandboxed(pack_ids: list[str]) -> bool:
     for pack_id in pack_ids:
         try:
@@ -668,6 +685,7 @@ def main(argv: list[str] | None = None) -> int:
                 sandboxed_enabled=sandboxed_enabled,
             ),
             max_transient_retries=args.max_transient_retries,
+            retry_on_timeout=args.retry_on_timeout,
             sampling_overrides=sampling_overrides or None,
             sampling_from_server=args.sampling_from_server,
             thinking_sampler=_load_thinking_sampler(args.thinking_sampler),

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -338,6 +338,7 @@ class Runner:
         sandbox_image_tag: str = "latest",
         sandbox_log_dir: str | None = None,
         max_transient_retries: int = 3,
+        retry_on_timeout: bool = False,
         sampling_overrides: dict | None = None,
         sampling_from_server: bool = False,
         thinking_sampler: dict | None = None,
@@ -366,6 +367,11 @@ class Runner:
         # See SandboxClient.stop(log_dir=...) for the snapshot.
         self.sandbox_log_dir = sandbox_log_dir
         self.max_transient_retries = max(0, int(max_transient_retries))
+        # A timeout means the per-request budget was genuinely exceeded; retrying
+        # just burns another full budget for the same outcome (#58). Default to
+        # failing fast on the first timeout. Connection errors / HTTP 5xx are
+        # genuinely transient and keep retrying regardless of this flag.
+        self.retry_on_timeout = bool(retry_on_timeout)
         # CLI-level sampling overrides (--temperature, --top-p, etc.).
         # When set, the run is tagged as non-canonical in the output.
         self.sampling_overrides = sampling_overrides or {}
@@ -678,7 +684,37 @@ class Runner:
             return None
         return self._measured_decode_tps
 
+    def _endpoint_reachable(self, timeout: float = 5.0) -> bool:
+        """Cheap host-side reachability check before the TPS probe.
+
+        A blackholed endpoint (silently drops packets) would otherwise make the
+        probe's `_post_chat` calls block for their full read timeout. Probe a
+        lightweight `GET .../v1/models` (falling back to `.../models`) with a
+        short timeout and NO transient retry; if nothing answers, the caller
+        skips the decode probe and falls back to static pack budgets.
+        """
+        base = self.endpoint.rstrip("/")
+        if base.endswith("/v1"):
+            base = base[: -len("/v1")]
+        for suffix in ("/v1/models", "/models"):
+            url = f"{base}{suffix}"
+            try:
+                with httpx.Client(timeout=timeout) as client:
+                    response = client.get(url)
+            except httpx.HTTPError:
+                continue
+            # Any HTTP response (even 4xx/5xx) means the host is reachable and
+            # answering; only transport-level failures count as unreachable.
+            if response.status_code < 500:
+                return True
+        return False
+
     def _probe_decode_tps(self) -> float | None:
+        if not self._endpoint_reachable():
+            self._timeout_scaling_note = (
+                "endpoint unreachable on preflight; skipping TPS probe, using static pack budgets"
+            )
+            return None
         samples: list[float] = []
         prompt = (
             "Write a concise local-inference benchmark note of about 200 tokens. "
@@ -697,7 +733,12 @@ class Runner:
                 "chat_template_kwargs": {"enable_thinking": False},
             }
             started = time.perf_counter()
-            _status, response, _trace = self._post_chat(request, 120.0)
+            # The probe must never be the thing that hangs a run: bounded read
+            # budget and NO transient retry (max_attempts=1). Combined with the
+            # preflight above and the #58 no-retry-on-timeout fix, a dead or
+            # blackholed endpoint costs at most one short timeout per sample
+            # instead of 3 x (retry loop x 120s).
+            _status, response, _trace = self._post_chat(request, 30.0, max_attempts=1)
             elapsed = max(time.perf_counter() - started, 1e-6)
             tokens = self._completion_tokens(response)
             if tokens is None:
@@ -962,9 +1003,16 @@ class Runner:
             return 20
         return 15
 
-    def _post_chat(self, request: dict, timeout: float) -> tuple[int, dict, dict | None]:
+    def _post_chat(
+        self, request: dict, timeout: float, *, max_attempts: int | None = None
+    ) -> tuple[int, dict, dict | None]:
         transient_errors: list[str] = []
-        max_attempts = self.max_transient_retries + 1
+        # `max_attempts` lets callers (e.g. the startup TPS probe) opt out of the
+        # transient-retry loop so they can never hang a run on a dead endpoint.
+        if max_attempts is None:
+            max_attempts = self.max_transient_retries + 1
+        else:
+            max_attempts = max(1, int(max_attempts))
 
         for attempt in range(1, max_attempts + 1):
             try:
@@ -972,7 +1020,10 @@ class Runner:
                     response = client.post(_chat_url(self.endpoint), json=request)
             except httpx.TimeoutException as exc:
                 transient_errors.append(f"attempt {attempt}: {type(exc).__name__}: {exc}")
-                if attempt >= max_attempts:
+                # A timeout means the budget was genuinely exceeded — retrying just
+                # burns another full budget for the same outcome (#58). Fail fast
+                # unless explicitly configured to retry timeouts.
+                if attempt >= max_attempts or not self.retry_on_timeout:
                     trace = _transient_trace(transient_errors, attempt) or {}
                     raise _TransientPostFailure("timeout", f"timed out after {timeout}s", trace) from exc
                 self._sleep_before_transient_retry(attempt)

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -295,10 +295,11 @@ def test_probe_sends_enable_thinking_false(monkeypatch):
     runner = Runner(endpoint="http://localhost:9999", model="fake")
     requests = []
 
-    def fake_post_chat(request, timeout):
+    def fake_post_chat(request, timeout, *, max_attempts=None):
         requests.append(request)
         return 200, {"choices": [{"message": {"content": "ok"}}], "usage": {"completion_tokens": 100}}, None
 
+    monkeypatch.setattr(runner, "_endpoint_reachable", lambda *a, **k: True)
     monkeypatch.setattr(runner, "_post_chat", fake_post_chat)
     monkeypatch.setattr(
         "benchlocal_cli.runner.time.perf_counter",

--- a/tests/test_transient_retries.py
+++ b/tests/test_transient_retries.py
@@ -167,11 +167,38 @@ def test_single_turn_exhausted_remote_protocol_error_fails_with_trace(monkeypatc
     assert len(run.result.verifier_trace["transient_errors"]) == 2
 
 
-def test_single_turn_retries_timeout_then_passes(monkeypatch):
+def test_single_turn_does_not_retry_timeout_by_default(monkeypatch):
+    # #58: a timeout means the budget was genuinely exceeded; retrying just burns
+    # another full budget for the same outcome. Fail fast after the FIRST timeout.
     import benchlocal_cli.runner as runner_module
 
     _install_sequence_client(monkeypatch, runner_module, [httpx.ReadTimeout("slow read"), (200, _ok_payload())])
-    runner = Runner(endpoint="http://localhost:9999", model="fake", enable_sandboxed_packs=True, max_transient_retries=1)
+    runner = Runner(endpoint="http://localhost:9999", model="fake", enable_sandboxed_packs=True, max_transient_retries=3)
+    runner._sandbox_clients["bugfind-15"] = FakeSandbox()
+
+    run = runner.run_scenario(_sandbox_meta(), _single_scenario())
+
+    assert run.result.passed is False
+    assert run.result.failure_mode == "timeout"
+    # Exactly one attempt — the (200, ...) follow-up event is never consumed.
+    assert SequenceHTTPClient.calls == 1
+    assert run.result.verifier_trace is not None
+    assert run.result.verifier_trace["transient_retries"] == 0
+    assert "ReadTimeout" in run.result.verifier_trace["transient_errors"][0]
+
+
+def test_single_turn_retries_timeout_when_opted_in(monkeypatch):
+    # Opt-in regression guard: --retry-on-timeout restores the old behavior.
+    import benchlocal_cli.runner as runner_module
+
+    _install_sequence_client(monkeypatch, runner_module, [httpx.ReadTimeout("slow read"), (200, _ok_payload())])
+    runner = Runner(
+        endpoint="http://localhost:9999",
+        model="fake",
+        enable_sandboxed_packs=True,
+        max_transient_retries=1,
+        retry_on_timeout=True,
+    )
     runner._sandbox_clients["bugfind-15"] = FakeSandbox()
 
     run = runner.run_scenario(_sandbox_meta(), _single_scenario())
@@ -231,3 +258,116 @@ def test_multiturn_retries_transient_post_and_preserves_trace(monkeypatch):
     assert run.result.verifier_trace["trace"] == {"turn_count": 1}
     assert run.result.verifier_trace["transient_retries"] == 1
     assert "RemoteProtocolError" in run.result.verifier_trace["transient_errors"][0]
+
+
+class ProbeHTTPClient:
+    """Counts GET (preflight) and POST (decode probe) calls for probe tests."""
+
+    get_calls = 0
+    post_calls = 0
+    get_behavior: object = None  # exception to raise, or status code to return
+    post_payload: dict | None = None
+
+    def __init__(self, timeout: float) -> None:
+        self.timeout = timeout
+
+    def __enter__(self) -> ProbeHTTPClient:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def get(self, url: str) -> FakeHTTPResponse:
+        cls = type(self)
+        cls.get_calls += 1
+        behavior = cls.get_behavior
+        if isinstance(behavior, BaseException):
+            raise behavior
+        return FakeHTTPResponse({}, status_code=int(behavior or 200))
+
+    def post(self, url: str, json: dict) -> FakeHTTPResponse:
+        cls = type(self)
+        cls.post_calls += 1
+        return FakeHTTPResponse(cls.post_payload or {}, status_code=200)
+
+
+def _install_probe_client(monkeypatch, *, get_behavior, post_payload=None) -> None:
+    import benchlocal_cli.runner as runner_module
+
+    ProbeHTTPClient.get_calls = 0
+    ProbeHTTPClient.post_calls = 0
+    ProbeHTTPClient.get_behavior = get_behavior
+    ProbeHTTPClient.post_payload = post_payload
+    monkeypatch.setattr(runner_module.httpx, "Client", ProbeHTTPClient)
+    monkeypatch.setattr(runner_module.time, "sleep", lambda delay: None)
+
+
+def test_probe_fails_fast_when_endpoint_unreachable(monkeypatch):
+    # A blackholed/unreachable endpoint must NOT trigger 3 samples x retry-loop of
+    # _post_chat. The preflight catches it and the probe returns None immediately.
+    _install_probe_client(monkeypatch, get_behavior=httpx.ConnectError("blackholed"))
+    runner = Runner(endpoint="http://localhost:9999", model="fake", max_transient_retries=3)
+
+    measured = runner._probe_decode_tps()
+
+    assert measured is None
+    # Preflight tried /v1/models and /models, then bailed — no probe POSTs at all.
+    assert ProbeHTTPClient.get_calls == 2
+    assert ProbeHTTPClient.post_calls == 0
+
+
+def test_probe_measures_tps_when_endpoint_reachable(monkeypatch):
+    # Regression guard: a reachable endpoint still measures TPS normally.
+    _install_probe_client(
+        monkeypatch,
+        get_behavior=200,
+        post_payload={
+            "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+            "usage": {"completion_tokens": 200},
+        },
+    )
+    runner = Runner(endpoint="http://localhost:9999/v1", model="fake", max_transient_retries=3)
+
+    measured = runner._probe_decode_tps()
+
+    assert measured is not None
+    assert measured > 0
+    # Preflight answered on the first probe (/v1/models), then 3 decode samples.
+    assert ProbeHTTPClient.get_calls == 1
+    assert ProbeHTTPClient.post_calls == 3
+
+
+def test_probe_post_does_not_retry_on_dead_endpoint(monkeypatch):
+    # Even if the preflight is somehow satisfied but the chat POST then stalls,
+    # the probe's _post_chat(max_attempts=1) must not loop through retries.
+    import benchlocal_cli.runner as runner_module
+
+    state = {"get_calls": 0, "post_calls": 0}
+
+    class StallAfterPreflightClient:
+        def __init__(self, timeout: float) -> None:
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+        def get(self, url: str) -> FakeHTTPResponse:
+            state["get_calls"] += 1
+            return FakeHTTPResponse({}, status_code=200)
+
+        def post(self, url: str, json: dict):
+            state["post_calls"] += 1
+            raise httpx.ReadTimeout("stalled")
+
+    monkeypatch.setattr(runner_module.httpx, "Client", StallAfterPreflightClient)
+    monkeypatch.setattr(runner_module.time, "sleep", lambda delay: None)
+    runner = Runner(endpoint="http://localhost:9999", model="fake", max_transient_retries=3)
+
+    measured = runner._timeout_measured_tps()
+
+    assert measured is None
+    # Exactly one POST attempt despite max_transient_retries=3 (max_attempts=1).
+    assert state["post_calls"] == 1


### PR DESCRIPTION
## Summary

Two related fail-fast fixes in `runner.py`'s request path, both addressing multi-minute host-side stalls against a dead / blackholed endpoint.

### Fix 1 — don't retry timeouts as transient (#58)
`_post_chat` treated `httpx.TimeoutException` as transient and retried it `max_transient_retries` times with exponential backoff. A timeout means the per-request *budget was genuinely exceeded* — retrying just burns another full budget for the same outcome (the `4 × 60s + backoff = 247s` amplification noted in #58).

- On `httpx.TimeoutException`, fail fast after the **first** timeout.
- `ConnectError` / `RemoteProtocolError` / HTTP 5xx keep their existing retry behavior unchanged.
- Old behavior is available behind a new `--retry-on-timeout` flag (env `BENCHLOCAL_RETRY_ON_TIMEOUT`), defaulting **off** — per the issue's suggested clean gate.

### Fix 2 — host-probe fail-fast on unreachable endpoint (review High finding)
`_probe_decode_tps()` sent 3 samples via `_post_chat(..., 120.0)`. On a blackholed endpoint each call could burn `4 attempts × 120s + backoff`, × 3 samples → a multi-minute stall that also pre-empted the sandbox-side reachability error path.

- Added a cheap reachability preflight: `GET {endpoint}/v1/models` (fallback `/models`) with a 5s timeout and **no** retry. If unreachable, skip the probe and fall back to static budgets (the existing `measured_tps=None` path).
- The probe's own `_post_chat` call now uses a bounded 30s budget and `max_attempts=1` so it can never hang a run, even if the preflight is satisfied but the chat POST then stalls.
- Reachable-endpoint behavior is unchanged — the probe runs normally and returns measured TPS.

## Tests
- `_post_chat` does **not** retry on `TimeoutException` by default (exactly 1 attempt; surfaces immediately).
- `--retry-on-timeout` opt-in restores retry behavior (guard).
- Regression guards: still retries `ConnectError` and HTTP 5xx.
- Probe fails fast (no 12× hammering, no stall) when the endpoint is unreachable; probe still measures TPS when reachable; probe POST does not retry on a stalled endpoint.
- Updated the existing thinking-off probe test for the new preflight.

`python -m pytest -q` → **218 passed**. No net-new ruff errors introduced.

> Note: the maintainer will live-validate the actual fail-fast wall-time behavior on the rig (dead / blackholed endpoint).

Closes #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
