### PR TITLE
feat(cloud): Bearer auth (--api-key) + spend guard (--max-total-tokens) for cloud endpoints

### DIFF
--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -40,7 +40,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from benchlocal_cli import __version__
-from benchlocal_cli.runner import PACK_MODES, SANDBOX_MODES, Runner, _utc_now, list_packs, load_pack
+from benchlocal_cli.runner import PACK_MODES, SANDBOX_MODES, Runner, _SpendGuardExceeded, _utc_now, list_packs, load_pack
 from benchlocal_cli.types import PackResult, RunResult, ScenarioRun
 
 
@@ -211,6 +211,26 @@ def _parser() -> argparse.ArgumentParser:
         ),
     )
     run.add_argument("--extra-body", help="JSON object merged into each chat-completions request body")
+    # Cloud endpoints (OpenRouter / DashScope / DeepInfra / …): Bearer auth + a spend guard.
+    run.add_argument(
+        "--api-key",
+        default=os.environ.get("BENCHLOCAL_API_KEY") or os.environ.get("OPENAI_API_KEY") or None,
+        help=(
+            "Bearer token for cloud OpenAI-compatible endpoints; sent as "
+            "'Authorization: Bearer <key>' on every request + probe. "
+            "Default: $BENCHLOCAL_API_KEY or $OPENAI_API_KEY. Local vLLM/llama.cpp need none. "
+            "Pin a provider/quant with e.g. --extra-body '{\"provider\":{\"only\":[\"DeepInfra\"],\"allow_fallbacks\":false}}'."
+        ),
+    )
+    run.add_argument(
+        "--max-total-tokens",
+        type=int,
+        default=_env_int("BENCHLOCAL_MAX_TOTAL_TOKENS", 0) or None,
+        help=(
+            "cloud spend guard: stop the run once cumulative reported usage tokens exceed N "
+            "(default: unlimited; env BENCHLOCAL_MAX_TOTAL_TOKENS)"
+        ),
+    )
     run.add_argument("--mock-responses-from-json", help="JSON object mapping scenario id to OpenAI response (testing only)")
     # v0.8 — diagnostic tooling
     run.add_argument(
@@ -693,6 +713,8 @@ def main(argv: list[str] | None = None) -> int:
             thinking_enabled=args.thinking_override,
             thinking_max_tokens=effective_thinking_max,
             extra_body=_load_extra_body(args.extra_body),
+            api_key=args.api_key,
+            max_total_tokens=args.max_total_tokens,
             sandbox_image_tag=args.sandbox_image_tag,
             sandbox_log_dir=_resolve_sandbox_log_dir(
                 requested=args.sandbox_log_dir,
@@ -709,7 +731,16 @@ def main(argv: list[str] | None = None) -> int:
             on_scenario_complete=on_scenario_complete,
             on_progress_event=on_progress_event,
         )
-        result = runner.run(pack_ids, mode=mode, repeat=max(1, args.repeat))
+        try:
+            result = runner.run(pack_ids, mode=mode, repeat=max(1, args.repeat))
+        except _SpendGuardExceeded as exc:
+            print(f"\n[spend-guard] {exc}", file=sys.stderr)
+            print(
+                f"[spend-guard] run stopped after {exc.tokens_used} tokens (cap {exc.cap}); "
+                "completed packs preserved only if --incremental + --save-json were set.",
+                file=sys.stderr,
+            )
+            return 2
 
         # v0.8: --previous-result delta classification
         if args.previous_result:

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -22,6 +22,23 @@ from benchlocal_cli.sandbox import SandboxClient, config_for_pack
 from benchlocal_cli.scoring.common import content_with_source, sanitize_response_text_fields
 from benchlocal_cli.types import PackResult, RunResult, ScenarioResult, ScenarioRun
 
+
+class _SpendGuardExceeded(BaseException):
+    """Cumulative token budget (`--max-total-tokens`) exceeded mid-run.
+
+    Subclasses BaseException (like KeyboardInterrupt) so the per-scenario
+    `except Exception` paths don't swallow it — it must propagate up to the
+    top-level run() caller, which stops the run and reports partial results.
+    """
+
+    def __init__(self, tokens_used: int, cap: int) -> None:
+        self.tokens_used = tokens_used
+        self.cap = cap
+        super().__init__(
+            f"spend guard: cumulative {tokens_used} tokens exceeded --max-total-tokens={cap}"
+        )
+
+
 PACK_MODES = {
     # quick — 30 scenarios, no Docker, ~5-10 min
     "quick": ["toolcall-15", "instructfollow-15"],
@@ -335,6 +352,8 @@ class Runner:
         thinking_enabled: bool | None = None,
         thinking_max_tokens: int = 16384,
         extra_body: dict | None = None,
+        api_key: str | None = None,
+        max_total_tokens: int | None = None,
         sandbox_image_tag: str = "latest",
         sandbox_log_dir: str | None = None,
         max_transient_retries: int = 3,
@@ -362,6 +381,14 @@ class Runner:
         self.thinking_mode = thinking_mode_from_override(thinking_enabled)
         self.thinking_max_tokens = thinking_max_tokens
         self.extra_body = extra_body or {}
+        self.api_key = api_key
+        # Bearer auth for cloud OpenAI-compatible endpoints (OpenRouter, DashScope, …);
+        # empty for local vLLM / llama.cpp, which need no auth. Applied to every
+        # model call + the reachability/props probes.
+        self._request_headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+        # Cumulative token spend guard (cloud-cost safety). None = unlimited.
+        self.max_total_tokens = max_total_tokens
+        self.tokens_used = 0
         self.sandbox_image_tag = sandbox_image_tag
         # If set, sandbox container stderr/stdout is captured to
         # `<sandbox_log_dir>/sandbox-<pack_id>.log` before container teardown.
@@ -488,7 +515,7 @@ class Runner:
         props_url = f"{base}/props"
         try:
             with httpx.Client(timeout=5.0) as client:
-                resp = client.get(props_url)
+                resp = client.get(props_url, headers=self._request_headers)
             if resp.status_code == 200:
                 body = resp.json()
                 params = (body.get("default_generation_settings") or {}).get("params") or {}
@@ -711,7 +738,7 @@ class Runner:
             url = f"{base}{suffix}"
             try:
                 with httpx.Client(timeout=timeout) as client:
-                    response = client.get(url)
+                    response = client.get(url, headers=self._request_headers)
             except httpx.HTTPError:
                 continue
             # Any HTTP response (even 4xx/5xx) means the host is reachable and
@@ -1028,7 +1055,7 @@ class Runner:
         for attempt in range(1, max_attempts + 1):
             try:
                 with httpx.Client(timeout=timeout) as client:
-                    response = client.post(_chat_url(self.endpoint), json=request)
+                    response = client.post(_chat_url(self.endpoint), json=request, headers=self._request_headers)
             except httpx.TimeoutException as exc:
                 transient_errors.append(f"attempt {attempt}: {type(exc).__name__}: {exc}")
                 # A timeout means the budget was genuinely exceeded — retrying just
@@ -1057,6 +1084,13 @@ class Runner:
                 if attempt < max_attempts:
                     self._sleep_before_transient_retry(attempt)
                     continue
+
+            # Spend guard: accumulate reported usage (cloud-cost safety). Trips on
+            # the cumulative cap mid-run; _SpendGuardExceeded propagates past the
+            # per-scenario except-Exception handlers to the top-level run() caller.
+            self.tokens_used += int((raw_response.get("usage") or {}).get("total_tokens") or 0)
+            if self.max_total_tokens is not None and self.tokens_used > self.max_total_tokens:
+                raise _SpendGuardExceeded(self.tokens_used, self.max_total_tokens)
 
             return response.status_code, raw_response, _transient_trace(transient_errors, attempt)
 

--- a/tests/test_cloud_auth.py
+++ b/tests/test_cloud_auth.py
@@ -1,0 +1,113 @@
+"""Cloud-endpoint Bearer auth (--api-key) + cumulative spend guard (--max-total-tokens).
+
+Local vLLM/llama.cpp endpoints need no auth (header stays empty); cloud
+OpenAI-compatible providers (OpenRouter, DashScope, …) require
+`Authorization: Bearer <key>`. The spend guard trips on cumulative usage so a
+cloud run can't silently overspend.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import benchlocal_cli.runner as runner_module
+from benchlocal_cli.runner import Runner, _SpendGuardExceeded
+
+
+class _Resp:
+    def __init__(self, payload: dict, status: int = 200) -> None:
+        self._p = payload
+        self.status_code = status
+        self.text = ""
+
+    def json(self) -> dict:
+        return self._p
+
+
+def _ok(tokens: int) -> _Resp:
+    return _Resp(
+        {"choices": [{"message": {"role": "assistant", "content": "ok"}}],
+         "usage": {"total_tokens": tokens}}
+    )
+
+
+def test_api_key_builds_bearer_header():
+    r = Runner(endpoint="https://openrouter.ai/api/v1", model="m", api_key="sk-abc")
+    assert r._request_headers == {"Authorization": "Bearer sk-abc"}
+
+
+def test_no_api_key_means_no_auth_header():
+    r = Runner(endpoint="http://localhost:8010", model="m")
+    assert r._request_headers == {}
+
+
+def test_auth_header_is_sent_on_chat_post(monkeypatch):
+    seen: dict = {}
+
+    class _Client:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+        def post(self, url, json, **kwargs):
+            seen["headers"] = kwargs.get("headers")
+            return _ok(5)
+
+    monkeypatch.setattr(runner_module.httpx, "Client", _Client)
+    r = Runner(endpoint="https://cloud/v1", model="m", api_key="sk-xyz")
+    status, _body, _trace = r._post_chat({"messages": []}, 10.0)
+
+    assert status == 200
+    assert seen["headers"] == {"Authorization": "Bearer sk-xyz"}
+
+
+def test_spend_guard_trips_over_cumulative_cap(monkeypatch):
+    class _Client:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+        def post(self, url, json, **kwargs):
+            return _ok(60)
+
+    monkeypatch.setattr(runner_module.httpx, "Client", _Client)
+    r = Runner(endpoint="https://cloud/v1", model="m", max_total_tokens=100)
+
+    # First call: 60 tokens, under the 100 cap → returns normally.
+    r._post_chat({"messages": []}, 10.0)
+    assert r.tokens_used == 60
+
+    # Second call: cumulative 120 > 100 → guard trips.
+    with pytest.raises(_SpendGuardExceeded):
+        r._post_chat({"messages": []}, 10.0)
+
+
+def test_no_spend_guard_when_cap_unset(monkeypatch):
+    class _Client:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return None
+
+        def post(self, url, json, **kwargs):
+            return _ok(10_000)
+
+    monkeypatch.setattr(runner_module.httpx, "Client", _Client)
+    r = Runner(endpoint="http://localhost:8010", model="m")  # max_total_tokens=None
+    for _ in range(3):
+        r._post_chat({"messages": []}, 10.0)
+    assert r.tokens_used == 30_000  # accumulates, never trips

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -159,7 +159,7 @@ class FakeHTTPClient:
     def __exit__(self, exc_type, exc, tb) -> None:
         return None
 
-    def post(self, url: str, json: dict) -> FakeHTTPResponse:
+    def post(self, url: str, json: dict, **_kwargs) -> FakeHTTPResponse:
         FakeHTTPClient.calls += 1
         if FakeHTTPClient.calls == 1:
             return FakeHTTPResponse(
@@ -540,7 +540,7 @@ class FakeAlwaysToolHTTPClient:
     def __exit__(self, exc_type, exc, tb) -> None:
         return None
 
-    def post(self, url: str, json: dict) -> FakeHTTPResponse:
+    def post(self, url: str, json: dict, **_kwargs) -> FakeHTTPResponse:
         return FakeHTTPResponse(
             {
                 "choices": [
@@ -573,7 +573,7 @@ class FakeTimeoutHTTPClient:
     def __exit__(self, exc_type, exc, tb) -> None:
         return None
 
-    def post(self, url: str, json: dict) -> FakeHTTPResponse:
+    def post(self, url: str, json: dict, **_kwargs) -> FakeHTTPResponse:
         import benchlocal_cli.runner as runner_module
 
         raise runner_module.httpx.TimeoutException("read timed out")

--- a/tests/test_transient_retries.py
+++ b/tests/test_transient_retries.py
@@ -29,7 +29,7 @@ class SequenceHTTPClient:
     def __exit__(self, exc_type, exc, tb) -> None:
         return None
 
-    def post(self, url: str, json: dict) -> FakeHTTPResponse:
+    def post(self, url: str, json: dict, **_kwargs) -> FakeHTTPResponse:
         cls = type(self)
         event = cls.events[cls.calls]
         cls.calls += 1
@@ -277,7 +277,7 @@ class ProbeHTTPClient:
     def __exit__(self, exc_type, exc, tb) -> None:
         return None
 
-    def get(self, url: str) -> FakeHTTPResponse:
+    def get(self, url: str, **_kwargs) -> FakeHTTPResponse:
         cls = type(self)
         cls.get_calls += 1
         behavior = cls.get_behavior
@@ -285,7 +285,7 @@ class ProbeHTTPClient:
             raise behavior
         return FakeHTTPResponse({}, status_code=int(behavior or 200))
 
-    def post(self, url: str, json: dict) -> FakeHTTPResponse:
+    def post(self, url: str, json: dict, **_kwargs) -> FakeHTTPResponse:
         cls = type(self)
         cls.post_calls += 1
         return FakeHTTPResponse(cls.post_payload or {}, status_code=200)
@@ -354,11 +354,11 @@ def test_probe_post_does_not_retry_on_dead_endpoint(monkeypatch):
         def __exit__(self, exc_type, exc, tb):
             return None
 
-        def get(self, url: str) -> FakeHTTPResponse:
+        def get(self, url: str, **_kwargs) -> FakeHTTPResponse:
             state["get_calls"] += 1
             return FakeHTTPResponse({}, status_code=200)
 
-        def post(self, url: str, json: dict):
+        def post(self, url: str, json: dict, **_kwargs):
             state["post_calls"] += 1
             raise httpx.ReadTimeout("stalled")
 


### PR DESCRIPTION
## What

Lets `benchlocal-cli run` target **cloud OpenAI-compatible providers** (OpenRouter, DashScope, DeepInfra, …), not just local vLLM/llama.cpp. The endpoint targeting, `/v1` normalization, transient-retry, and provider/quant pinning (via `--extra-body`) were already there — the missing piece was **request auth**, plus a spend safety-net.

## Changes
- **`--api-key`** (default `$BENCHLOCAL_API_KEY` → `$OPENAI_API_KEY`) → sends `Authorization: Bearer <key>` on every chat POST + the reachability/`/props` probes. Empty when unset, so local endpoints are unchanged.
- **`--max-total-tokens`** (env `$BENCHLOCAL_MAX_TOTAL_TOKENS`) → cumulative usage-token spend guard. Trips `_SpendGuardExceeded` — which subclasses `BaseException` (like `KeyboardInterrupt`) so the per-scenario `except Exception` paths can't swallow it; it propagates to the top-level `run()` caller, which stops and reports (completed packs preserved with `--incremental --save-json`).
- Test doubles (`SequenceHTTPClient` / fake httpx clients) updated to accept the new `headers` kwarg.

## Usage
```bash
# Q8-vs-fp8 precision compare: pin a provider/quant on OpenRouter
benchlocal-cli run --medium \
  --endpoint https://openrouter.ai/api/v1 --model qwen/qwen3.6-27b \
  --api-key "$OPENROUTER_API_KEY" \
  --extra-body '{"provider":{"only":["DeepInfra"],"allow_fallbacks":false}}' \
  --max-total-tokens 2000000
```

## Scope
Deterministic packs only (host-side, no sandbox egress). Running the **agent packs** (hermesagent-20/cli-40/bugfind-15) over a cloud endpoint needs container egress + key-injection — deliberately **out of scope** here.

## Validation
- 236 tests pass (5 new in `tests/test_cloud_auth.py`: header build + header actually sent + spend-guard trip + no-trip-when-unset).
- **Live vs OpenRouter**: HTTP 200 with the key + `provider` pin honored (DeepInfra), usage tracked; **401 without the key** (negative control). 🤖 Generated with [Claude Code](https://claude.com/claude-code)
