### PR TITLE
feat(grader-fidelity): token_limit failure_mode (#61) + --negative-control probe (#62 tier-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,22 @@ benchlocal-cli inspect results.json --diff previous.json     # side-by-side vs a
 benchlocal-cli inspect results.json --logs ./sandbox-logs    # pull sandboxed-pack stdout/stderr
 ```
 
-`failure_mode` is one of `verifier_fail`, `timeout`, `agent_runner_timeout`, `agent_runner_crashed`, `server_error`, `http_error`, `model_endpoint_unreachable`, `result_json_malformed`, `wrong_answer`, `verifier_not_implemented`.
+`failure_mode` is one of `verifier_fail`, `token_limit`, `timeout`, `agent_runner_timeout`, `agent_runner_crashed`, `server_error`, `http_error`, `model_endpoint_unreachable`, `result_json_malformed`, `wrong_answer`, `verifier_not_implemented`.
+
+`token_limit` (#61) means the completion hit the token cap (`finish_reason == "length"`) and was truncated mid-output — the model overthought or looped until the budget ran out, *not* a content verdict. It's reclassified from the underlying content-failure (the original verdict is kept in `detail`), so "looped / truncated" reads distinctly from "ran to completion but wrong" (`verifier_fail`). Filter it with `inspect --mode token_limit`.
+
+## Negative control (grader false-positive probe)
+
+We catch verifiers that are too *strict* by hand (the false-negative audit). `--negative-control` (#62) catches the opposite — verifiers too *lenient* to be measuring anything:
+
+```bash
+# feed deterministic junk to every scenario instead of calling a model;
+# any PASS = a verifier that accepted junk it should reject. No endpoint/GPU needed.
+benchlocal-cli run --negative-control --medium
+benchlocal-cli run --negative-control --negative-control-text "" --pack instructfollow-15   # pure-empty control
+```
+
+`--endpoint`/`--model` are not required in this mode. The junk defaults to `(no answer)`; override with `--negative-control-text` (an empty string is the purest control, while a constant non-answer additionally surfaces *format-only* verifiers that pass anything shaped right). Any PASS is printed as a candidate false-positive to review — it bounds, from the lenient side, how much a pack's score can be trusted.
 
 ## Attribution
 

--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -86,8 +86,27 @@ def _parser() -> argparse.ArgumentParser:
     mode.add_argument("--full", action="store_true", help="8 packs incl. sandboxed, ~25-40 min, requires Docker")
     mode.add_argument("--reasoning", action="store_true", help="reasoning packs: HE+, LCB v6, GPQA metadata, GSM-Symbolic; separate from --full")
     run.add_argument("--pack", help="run a single named pack (overrides --quick/--medium/--full)")
-    run.add_argument("--endpoint", required=True, help="OpenAI-compatible base URL (e.g. http://localhost:8010)")
-    run.add_argument("--model", required=True, help="model id served by the endpoint")
+    # endpoint/model are required for normal runs; relaxed to optional so the
+    # #62 negative-control probe (which never calls a model) can run without them.
+    # Enforced in cmd_run when --negative-control is absent.
+    run.add_argument("--endpoint", help="OpenAI-compatible base URL (e.g. http://localhost:8010)")
+    run.add_argument("--model", help="model id served by the endpoint")
+    # #62 tier-1: grader false-positive probe. Feeds a deterministic junk response
+    # to every scenario instead of calling the endpoint; any PASS flags a verifier
+    # that's under-checking (it accepted junk it should reject). No GPU/endpoint
+    # needed — reuses the mock path. Pairs with the false-negative audit (#35/36/37).
+    run.add_argument(
+        "--negative-control",
+        action="store_true",
+        help="grader false-positive probe: feed junk to every scenario (no endpoint call); "
+             "any PASS = candidate too-lenient verifier (#62). Endpoint/model not required.",
+    )
+    run.add_argument(
+        "--negative-control-text",
+        default="(no answer)",
+        help="junk content fed to every scenario under --negative-control "
+             "(default: '(no answer)'; pass an empty string for the pure-empty control).",
+    )
     run.add_argument("--timeout-per-case", type=float, default=None, help="per-scenario HTTP timeout override (default: pack metadata, usually 60s; agentic packs may use larger budgets)")
     run.add_argument("--measured-tps", type=float, default=None, help="served model decode TPS override for dynamic timeout scaling; skips the startup probe")
     run.add_argument("--reference-tps", type=float, default=None, help="override pack timeout_reference_tps metadata for dynamic timeout scaling")
@@ -484,6 +503,37 @@ def _load_mock(path: str | None) -> dict[str, dict] | None:
     return data
 
 
+def _print_negative_control_report(result, junk_text: str) -> None:
+    """#62 tier-1: under --negative-control every scenario was fed junk, so the
+    normal scoreboard semantics invert — any PASS means a verifier accepted junk
+    it should have rejected (candidate false-positive). Print those PASSes."""
+    suspicious: list[str] = []
+    total = 0
+    for pack in result.packs:
+        for sc in pack.scenarios:
+            if sc.result.failure_mode == "verifier_not_implemented":
+                continue
+            total += 1
+            if sc.result.passed:
+                suspicious.append(f"{pack.pack_id} {sc.id} ({sc.result.failure_mode})")
+    shown = repr(junk_text) if junk_text else "'' (empty string)"
+    print("", file=sys.stderr)
+    print(f"=== NEGATIVE CONTROL (junk input: {shown}) ===", file=sys.stderr)
+    print(
+        "Any PASS = candidate false-positive verifier (it accepted junk it should reject).",
+        file=sys.stderr,
+    )
+    if suspicious:
+        print(f"⚠ {len(suspicious)}/{total} scenario(s) PASSed the junk control — review:", file=sys.stderr)
+        for s in suspicious:
+            print(f"  - {s}", file=sys.stderr)
+    else:
+        print(
+            f"✓ 0/{total} PASSed — all exercised verifiers correctly rejected the junk.",
+            file=sys.stderr,
+        )
+
+
 def _load_extra_body(value: str | None) -> dict | None:
     if not value:
         return None
@@ -578,6 +628,18 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "history":
             from benchlocal_cli.history import history_main
             return history_main(args)
+
+        # #62: endpoint/model are optional only under --negative-control (no model call).
+        if args.negative_control:
+            args.endpoint = args.endpoint or "negative-control"
+            args.model = args.model or "negative-control"
+        elif not args.endpoint or not args.model:
+            print(
+                "benchlocal-cli: run requires --endpoint and --model "
+                "(omit them only with --negative-control)",
+                file=sys.stderr,
+            )
+            return 1
 
         mode = _mode_from_args(args)
         if args.sandboxed_only:
@@ -730,6 +792,7 @@ def main(argv: list[str] | None = None) -> int:
             timeout_scale_down=args.timeout_scale_down,
             enable_sandboxed_packs=sandboxed_enabled,
             mock_responses=_load_mock(args.mock_responses_from_json),
+            negative_control=args.negative_control_text if args.negative_control else None,
             thinking_enabled=args.thinking_override,
             thinking_max_tokens=effective_thinking_max,
             extra_body=_load_extra_body(args.extra_body),
@@ -798,6 +861,9 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(result_dict, indent=2, sort_keys=True))
         else:
             print(_markdown(result))
+
+        if args.negative_control:
+            _print_negative_control_report(result, args.negative_control_text)
 
         if args.exit_on_regression and result.delta and result.delta.get("total_regressions", 0) > 0:
             return 3  # CI-friendly regression exit code

--- a/benchlocal_cli/inspect.py
+++ b/benchlocal_cli/inspect.py
@@ -433,7 +433,7 @@ def add_inspect_subparser(subparsers) -> None:
     parser.add_argument("--failed", action="store_true", help="show only failed scenarios")
     parser.add_argument(
         "--mode",
-        help="show only scenarios with this failure_mode (e.g. timeout, verifier_fail, agent_runner_timeout)",
+        help="show only scenarios with this failure_mode (e.g. timeout, verifier_fail, token_limit, agent_runner_timeout)",
     )
     parser.add_argument(
         "--full",

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -80,6 +80,23 @@ SANDBOX_MODES = {"full", "reasoning"}
 SANDBOXED_PACK_IDS = ["bugfind-15", "hermesagent-20", "cli-40", "humaneval-plus-30", "lcb-v6-30"]
 DEFAULT_TIMEOUT_PER_CASE = 60.0
 
+# #61: content-verdict failure modes that a token-cap truncation should override.
+# A failure on any of these *while* finish_reason == "length" is confounded by
+# truncation — the model was cut off mid-output — so it's reclassified to
+# `token_limit`. Excludes passes (a verified-correct answer that happened to hit
+# the cap is still correct) and infra/transport modes (timeout / http_error /
+# server_error / verifier_not_implemented), which have no normal finish_reason.
+_CONTENT_FAILURE_MODES = frozenset({
+    "verifier_fail",
+    "wrong_answer",
+    "invalid_json",
+    "no_answer_found",
+    "missing_field",
+    "extra_fields",
+    "schema_violation",
+    "wrong_structure",
+})
+
 
 def pack_default_thinking(meta: dict) -> bool:
     """Return the pack-declared default thinking mode. Missing means off."""
@@ -252,6 +269,19 @@ def build_chat_request(
     return request
 
 
+def _negative_control_response(text: str) -> dict:
+    """#62 tier-1: a synthetic OpenAI completion carrying deliberate junk content,
+    fed to every scenario in negative-control mode. Shaped like a real response
+    (choices[0].message.content + finish_reason) so it flows through the normal
+    scoring path; any verifier that PASSes this is under-checking."""
+    return {
+        "choices": [
+            {"message": {"role": "assistant", "content": text}, "finish_reason": "stop"}
+        ],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    }
+
+
 def _chat_url(endpoint: str) -> str:
     """Normalize an endpoint URL to the OpenAI chat-completions path.
 
@@ -349,6 +379,7 @@ class Runner:
         timeout_scale_down: bool = False,
         enable_sandboxed_packs: bool = False,
         mock_responses: dict[str, dict] | None = None,
+        negative_control: str | None = None,
         thinking_enabled: bool | None = None,
         thinking_max_tokens: int = 16384,
         extra_body: dict | None = None,
@@ -377,6 +408,9 @@ class Runner:
         self._timeout_scaling_note_emitted = False
         self.enable_sandboxed_packs = enable_sandboxed_packs
         self.mock_responses = mock_responses or {}
+        # #62 tier-1: when set, every scenario is served this junk text instead of
+        # calling the endpoint — a negative control for verifier false-positives.
+        self.negative_control = negative_control
         self.thinking_override = thinking_enabled
         self.thinking_enabled = bool(thinking_enabled)
         self.thinking_mode = thinking_mode_from_override(thinking_enabled)
@@ -719,6 +753,10 @@ class Runner:
         return float(self.thinking_max_tokens) / float(nominal_max)
 
     def _timeout_measured_tps(self) -> float | None:
+        # #62: negative-control never calls the endpoint — skip the decode probe
+        # entirely (no endpoint to probe) and use static pack budgets.
+        if self.negative_control is not None:
+            return None
         if self._measured_decode_tps is not None:
             return self._measured_decode_tps
         try:
@@ -950,6 +988,7 @@ class Runner:
             and getattr(getattr(sandbox_client, "config", None), "multi_turn", False)
             and self._should_use_multiturn(scenario)
             and scenario["id"] not in self.mock_responses
+            and self.negative_control is None
         ):
             return self._run_multiturn_scenario(
                 meta,
@@ -961,7 +1000,10 @@ class Runner:
                 timeout,
             )
 
-        if scenario["id"] in self.mock_responses:
+        if self.negative_control is not None:
+            raw_response = _negative_control_response(self.negative_control)
+            latency = 0.0
+        elif scenario["id"] in self.mock_responses:
             raw_response = self.mock_responses[scenario["id"]]
             latency = 0.0
         else:
@@ -1012,6 +1054,7 @@ class Runner:
         if isinstance(usage, dict) and isinstance(usage.get("completion_tokens"), int):
             tokens = usage["completion_tokens"]
         result = replace(result, latency_seconds=latency, tokens_completion=tokens)
+        result = self._reclassify_if_truncated(result, raw_response)  # #61
         result = self._inject_transient_trace(result, transient_trace)
         if sandboxed_path:
             result = self._inject_sandbox_log_file(result, scenario.get("pack_id"))
@@ -1024,6 +1067,32 @@ class Runner:
             result,
             repeat_index,
             response_field_used=response_field_used,
+        )
+
+    @staticmethod
+    def _reclassify_if_truncated(result: ScenarioResult, raw_response: dict | None) -> ScenarioResult:
+        """#61: a failed completion that hit the token cap (finish_reason == "length")
+        is a truncation, not a content verdict. Reclassify it to `token_limit` so
+        "overthought / looped until the budget ran out" is legible at a glance vs
+        "ran to completion but produced a wrong answer". Only content-failure modes
+        are overridden; passes and infra failures are left untouched. The original
+        verdict is preserved in `detail` for forensics."""
+        if result.passed or result.failure_mode not in _CONTENT_FAILURE_MODES:
+            return result
+        if not isinstance(raw_response, dict):
+            return result
+        choices = raw_response.get("choices")
+        if not (isinstance(choices, list) and choices and isinstance(choices[0], dict)):
+            return result
+        if choices[0].get("finish_reason") != "length":
+            return result
+        return replace(
+            result,
+            failure_mode="token_limit",
+            detail=(
+                f"output truncated at token limit (finish_reason=length); "
+                f"underlying verdict was {result.failure_mode}: {result.detail}"
+            ),
         )
 
     @staticmethod

--- a/benchlocal_cli/types.py
+++ b/benchlocal_cli/types.py
@@ -15,6 +15,10 @@ FailureMode = Literal[
     "extra_fields",
     "schema_violation",
     "wrong_structure",
+    # #61: completion hit the token cap (finish_reason == "length") and was
+    # truncated mid-output — distinct from a content verdict so "overthought /
+    # looped" is legible vs "ran to completion but wrong" (verifier_fail).
+    "token_limit",
     "timeout",
     "agent_loop_exhausted",
     "http_error",

--- a/tests/test_grader_fidelity.py
+++ b/tests/test_grader_fidelity.py
@@ -1,0 +1,83 @@
+"""#61 token_limit reclassification + #62 tier-1 negative-control (grader fidelity)."""
+
+from __future__ import annotations
+
+from benchlocal_cli.runner import Runner, _negative_control_response
+from benchlocal_cli.types import ScenarioResult
+
+
+def _resp(finish_reason: str) -> dict:
+    return {"choices": [{"message": {"content": "x"}, "finish_reason": finish_reason}]}
+
+
+# ---------------------------------------------------------------------------
+# #61 — finish_reason == "length" reclassifies a content-failure to token_limit
+# ---------------------------------------------------------------------------
+
+def test_truncated_content_failure_becomes_token_limit():
+    r = Runner._reclassify_if_truncated(
+        ScenarioResult("a", False, "verifier_fail", "wrong"), _resp("length")
+    )
+    assert r.failure_mode == "token_limit"
+    assert "finish_reason=length" in r.detail
+    assert "verifier_fail" in r.detail  # original verdict preserved for forensics
+
+
+def test_all_content_modes_reclassified_at_length():
+    for mode in (
+        "verifier_fail", "wrong_answer", "invalid_json", "no_answer_found",
+        "missing_field", "extra_fields", "schema_violation", "wrong_structure",
+    ):
+        r = Runner._reclassify_if_truncated(ScenarioResult("a", False, mode, "x"), _resp("length"))
+        assert r.failure_mode == "token_limit", mode
+
+
+def test_non_length_finish_reason_unchanged():
+    r = Runner._reclassify_if_truncated(
+        ScenarioResult("a", False, "verifier_fail", "wrong"), _resp("stop")
+    )
+    assert r.failure_mode == "verifier_fail"
+
+
+def test_pass_never_reclassified_even_at_length():
+    r = Runner._reclassify_if_truncated(ScenarioResult("a", True, "passed", "ok"), _resp("length"))
+    assert r.passed and r.failure_mode == "passed"
+
+
+def test_infra_failures_not_reclassified():
+    for mode in ("server_error", "http_error", "timeout", "verifier_not_implemented"):
+        r = Runner._reclassify_if_truncated(ScenarioResult("a", False, mode, "x"), _resp("length"))
+        assert r.failure_mode == mode, mode
+
+
+def test_missing_choices_unchanged():
+    r = Runner._reclassify_if_truncated(
+        ScenarioResult("a", False, "wrong_answer", "x"), {"usage": {}}
+    )
+    assert r.failure_mode == "wrong_answer"
+
+
+# ---------------------------------------------------------------------------
+# #62 tier-1 — negative-control junk-mock
+# ---------------------------------------------------------------------------
+
+def test_negative_control_response_shape():
+    resp = _negative_control_response("(no answer)")
+    assert resp["choices"][0]["message"]["content"] == "(no answer)"
+    assert resp["choices"][0]["finish_reason"] == "stop"
+    assert resp["usage"]["completion_tokens"] == 0
+
+
+def test_negative_control_run_is_offline_and_junk_fails_toolcall():
+    # The endpoint is intentionally bogus: if negative-control ever touched the
+    # network this would error/hang. Instead every scenario is served junk
+    # locally, so the run completes and junk (no tool_calls) fails toolcall-15.
+    runner = Runner(
+        endpoint="http://negative-control.invalid",
+        model="x",
+        negative_control="(no answer)",
+    )
+    result = runner.run(["toolcall-15"])
+    pack = next(p for p in result.packs if p.pack_id == "toolcall-15")
+    assert pack.total == 15
+    assert pack.passed == 0  # junk has no tool_calls → no false-positives on this pack


### PR DESCRIPTION
Grader-fidelity batch — closes #61 and #62 (tier-1). Both harden the thing every quality score flows through, and they're complementary: together they bound how much a pack's score can be trusted from both sides.

## #61 — `token_limit` failure_mode

A completion that overthinks or loops until `max_tokens` (`finish_reason == "length"`) was indistinguishable from a genuinely wrong answer — both bucketed as `verifier_fail`. Now a failed content-verdict with `finish_reason == "length"` is reclassified to a distinct **`token_limit`** mode.

- Only **content-failure** modes are overridden (verifier_fail / wrong_answer / invalid_json / no_answer_found / missing_field / extra_fields / schema_violation / wrong_structure). **Passes** (a correct answer that happened to hit the cap is still correct) and **infra** modes (timeout / http_error / server_error / verifier_not_implemented) are left untouched.
- The original verdict is preserved in `detail` for forensics.
- Surfaces in the end-of-run `Failure breakdown:`, saved JSON, and `inspect --mode token_limit`.
- Scoped to the **non-agentic completion path** (the agentic packs already separate `agent_runner_timeout`).

## #62 tier-1 — `--negative-control` junk-mock

We catch over-*strict* verifiers by hand (the #35/#36/#37 false-negative audit). This catches over-*lenient* ones: feed deterministic junk to every scenario instead of calling a model — **any PASS = a verifier that accepted junk it should reject**.

```bash
benchlocal-cli run --negative-control --medium                 # default junk "(no answer)"
benchlocal-cli run --negative-control --negative-control-text "" --pack instructfollow-15   # pure-empty
```

- Reuses the existing mock path — **no endpoint/GPU needed**; `--endpoint`/`--model` are optional in this mode (the decode-TPS probe is skipped).
- `--negative-control-text` overrides the junk (default `(no answer)`; empty string = purest control; a constant non-answer also surfaces *format-only* verifiers).
- Prints a dedicated NEGATIVE CONTROL report listing any PASS as a candidate false-positive.

**It already earned its keep:** on the first run with the default junk, **7/30 scenarios PASSed** (format-only `instructfollow-15` verifiers that accept a 2-word non-answer) — real candidates to review.

Tier-2 (a known-bad / tiny *model* run, vs junk-mock) is left as the documented follow-up in #62.

## Tests
`tests/test_grader_fidelity.py` — 8 cases (the #61 reclassification matrix + the #62 junk shape + an offline negative-control integration run). Full suite **250 passed** (was 242), no regressions.

Downstream note: the club-3090 `quality-test.sh` wrapper forwards run args unchanged, so `--negative-control` is usable through it without changes.
