### PR TITLE
feat(cli): rename --reasoning → --reasoning-packs (+ deprecated alias) (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ CLI for running LLM behavioral evaluation packs against any OpenAI-compatible en
 
 - **BenchLocal** ports — tool-call · instruction-follow · structured output · numeric reasoning · data extraction · debug · multi-tool agent · CLI exec (8 packs from [stevibe/BenchLocal](https://github.com/stevibe/BenchLocal), MIT-licensed).
 - **Eval-expansion track** — additional packs vendored from upstream open-source benches. v0.9 ships `aider-polyglot-30` (multi-language code editing via [Aider-AI/aider](https://github.com/Aider-AI/aider)'s `benchmark.py`).
-- **Reasoning suite** — opt-in `--reasoning` packs for code reasoning, symbolic math, and gated science QA: HumanEval+, LiveCodeBench v6, GSM-Symbolic, and GPQA-Diamond metadata.
+- **Reasoning suite** — opt-in `--reasoning-packs` packs for code reasoning, symbolic math, and gated science QA: HumanEval+, LiveCodeBench v6, GSM-Symbolic, and GPQA-Diamond metadata.
 
 Companion to [club-3090](https://github.com/noonghunna/club-3090) — primarily intended for measuring quality on quantized models served by club-3090's compose stack, but works against any OpenAI-compatible API.
 
@@ -14,7 +14,7 @@ We needed a headless, scriptable quality gate for compose-release validation on 
 
 - Hits any OpenAI-compatible HTTP endpoint
 - Runs BenchLocal's 8 deterministic-verifier packs + agentic eval packs (currently 1: `aider-polyglot-30`) + the opt-in reasoning suite
-- Supports `--quick` / `--medium` / `--full` budget modes for the BenchLocal packs (~30-45 min for `--full`) plus a separate `--reasoning` mode; agentic packs can also run independently via `--pack <name>`
+- Supports `--quick` / `--medium` / `--full` budget modes for the BenchLocal packs (~30-45 min for `--full`) plus a separate `--reasoning-packs` mode; agentic packs can also run independently via `--pack <name>`
 - Outputs paste-ready markdown for benchmark tables + JSON for machine consumption
 - Keeps quantized-model quality measurement light enough to run as a CI gate
 
@@ -31,10 +31,12 @@ We needed a headless, scriptable quality gate for compose-release validation on 
 | `--quick` | ToolCall-15 + InstructFollow-15 | ~10-15 min | Per-commit gate; pre-push smoke |
 | `--medium` (default) | + StructOutput-15 + DataExtract-15 | ~25-30 min | Pre-release; pin bumps; new compose authoring |
 | `--full` | + ReasonMath-15 + (BugFind / HermesAgent / CLI when sandboxed) | ~45-60 min | Cross-rig comparison; quality A/B vs another quant |
-| `--reasoning` | HumanEval+-30 + LiveCodeBench-v6-30 + GPQA-Diamond (gated) + GSM-Symbolic-30 | ~30-90+ min; code packs need Docker | Dedicated reasoning/code suite; structured-CoT / no-think / thinking A/B |
-| `--pack aider-polyglot-30` | aider-polyglot-30 (independent — not bundled in `--quick`/`--medium`/`--full`/`--reasoning`) | ~15-25 min | Agentic code-editing signal; cross-model quality A/B for IDE-agent / coding workloads |
+| `--reasoning-packs` | HumanEval+-30 + LiveCodeBench-v6-30 + GPQA-Diamond (gated) + GSM-Symbolic-30 | ~30-90+ min; code packs need Docker | Dedicated reasoning/code suite; structured-CoT / no-think / thinking A/B |
+| `--pack aider-polyglot-30` | aider-polyglot-30 (independent — not bundled in `--quick`/`--medium`/`--full`/`--reasoning-packs`) | ~15-25 min | Agentic code-editing signal; cross-model quality A/B for IDE-agent / coding workloads |
 
-Pack selection in each mode follows Codex design-review feedback (2026-05-09) — ToolCall + InstructFollow are the primary signals for IDE-agent regressions; StructOutput catches grammar/JSON drift; ReasonMath defers to `--full` because it leans toward generic benchmark behavior rather than agent-stack-specific. `--reasoning` stays separate from `--full` because it changes the question from general behavior to code/math/science reasoning under larger thinking budgets. AiderPolyglot-30 is run independently because its harness is a batch runner with multi-turn edit/test loops — different shape from the per-scenario BenchLocal packs.
+Pack selection in each mode follows Codex design-review feedback (2026-05-09) — ToolCall + InstructFollow are the primary signals for IDE-agent regressions; StructOutput catches grammar/JSON drift; ReasonMath defers to `--full` because it leans toward generic benchmark behavior rather than agent-stack-specific. `--reasoning-packs` stays separate from `--full` because it changes the question from general behavior to code/math/science reasoning under larger thinking budgets. AiderPolyglot-30 is run independently because its harness is a batch runner with multi-turn edit/test loops — different shape from the per-scenario BenchLocal packs.
+
+> **Two orthogonal axes.** A mode flag picks **which packs** run (`--quick` / `--medium` / `--full` / `--reasoning-packs`); `--enable-thinking` / `--no-thinking` pick **the thinking mode** (orthogonal to the pack-set). For a clean *with-vs-without-reasoning* A/B on the standard suite, vary the mode on a fixed pack-set: `--full --no-thinking` vs `--full --enable-thinking`. `--reasoning-packs` was previously named `--reasoning` (it read like a mode but is a pack-set); the old flag still works as a hidden, deprecated alias that prints a warning.
 
 ## Sampling
 
@@ -202,7 +204,7 @@ benchlocal-cli run --quick --endpoint http://localhost:8020 --model qwen3.6-27b-
 
 ## Reasoning models
 
-`benchlocal-cli` uses each pack's `default_thinking` metadata by default. Reasoning-rewarding packs such as `reasonmath-15`, `bugfind-15`, `instructfollow-15`, `hermesagent-20`, and every `--reasoning` pack run with `chat_template_kwargs.enable_thinking=true`; execution/format packs such as `toolcall-15`, `structoutput-15`, `dataextract-15`, and `cli-40` run answer-only. Use `--enable-thinking` to force thinking on for every pack, or `--no-thinking` to force it off for every pack. Whenever thinking is enabled for a pack, request `max_tokens` is raised to `--thinking-max-tokens` (default `16384`) and the request uses the recommended thinking sampler (`temperature=1.0`, `top_p=0.95`, `top_k=20`, `min_p=0.0`) instead of the deterministic pack's greedy sampler. Override it with `--thinking-sampler '{"temperature":0.7,"top_p":0.9}'`, override individual sampling keys with `--temperature`/`--top-p`/`--top-k`/`--min-p`, or use `--sampling-from-server` to omit sampler params entirely. HumanEval+ and LiveCodeBench also carry 16K scenario budgets so thinking-on code runs do not measure a 4K truncation failure; hardest LCB items may still exceed 16K, so compare against `--no-thinking` for budget-runaway diagnostics. Use `--extra-body` to pass any other OpenAI-compatible server extension fields. Saved JSON records `thinking_enabled` per pack plus the run-level `thinking_mode`.
+`benchlocal-cli` uses each pack's `default_thinking` metadata by default. Reasoning-rewarding packs such as `reasonmath-15`, `bugfind-15`, `instructfollow-15`, `hermesagent-20`, and every `--reasoning-packs` pack run with `chat_template_kwargs.enable_thinking=true`; execution/format packs such as `toolcall-15`, `structoutput-15`, `dataextract-15`, and `cli-40` run answer-only. Use `--enable-thinking` to force thinking on for every pack, or `--no-thinking` to force it off for every pack. Whenever thinking is enabled for a pack, request `max_tokens` is raised to `--thinking-max-tokens` (default `16384`) and the request uses the recommended thinking sampler (`temperature=1.0`, `top_p=0.95`, `top_k=20`, `min_p=0.0`) instead of the deterministic pack's greedy sampler. Override it with `--thinking-sampler '{"temperature":0.7,"top_p":0.9}'`, override individual sampling keys with `--temperature`/`--top-p`/`--top-k`/`--min-p`, or use `--sampling-from-server` to omit sampler params entirely. HumanEval+ and LiveCodeBench also carry 16K scenario budgets so thinking-on code runs do not measure a 4K truncation failure; hardest LCB items may still exceed 16K, so compare against `--no-thinking` for budget-runaway diagnostics. Use `--extra-body` to pass any other OpenAI-compatible server extension fields. Saved JSON records `thinking_enabled` per pack plus the run-level `thinking_mode`.
 
 ## Output
 

--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -53,14 +53,20 @@ def _parser() -> argparse.ArgumentParser:
             "OpenAI-compatible endpoint."
         ),
         epilog=(
-            "Modes:\n"
-            "  --quick    2 packs, 30 scenarios, no Docker        (~5-10 min)\n"
-            "  --medium   5 packs, 75 scenarios, no Docker        (~15-25 min)\n"
-            "  --full     8 packs, 150 scenarios, requires Docker (~25-40 min)\n"
+            "Pack-set (pick WHAT runs):\n"
+            "  --quick           2 packs, 30 scenarios, no Docker        (~5-10 min)\n"
+            "  --medium          5 packs, 75 scenarios, no Docker        (~15-25 min)\n"
+            "  --full            8 packs, 150 scenarios, requires Docker (~25-40 min)\n"
+            "  --reasoning-packs HE+, LCB v6, GPQA, GSM-Symbolic         (separate suite, ~30-90+ min)\n"
+            "\n"
+            "Thinking mode (orthogonal — pick HOW it runs):\n"
+            "  --enable-thinking / --no-thinking   force thinking on/off for every pack\n"
+            "  (default: each pack's own default_thinking)\n"
             "\n"
             "Examples:\n"
             "  benchlocal-cli run --quick --endpoint http://localhost:8010 --model qwen3.6-27b\n"
-            "  benchlocal-cli run --full  --endpoint http://localhost:8010 --model qwen3.6-27b\n"
+            "  benchlocal-cli run --full --no-thinking     --endpoint … --model …   # 8-pack, reasoning OFF\n"
+            "  benchlocal-cli run --full --enable-thinking --endpoint … --model …   # 8-pack, reasoning ON\n"
             "  benchlocal-cli run --pack toolcall-15 --endpoint http://localhost:8010 --model qwen3.6-27b\n"
             "  benchlocal-cli list         # show all available packs\n"
         ),
@@ -84,7 +90,15 @@ def _parser() -> argparse.ArgumentParser:
     mode.add_argument("--quick", action="store_true", help="2 packs, ~5-10 min, no Docker")
     mode.add_argument("--medium", action="store_true", help="5 packs (default), ~15-25 min, no Docker")
     mode.add_argument("--full", action="store_true", help="8 packs incl. sandboxed, ~25-40 min, requires Docker")
-    mode.add_argument("--reasoning", action="store_true", help="reasoning packs: HE+, LCB v6, GPQA metadata, GSM-Symbolic; separate from --full")
+    mode.add_argument(
+        "--reasoning-packs",
+        action="store_true",
+        help="reasoning/code-reasoning pack-set: HE+, LCB v6, GPQA metadata, GSM-Symbolic "
+             "(separate suite; pick the thinking MODE with --enable-thinking/--no-thinking)",
+    )
+    # Deprecated alias for --reasoning-packs (back-compat for scripted callers). Hidden;
+    # it reads like a thinking-mode but is actually a pack-set selector — #65.
+    mode.add_argument("--reasoning", action="store_true", help=argparse.SUPPRESS)
     run.add_argument("--pack", help="run a single named pack (overrides --quick/--medium/--full)")
     # endpoint/model are required for normal runs; relaxed to optional so the
     # #62 negative-control probe (which never calls a model) can run without them.
@@ -308,7 +322,7 @@ def _mode_from_args(args: argparse.Namespace) -> str:
         return "quick"
     if args.full:
         return "full"
-    if getattr(args, "reasoning", False):
+    if getattr(args, "reasoning_packs", False) or getattr(args, "reasoning", False):
         return "reasoning"
     return "medium"
 
@@ -629,6 +643,14 @@ def main(argv: list[str] | None = None) -> int:
             from benchlocal_cli.history import history_main
             return history_main(args)
 
+        # #65: --reasoning is a deprecated alias for --reasoning-packs.
+        if getattr(args, "reasoning", False):
+            print(
+                "benchlocal-cli: --reasoning is deprecated; use --reasoning-packs "
+                "(it's the pack-set selector, not a thinking mode — pick the mode with "
+                "--enable-thinking/--no-thinking). Treating as --reasoning-packs.",
+                file=sys.stderr,
+            )
         # #62: endpoint/model are optional only under --negative-control (no model call).
         if args.negative_control:
             args.endpoint = args.endpoint or "negative-control"

--- a/tests/test_reasoning_packs.py
+++ b/tests/test_reasoning_packs.py
@@ -1,10 +1,47 @@
 from __future__ import annotations
 
+import argparse
 import json
 
-from benchlocal_cli.cli import main
+from benchlocal_cli.cli import _mode_from_args, main
 from benchlocal_cli.runner import PACK_MODES, Runner, load_pack
 from benchlocal_cli.scoring import answer_match
+
+
+def _mode_ns(**kw) -> argparse.Namespace:
+    base = dict(pack=None, quick=False, medium=False, full=False,
+                reasoning=False, reasoning_packs=False)
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+# #65 — --reasoning renamed to --reasoning-packs (pack-set selector), with the
+# old flag kept as a hidden, deprecated, back-compat alias.
+def test_reasoning_packs_selects_reasoning_mode():
+    assert _mode_from_args(_mode_ns(reasoning_packs=True)) == "reasoning"
+
+
+def test_deprecated_reasoning_alias_still_selects_reasoning_mode():
+    assert _mode_from_args(_mode_ns(reasoning=True)) == "reasoning"
+
+
+def test_default_mode_is_medium():
+    assert _mode_from_args(_mode_ns()) == "medium"
+
+
+def test_reasoning_packs_visible_in_help(capsys):
+    import pytest
+    with pytest.raises(SystemExit):
+        main(["run", "--help"])
+    out = capsys.readouterr().out
+    assert "--reasoning-packs" in out  # primary flag is documented
+
+
+def test_reasoning_packs_mutually_exclusive_with_full():
+    import pytest
+    # pack-set selectors are mutually exclusive — argparse exits at parse time.
+    with pytest.raises(SystemExit):
+        main(["run", "--reasoning-packs", "--full", "--endpoint", "x", "--model", "y"])
 
 
 def _response(content: str) -> dict:


### PR DESCRIPTION
Closes #65.

`--reasoning` is a **pack-set selector** (it runs the reasoning suite — HE+, LCB v6, GPQA metadata, GSM-Symbolic), but its name reads like a *thinking mode* and it sat right next to `--enable-thinking` / `--no-thinking`. In practice that's genuinely ambiguous: a "with-reasoning vs without-reasoning" A/B is `--full --enable-thinking` vs `--full --no-thinking` — **not** `--reasoning`.

## Changes
- **`--reasoning-packs`** is now the primary pack-set flag.
- **`--reasoning`** stays as a **hidden, deprecated alias** (`argparse.SUPPRESS`) for back-compat — anything scripted against it keeps working, but it prints a one-line deprecation warning to stderr.
- `_mode_from_args` resolves either flag to the internal `reasoning` mode — the `PACK_MODES["reasoning"]` key is unchanged, so blast radius is just the CLI surface.
- **`--help` regrouped** into two clearly-separate axes:
  - *Pack-set (pick WHAT runs):* `--quick` / `--medium` / `--full` / `--reasoning-packs`
  - *Thinking mode (orthogonal — pick HOW it runs):* `--enable-thinking` / `--no-thinking`
  - plus `--full --no-thinking` / `--full --enable-thinking` examples.
- README: `--reasoning` → `--reasoning-packs` throughout + a "two orthogonal axes" note.

## Tests
`tests/test_reasoning_packs.py` (+5): both flags resolve to the reasoning mode, default = medium, `--reasoning-packs` visible in `--help`, and it's mutually exclusive with `--full`. Full suite **247 passed**, no regressions.

Downstream: the club-3090 `quality-test.sh` wrapper forwards run args, so the rename is picked up automatically; the rebench-full `--with-8pack-thinking` work (club-3090 #338) builds on this clarified vocabulary.
