### PR TITLE
Fix ReasonMath trace scoring for reasoning-channel responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,10 @@ benchlocal-cli inspect results.json --scenario IF-10 --full  # full prompt/respo
 benchlocal-cli inspect results.json --mode timeout           # only this failure_mode
 benchlocal-cli inspect results.json --diff previous.json     # side-by-side vs a prior run (regressions + latency delta)
 benchlocal-cli inspect results.json --logs ./sandbox-logs    # pull sandboxed-pack stdout/stderr
+benchlocal-cli rescore results.json --pack reasonmath-15 --output rescored.json
 ```
+
+Use `rescore` when a deterministic scorer changes and the saved JSON already contains `raw_response`. It re-grades from the stored model responses without calling the endpoint again; sandbox-backed packs are skipped because their verifier state lives in Docker fixtures.
 
 `failure_mode` is one of `verifier_fail`, `token_limit`, `timeout`, `agent_runner_timeout`, `agent_runner_crashed`, `server_error`, `http_error`, `model_endpoint_unreachable`, `result_json_malformed`, `wrong_answer`, `verifier_not_implemented`.
 

--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -80,6 +80,9 @@ def _parser() -> argparse.ArgumentParser:
     # v0.8 — `history` subcommand for querying the run-history CSV
     from benchlocal_cli.history import add_history_subparser
     add_history_subparser(sub)
+    # v0.9.x — offline re-grading of saved raw responses after scorer fixes.
+    from benchlocal_cli.rescore import add_rescore_subparser
+    add_rescore_subparser(sub)
 
     run = sub.add_parser(
         "run",
@@ -642,6 +645,10 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "history":
             from benchlocal_cli.history import history_main
             return history_main(args)
+
+        if args.command == "rescore":
+            from benchlocal_cli.rescore import rescore_result
+            return rescore_result(args.path, args)
 
         # #65: --reasoning is a deprecated alias for --reasoning-packs.
         if getattr(args, "reasoning", False):

--- a/benchlocal_cli/rescore.py
+++ b/benchlocal_cli/rescore.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+from benchlocal_cli.runner import _utc_now, load_pack
+from benchlocal_cli.scoring.common import content_with_source
+
+
+def add_rescore_subparser(sub) -> None:
+    parser = sub.add_parser(
+        "rescore",
+        help="re-run deterministic scorers against a saved result JSON",
+    )
+    parser.add_argument("path", help="saved benchlocal-cli result JSON")
+    parser.add_argument("--output", help="write rescored JSON to this path (default: stdout)")
+    parser.add_argument("--in-place", action="store_true", help="overwrite the input JSON with rescored results")
+    parser.add_argument("--pack", help="only rescore one pack id, e.g. reasonmath-15")
+
+
+def _score_saved_scenario(pack_meta: dict, scenario_index: dict[str, dict], run: dict) -> tuple[bool, str | None]:
+    raw_response = run.get("raw_response")
+    if not isinstance(raw_response, dict):
+        return False, "missing raw_response"
+
+    scenario_id = str(run.get("id") or "")
+    scenario = scenario_index.get(scenario_id) or run.get("raw_scenario")
+    if not isinstance(scenario, dict):
+        return False, "missing scenario definition"
+
+    verifier_type = scenario.get("verifier", {}).get("type") or pack_meta.get("verifier_module")
+    if not verifier_type or verifier_type == "_stub":
+        return False, "sandbox/stub scorer not rescored"
+
+    module = importlib.import_module(f"benchlocal_cli.scoring.{verifier_type}")
+    result = module.score_scenario(scenario, raw_response)
+
+    previous = run.get("result") if isinstance(run.get("result"), dict) else {}
+    result.latency_seconds = float(previous.get("latency_seconds") or run.get("latency_seconds") or 0.0)
+    tokens = previous.get("tokens_completion", run.get("tokens_completion"))
+    result.tokens_completion = tokens if isinstance(tokens, int) else None
+
+    result_dict = result.to_dict()
+    run["result"] = result_dict
+    run["passed"] = result.passed
+    run["failure_mode"] = result.failure_mode
+    run["detail"] = result.detail
+    run["latency_seconds"] = result.latency_seconds
+    run["tokens_completion"] = result.tokens_completion
+    run["verifier_trace"] = result.verifier_trace
+    run["response_field_used"] = content_with_source(raw_response)[1]
+    return True, None
+
+
+def _recompute_pack(pack: dict) -> None:
+    scenarios = [s for s in pack.get("scenarios", []) if isinstance(s, dict)]
+    total = len(scenarios)
+    passed = sum(1 for scenario in scenarios if bool(scenario.get("passed")))
+    pack["passed"] = passed
+    pack["total"] = total
+    pack["score"] = passed / total if total else 0.0
+
+
+def _recompute_totals(data: dict) -> None:
+    packs = [p for p in data.get("packs", []) if isinstance(p, dict) and not p.get("skipped")]
+    total = sum(int(pack.get("total") or 0) for pack in packs)
+    passed = sum(int(pack.get("passed") or 0) for pack in packs)
+    data["totals"] = {"passed": passed, "total": total, "score": passed / total if total else 0.0}
+
+
+def rescore_result(path: str, args: Any) -> int:
+    source = Path(path)
+    data = json.loads(source.read_text())
+    if not isinstance(data, dict):
+        raise ValueError("result JSON must be an object")
+
+    rescored = 0
+    skipped: dict[str, int] = {}
+    for pack in data.get("packs", []):
+        if not isinstance(pack, dict):
+            continue
+        pack_id = str(pack.get("pack_id") or "")
+        if args.pack and pack_id != args.pack:
+            continue
+        try:
+            pack_meta, current_scenarios = load_pack(pack_id)
+        except Exception:
+            pack_meta, current_scenarios = {"verifier_module": None}, []
+        if pack_meta.get("supports_sandboxed_only"):
+            skipped[pack_id] = len(pack.get("scenarios") or [])
+            continue
+        scenario_index = {str(scenario.get("id")): scenario for scenario in current_scenarios if isinstance(scenario, dict)}
+        for run in pack.get("scenarios", []):
+            if not isinstance(run, dict):
+                continue
+            did_score, reason = _score_saved_scenario(pack_meta, scenario_index, run)
+            if did_score:
+                rescored += 1
+            elif reason:
+                skipped[reason] = skipped.get(reason, 0) + 1
+        _recompute_pack(pack)
+
+    _recompute_totals(data)
+    data["rescored"] = {
+        "at": _utc_now(),
+        "scenarios": rescored,
+        "skipped": skipped,
+        "pack_filter": args.pack,
+    }
+
+    if args.in_place and args.output:
+        raise ValueError("use either --in-place or --output, not both")
+    target = source if args.in_place else Path(args.output) if args.output else None
+    payload = json.dumps(data, indent=2, sort_keys=True)
+    if target:
+        target.write_text(payload + "\n")
+    else:
+        print(payload)
+    return 0

--- a/benchlocal_cli/scoring/common.py
+++ b/benchlocal_cli/scoring/common.py
@@ -74,6 +74,25 @@ def content_with_source(response: dict) -> tuple[str, str | None]:
     return "", None
 
 
+def content_channels_with_sources(response: dict) -> list[tuple[str, str]]:
+    channels: list[tuple[str, str]] = []
+    for field in ("content", "reasoning_content", "reasoning"):
+        value = response.get(field)
+        if isinstance(value, str) and value:
+            channels.append((field, sanitize_reasoning_tags(value)))
+    msg = message(response)
+    for field in ("content", "reasoning_content", "reasoning"):
+        value = msg.get(field)
+        if isinstance(value, str) and value:
+            channels.append((f"message.{field}", sanitize_reasoning_tags(value)))
+    return channels
+
+
+def combined_content_with_sources(response: dict) -> tuple[str, list[str]]:
+    channels = content_channels_with_sources(response)
+    return "\n".join(text for _, text in channels), [source for source, _ in channels]
+
+
 def content(response: dict) -> str:
     return content_with_source(response)[0]
 

--- a/benchlocal_cli/scoring/reason_math.py
+++ b/benchlocal_cli/scoring/reason_math.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 import re
 
-from benchlocal_cli.scoring.common import content, result
+from benchlocal_cli.scoring.common import content, content_channels_with_sources, result
 from benchlocal_cli.types import ScenarioResult
 
 
@@ -83,31 +83,44 @@ def _answer_axis(assertion: dict, raw_answer: str) -> tuple[int, str | None]:
     return 0, f"Unexpected final line: {answer_line}"
 
 
-def _trace_axis(assertion: dict, raw_answer: str) -> tuple[int, str | None]:
+def _checkpoint_matches(checkpoint_text: str, normalized_text: str) -> bool:
+    normalized_checkpoint = _norm(checkpoint_text)
+    if normalized_checkpoint in normalized_text:
+        return True
+    if "=" not in checkpoint_text:
+        return False
+    left, right = checkpoint_text.split("=", 1)
+    return _norm_checkpoint_label(left) in normalized_text and _norm(right) in normalized_text
+
+
+def _trace_axis(
+    assertion: dict,
+    raw_answer: str,
+    channels: list[tuple[str, str]] | None = None,
+) -> tuple[int, str | None, list[str]]:
     checkpoints = assertion.get("checkpoints") or []
     if not checkpoints:
-        return 2, None
+        return 2, None, []
 
     normalized = _norm(raw_answer)
     matched = []
+    matched_source_set: set[str] = set()
     for checkpoint in checkpoints:
         checkpoint_text = str(checkpoint)
-        normalized_checkpoint = _norm(checkpoint_text)
-        if normalized_checkpoint in normalized:
-            matched.append(checkpoint_text)
+        if not _checkpoint_matches(checkpoint_text, normalized):
             continue
+        matched.append(checkpoint_text)
+        for source, channel_text in channels or []:
+            if _checkpoint_matches(checkpoint_text, _norm(channel_text)):
+                matched_source_set.add(source)
 
-        if "=" not in checkpoint_text:
-            continue
-        left, right = checkpoint_text.split("=", 1)
-        if _norm_checkpoint_label(left) in normalized and _norm(right) in normalized:
-            matched.append(checkpoint_text)
-
+    matched_sources = [source for source, _ in channels or [] if source in matched_source_set]
+    source_note = f" Trace sources: {', '.join(matched_sources)}." if matched_sources else ""
     if len(matched) == len(checkpoints):
-        return 2, None
+        return 2, f"Matched checkpoints across {', '.join(matched_sources)}." if matched_sources else None, matched_sources
     if matched:
-        return 1, f"Matched {len(matched)}/{len(checkpoints)} checkpoints."
-    return 0, "No published checkpoints matched."
+        return 1, f"Matched {len(matched)}/{len(checkpoints)} checkpoints.{source_note}", matched_sources
+    return 0, f"No published checkpoints matched.{source_note}", matched_sources
 
 
 def _scored_result(
@@ -128,6 +141,8 @@ def _scored_result(
 
 def score_scenario(scenario: dict, response: dict) -> ScenarioResult:
     text = content(response).strip()
+    trace_channels = content_channels_with_sources(response)
+    trace_text = "\n".join(channel_text for _, channel_text in trace_channels).strip()
     for assertion in scenario.get("verifier", {}).get("asserts", []):
         kind = assertion.get("kind")
         if kind == "exact_numeric":
@@ -147,7 +162,7 @@ def score_scenario(scenario: dict, response: dict) -> ScenarioResult:
         elif kind == "exact_string":
             if any(key in assertion for key in ("canonical_answer", "accepted_answers", "partial_answers", "checkpoints")):
                 answer_points, answer_note = _answer_axis(assertion, text)
-                trace_points, trace_note = _trace_axis(assertion, text)
+                trace_points, trace_note, matched_sources = _trace_axis(assertion, trace_text, trace_channels)
                 score = round(100 * (0.7 * (answer_points / 2) + 0.3 * (trace_points / 2)))
                 passed = score >= 85
                 notes = " ".join(part for part in (answer_note, trace_note) if part)
@@ -155,6 +170,7 @@ def score_scenario(scenario: dict, response: dict) -> ScenarioResult:
                     "upstream_style_score": score,
                     "answer_axis_points": answer_points,
                     "trace_axis_points": trace_points,
+                    "trace_sources": matched_sources,
                     "status_threshold": "pass >= 85",
                     "notes": notes or None,
                 }

--- a/tests/test_reasoning_packs.py
+++ b/tests/test_reasoning_packs.py
@@ -99,6 +99,71 @@ def test_sandbox_safety_policy_intent_is_explicit_in_pack_metadata():
         assert "not explicit policy-following tests" in policy["description"]
 
 
+
+def test_rescore_regrades_saved_reason_math_reasoning_channel(tmp_path):
+    source = tmp_path / "run.json"
+    target = tmp_path / "rescored.json"
+    source.write_text(json.dumps({
+        "schema_version": "1",
+        "runner_version": "test",
+        "endpoint": "saved",
+        "model": "saved",
+        "mode": "custom",
+        "started_at": "2026-07-03T00:00:00Z",
+        "finished_at": "2026-07-03T00:00:01Z",
+        "packs": [{
+            "pack_id": "reasonmath-15",
+            "version": "1.0.0",
+            "upstream_commit": "test",
+            "scenario_count": 1,
+            "passed": 0,
+            "total": 1,
+            "score": 0.0,
+            "latency": {"p50": 0.1, "p95": 0.1, "mean": 0.1},
+            "scenarios": [{
+                "id": "RM-02",
+                "passed": False,
+                "failure_mode": "wrong_answer",
+                "detail": "old trace axis cap",
+                "latency_seconds": 0.1,
+                "tokens_completion": 12,
+                "result": {
+                    "scenario_id": "RM-02",
+                    "passed": False,
+                    "failure_mode": "wrong_answer",
+                    "detail": "old trace axis cap",
+                    "latency_seconds": 0.1,
+                    "tokens_completion": 12,
+                    "verifier_trace": {"upstream_style_score": 70},
+                },
+                "raw_scenario": {"id": "RM-02"},
+                "raw_response": {
+                    "choices": [{
+                        "message": {
+                            "content": "ANSWER: kg=0.313",
+                            "reasoning": "grams=312.5\nkg=0.3125",
+                        }
+                    }],
+                    "usage": {"completion_tokens": 12},
+                },
+                "request": {},
+                "sampling_params": {},
+                "status_code": 200,
+            }],
+        }],
+        "totals": {"passed": 0, "total": 1, "score": 0.0},
+    }))
+
+    assert main(["rescore", str(source), "--pack", "reasonmath-15", "--output", str(target)]) == 0
+
+    rescored = json.loads(target.read_text())
+    scenario = rescored["packs"][0]["scenarios"][0]
+    assert scenario["passed"] is True
+    assert scenario["result"]["verifier_trace"]["trace_axis_points"] == 2
+    assert scenario["result"]["verifier_trace"]["trace_sources"] == ["message.reasoning"]
+    assert rescored["totals"] == {"passed": 1, "total": 1, "score": 1.0}
+    assert rescored["rescored"]["scenarios"] == 1
+
 def test_answer_match_numeric_prefers_final_answer_line():
     scenario = {"id": "GSM", "verifier": {"asserts": [{"kind": "exact_numeric", "value": "20"}]}}
     assert answer_match.score_scenario(scenario, _response("Rough work mentions 20, but final says ANSWER: 21")).failure_mode == "wrong_answer"

--- a/tests/test_scoring_smoke.py
+++ b/tests/test_scoring_smoke.py
@@ -100,6 +100,82 @@ def test_reason_math_exact_string_multi_value_key_agnostic():
     assert reason_math.score_scenario(scenario, _response("ANSWER: total=$5721.24")).failure_mode == "wrong_answer"
 
 
+def _reason_math_checkpoint_scenario() -> dict:
+    return {
+        "id": "RM-split",
+        "verifier": {
+            "asserts": [
+                {
+                    "kind": "exact_string",
+                    "value": "fit=no; max_meetings=3",
+                    "canonical_answer": "ANSWER: fit=no; max_meetings=3",
+                    "checkpoints": ["meeting_a=09:00", "meeting_b=11:00"],
+                }
+            ]
+        },
+    }
+
+
+def _split_response(content: str, **extra_message: str) -> dict:
+    message = {"content": content}
+    message.update(extra_message)
+    return {"choices": [{"message": message}], "usage": {"completion_tokens": 3}}
+
+
+def test_reason_math_trace_axis_matches_content_only_checkpoints():
+    scenario = _reason_math_checkpoint_scenario()
+    response = _response("meeting_a=09:00\nmeeting_b=11:00\nANSWER: fit=no; max_meetings=3")
+
+    result = reason_math.score_scenario(scenario, response)
+
+    assert result.passed
+    assert result.verifier_trace["trace_axis_points"] == 2
+    assert result.verifier_trace["trace_sources"] == ["message.content"]
+
+
+def test_reason_math_trace_axis_matches_reasoning_only_checkpoints():
+    scenario = _reason_math_checkpoint_scenario()
+    response = _split_response(
+        "ANSWER: fit=no; max_meetings=3",
+        reasoning="meeting_a=09:00\nmeeting_b=11:00",
+    )
+
+    result = reason_math.score_scenario(scenario, response)
+
+    assert result.passed
+    assert result.verifier_trace["answer_axis_points"] == 2
+    assert result.verifier_trace["trace_axis_points"] == 2
+    assert result.verifier_trace["trace_sources"] == ["message.reasoning"]
+
+
+def test_reason_math_trace_axis_matches_split_content_and_reasoning_checkpoints():
+    scenario = _reason_math_checkpoint_scenario()
+    response = _split_response(
+        "meeting_b=11:00\nANSWER: fit=no; max_meetings=3",
+        reasoning="meeting_a=09:00",
+    )
+
+    result = reason_math.score_scenario(scenario, response)
+
+    assert result.passed
+    assert result.verifier_trace["trace_axis_points"] == 2
+    assert result.verifier_trace["trace_sources"] == ["message.content", "message.reasoning"]
+
+
+def test_reason_math_trace_axis_still_fails_when_no_channel_has_checkpoints():
+    scenario = _reason_math_checkpoint_scenario()
+    response = _split_response(
+        "ANSWER: fit=no; max_meetings=3",
+        reasoning="unrelated planning",
+    )
+
+    result = reason_math.score_scenario(scenario, response)
+
+    assert result.failure_mode == "wrong_answer"
+    assert result.verifier_trace["upstream_style_score"] == 70
+    assert result.verifier_trace["trace_axis_points"] == 0
+
+
 def test_data_extract_pass_and_fail():
     scenario = {"id": "DE", "verifier": {"asserts": [{"kind": "field_exact_value", "field": "email", "value": "a@example.com"}, {"kind": "no_extra_fields", "allowed": ["email"]}]}}
     assert data_extract.score_scenario(scenario, _response('{"email":"a@example.com"}')).passed


### PR DESCRIPTION
## Summary

Closes #80.

- keep ReasonMath final-answer extraction content-first, preserving the existing answer-axis behavior
- score ReasonMath checkpoints against all text channels (`content`, `reasoning_content`, and `reasoning`) so thinking-mode runs with vLLM reasoning parsers are not capped at 70%
- record `trace_sources` in verifier traces to show which response channels matched checkpoints
- add `benchlocal-cli rescore` for deterministic packs so saved JSONs with `raw_response` can be regraded without re-running the model
- document the rescore path in the README

## Verification

- `python3 -m py_compile benchlocal_cli/scoring/common.py benchlocal_cli/scoring/reason_math.py benchlocal_cli/rescore.py benchlocal_cli/cli.py tests/test_scoring_smoke.py tests/test_reasoning_packs.py`
- `pytest -q tests/test_reasoning_packs.py tests/test_scoring_smoke.py tests/test_sandbox_verifiers.py tests/test_reasoning_handling.py` -> 94 passed
- `pytest -q` -> 268 passed

## Notes

- `benchlocal-runs/` remains untracked and is not part of this PR.
- Sibling scorer audit: other deterministic scorers still use `content()` for final-answer/output parsing. This PR only changes ReasonMath checkpoint matching, where the reasoning channel is part of the scored trace axis.