### PR TITLE
fix(runner): honest sandbox-unavailable hint (build tooling isn't pip-packaged)

### DIFF
--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -617,8 +617,12 @@ class Runner:
             except Exception as exc:
                 msg = (
                     f"skipping {pack_id}: sandbox unavailable ({exc}). "
-                    f"Hint: ensure Docker is running and `bash tools/build-sandboxes.sh` has been run; "
-                    f"or use --medium for the deterministic-only subset (no Docker needed)."
+                    f"Hint: the sandboxed packs need pre-built Docker images (benchlocal-sandbox-*) "
+                    f"that aren't auto-pulled — and the build tooling is NOT in the pip package, it "
+                    f"lives in a benchlocal-cli checkout. Build them once: "
+                    f"`git clone https://github.com/noonghunna/benchlocal-cli && "
+                    f"bash benchlocal-cli/tools/build-sandboxes.sh`. "
+                    f"Or run a deterministic-only subset (no Docker needed)."
                 )
                 warnings.append(msg)
                 print(f"⚠️  {msg}", file=sys.stderr, flush=True)


### PR DESCRIPTION
## Problem

When a sandboxed pack (BugFind / CLI / Hermes / aider) can't start its Docker sandbox, the skip hint said:

> Hint: ensure Docker is running and `bash tools/build-sandboxes.sh` has been run; …

That path is wrong for most users:
- it's **relative**, so it only resolves from a benchlocal-cli source checkout;
- it's **absent on a `pip install`** entirely (`tools/` isn't in the package);
- and `build-sandboxes.sh` is a maintainer-only build script.

A downstream user running the packs from another repo (reported via [noonghunna/club-3090#492](https://github.com/noonghunna/club-3090/issues/492) — running `quality-test.sh --full`) followed the hint into a dead path.

## Fix

The hint now states the sandboxed packs need pre-built `benchlocal-sandbox-*` images that aren't auto-pulled, that the build tooling lives in a **checkout** (not the pip package), and gives the exact clone + build command:

```
git clone https://github.com/noonghunna/benchlocal-cli && bash benchlocal-cli/tools/build-sandboxes.sh
```

`py_compile` clean. (A nicer follow-up would be a `benchlocal-cli build-sandboxes` subcommand or published images so no checkout is needed — left out of this minimal hint fix.)