### PR TITLE
feat(run): add scenario-level selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,24 @@ benchlocal-cli run --pack aider-polyglot-30 --enable-sandboxed-packs \
 benchlocal-cli run --quick --endpoint http://localhost:8020 --model qwen3.6-27b-autoround --output json > results.json
 ```
 
+## Scenario selection
+
+Run exact scenarios with repeatable pack-qualified IDs, or keep a reusable newline-delimited selection file:
+
+```bash
+benchlocal-cli run \
+  --scenario cli-40/CLI-34 \
+  --scenario reasonmath-15/RM-04 \
+  --endpoint http://localhost:8010 --model qwen3.6-27b-autoround
+
+benchlocal-cli run --scenarios-file targeted.txt \
+  --endpoint http://localhost:8010 --model qwen3.6-27b-autoround
+```
+
+Selection alone defines the run set. With `--pack`, `--quick`, `--medium`, `--full`, `--reasoning-packs`, or `--sandboxed-only`, it intersects with that pack set. Selection files accept one `PACK_ID/SCENARIO_ID` per line, blank lines, and `#` comments. Unknown IDs fail before any model call and include near matches. Thinking and sampling follow the same pack defaults and overrides as ordinary runs.
+
+Selected results are intentionally explicit: JSON includes top-level `selection`, each pack's `scenario_count` is the selected subset, and `catalog_scenario_count` records the complete pack size. Human output labels subset scores `partial`. These are optional additive fields, so `schema_version` remains `1` and older result JSON stays readable. Partial results are refused by history ingestion and `rescore` unless `--allow-partial` is supplied. `--exit-on-regression` is allowed: with `--previous-result` it gates only selected scenario keys, while non-canonical sampling overrides remain blocked as before.
+
 ## Running against a cloud / managed endpoint
 
 The same packs run against any cloud OpenAI-compatible endpoint — a managed API, a router, your own hosted model — for a like-for-like local-vs-cloud comparison (identical prompts, identical verifiers).

--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -103,6 +103,17 @@ def _parser() -> argparse.ArgumentParser:
     # it reads like a thinking-mode but is actually a pack-set selector — #65.
     mode.add_argument("--reasoning", action="store_true", help=argparse.SUPPRESS)
     run.add_argument("--pack", help="run a single named pack (overrides --quick/--medium/--full)")
+    run.add_argument(
+        "--scenario",
+        action="append",
+        default=[],
+        metavar="PACK_ID/SCENARIO_ID",
+        help="run one pack-qualified scenario (repeatable); intersects with pack-set flags",
+    )
+    run.add_argument(
+        "--scenarios-file",
+        help="newline-delimited PACK_ID/SCENARIO_ID selections; blank lines and # comments allowed",
+    )
     # endpoint/model are required for normal runs; relaxed to optional so the
     # #62 negative-control probe (which never calls a model) can run without them.
     # Enforced in cmd_run when --negative-control is absent.
@@ -300,6 +311,11 @@ def _parser() -> argparse.ArgumentParser:
              "score, per-pack pass/total, runner_version). Falls back to "
              "BENCHLOCAL_HISTORY_FILE env. Use `benchlocal-cli history` to query.",
     )
+    run.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="allow a scenario-selection result to be appended to --history-file",
+    )
     return parser
 
 
@@ -338,6 +354,14 @@ def _pack_line(pack: PackResult) -> str:
         status = pack.status
     else:
         status = "ok" if pack.total else pack.status
+    if (
+        pack.catalog_scenario_count is not None
+        and pack.scenario_count < pack.catalog_scenario_count
+    ):
+        status = (
+            f"{status}; partial — {pack.scenario_count} of "
+            f"{pack.catalog_scenario_count} selected"
+        )
     score = f"{pack.score:.0%}" if pack.total else "-"
     p50 = "-" if pack.latency["p50"] is None else f"{pack.latency['p50']:.2f}s"
     return f"{pack.pack_id} (v{pack.version}) | {pack.passed} / {pack.total} | {score} | {p50} | {status}"
@@ -411,8 +435,12 @@ def _markdown(result: RunResult) -> str:
         override_str = ", ".join(f"{k}={v}" for k, v in result.sampling_overrides.items())
         canonical_tag = f" ⚠ NON-CANONICAL (sampling: {override_str})"
 
+    selection_tag = (
+        f" [PARTIAL SELECTION: {len(result.selection)} scenarios]"
+        if result.selection is not None else ""
+    )
     lines = [
-        f"=== benchlocal-cli --{result.mode}  (endpoint: {result.endpoint}, model: {result.model}, thinking={thinking}, {result.started_at}){canonical_tag} ===",
+        f"=== benchlocal-cli --{result.mode}  (endpoint: {result.endpoint}, model: {result.model}, thinking={thinking}, {result.started_at}){canonical_tag}{selection_tag} ===",
         "",
     ]
     show_variance = delta_pack_index is None and any(pack.variance for pack in result.packs)
@@ -436,6 +464,14 @@ def _markdown(result: RunResult) -> str:
             status = pack.status
         else:
             status = "ok" if pack.total else pack.status
+        if (
+            pack.catalog_scenario_count is not None
+            and pack.scenario_count < pack.catalog_scenario_count
+        ):
+            status = (
+                f"{status}; partial — {pack.scenario_count} of "
+                f"{pack.catalog_scenario_count} selected"
+            )
         score = f"{pack.score:.0%}" if pack.total else "-"
         p50 = "-" if pack.latency["p50"] is None else f"{pack.latency['p50']:.2f}s"
         p95 = "-" if pack.latency["p95"] is None else f"{pack.latency['p95']:.2f}s"
@@ -679,6 +715,35 @@ def main(argv: list[str] | None = None) -> int:
             pack_ids = [args.pack]
         else:
             pack_ids = PACK_MODES[mode]
+
+        from benchlocal_cli.selection import (
+            intersect_selection,
+            requested_ids,
+            validate_selection,
+        )
+        raw_selection = requested_ids(args.scenario, args.scenarios_file)
+        selection_ids: list[str] | None = None
+        selection_by_pack: dict[str, list[str]] | None = None
+        selection_requested = bool(args.scenario or args.scenarios_file)
+        if selection_requested:
+            if not raw_selection:
+                raise ValueError("scenario selection is empty")
+            selection_ids, selection_by_pack = validate_selection(raw_selection)
+            explicit_pack_set = bool(
+                args.pack or args.quick or args.medium or args.full
+                or args.reasoning_packs or args.reasoning or args.sandboxed_only
+            )
+            selection_ids, selection_by_pack = intersect_selection(
+                selection_ids,
+                selection_by_pack,
+                pack_ids if explicit_pack_set else None,
+            )
+            if explicit_pack_set:
+                pack_ids = [pack_id for pack_id in pack_ids if pack_id in selection_by_pack]
+            else:
+                pack_ids = list(selection_by_pack)
+                mode = "custom"
+
         # --full implies sandboxed packs by default; --no-sandboxed-packs opts out.
         # --sandboxed-only also implies sandbox is enabled (no point otherwise).
         # Single-pack runs (--pack) auto-enable sandbox if the pack requires it.
@@ -694,6 +759,8 @@ def main(argv: list[str] | None = None) -> int:
                     sandboxed_enabled = True
             except Exception:
                 pass  # let Runner surface the unknown-pack error
+        if selection_by_pack and _pack_ids_include_sandboxed(pack_ids):
+            sandboxed_enabled = True
         if args.no_sandboxed_packs and not args.sandboxed_only:
             sandboxed_enabled = False
         # Build sampling overrides from CLI flags (#19)
@@ -788,6 +855,7 @@ def main(argv: list[str] | None = None) -> int:
                     warnings=[],
                     sampling_overrides=sampling_overrides or None,
                     sampling_source="server" if args.sampling_from_server else None,
+                    selection=selection_ids,
                 )
                 try:
                     with Path(incremental_state["save_path"]).open("w", encoding="utf-8") as handle:
@@ -845,7 +913,13 @@ def main(argv: list[str] | None = None) -> int:
             on_progress_event=on_progress_event,
         )
         try:
-            result = runner.run(pack_ids, mode=mode, repeat=max(1, args.repeat))
+            result = runner.run(
+                pack_ids,
+                mode=mode,
+                repeat=max(1, args.repeat),
+                selection=selection_by_pack,
+                selection_ids=selection_ids,
+            )
         except _SpendGuardExceeded as exc:
             print(f"\n[spend-guard] {exc}", file=sys.stderr)
             print(
@@ -883,7 +957,7 @@ def main(argv: list[str] | None = None) -> int:
         if history_path:
             try:
                 from benchlocal_cli.history import append_run
-                append_run(result_dict, history_path)
+                append_run(result_dict, history_path, allow_partial=args.allow_partial)
             except Exception as exc:
                 print(f"benchlocal-cli: warning — history append failed: {exc}", file=sys.stderr)
         if args.output == "json":

--- a/benchlocal_cli/delta.py
+++ b/benchlocal_cli/delta.py
@@ -137,6 +137,7 @@ def classify(current: dict, previous_path: str | Path) -> RunDelta:
 
     current_map = _build_scenario_map(current.get("packs") or [])
     previous_map = _build_scenario_map(previous.get("packs") or [])
+    selected_keys = set(current.get("selection") or []) if current.get("selection") is not None else None
 
     # Index per-pack deltas by pack_id for accumulation
     pack_deltas: dict[str, PackDelta] = {}
@@ -168,6 +169,8 @@ def classify(current: dict, previous_path: str | Path) -> RunDelta:
 
     # Walk previous → find scenarios dropped from current
     for (pack_id, scenario_id), _ in previous_map.items():
+        if selected_keys is not None and f"{pack_id}/{scenario_id}" not in selected_keys:
+            continue
         if (pack_id, scenario_id) not in current_map:
             d = _ensure(pack_id)
             d.dropped += 1

--- a/benchlocal_cli/history.py
+++ b/benchlocal_cli/history.py
@@ -86,10 +86,12 @@ def _row_from_run(run_dict: dict) -> dict[str, str]:
     return row
 
 
-def append_run(run_dict: dict, history_path: str | Path) -> None:
+def append_run(run_dict: dict, history_path: str | Path, *, allow_partial: bool = False) -> None:
     """Append a row to the history CSV. Creates the file with a header on
     first write. Acquires a POSIX flock to prevent concurrent-append corruption
     (Codex review #5)."""
+    if run_dict.get("selection") is not None and not allow_partial:
+        raise ValueError("partial selection results require --allow-partial for history ingestion")
     history_path = Path(history_path)
     history_path.parent.mkdir(parents=True, exist_ok=True)
     row = _row_from_run(run_dict)

--- a/benchlocal_cli/rescore.py
+++ b/benchlocal_cli/rescore.py
@@ -18,6 +18,11 @@ def add_rescore_subparser(sub) -> None:
     parser.add_argument("--output", help="write rescored JSON to this path (default: stdout)")
     parser.add_argument("--in-place", action="store_true", help="overwrite the input JSON with rescored results")
     parser.add_argument("--pack", help="only rescore one pack id, e.g. reasonmath-15")
+    parser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="allow rescoring a scenario-selection result (not a canonical pack total)",
+    )
 
 
 def _score_saved_scenario(pack_meta: dict, scenario_index: dict[str, dict], run: dict) -> tuple[bool, str | None]:
@@ -75,6 +80,8 @@ def rescore_result(path: str, args: Any) -> int:
     data = json.loads(source.read_text())
     if not isinstance(data, dict):
         raise ValueError("result JSON must be an object")
+    if data.get("selection") is not None and not args.allow_partial:
+        raise ValueError("partial selection results require --allow-partial to rescore")
 
     rescored = 0
     skipped: dict[str, int] = {}

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -465,7 +465,15 @@ class Runner:
             return 5.0
         return max(0.25, value)
 
-    def run(self, pack_ids: list[str], *, mode: str = "custom", repeat: int = 1) -> RunResult:
+    def run(
+        self,
+        pack_ids: list[str],
+        *,
+        mode: str = "custom",
+        repeat: int = 1,
+        selection: dict[str, list[str]] | None = None,
+        selection_ids: list[str] | None = None,
+    ) -> RunResult:
         started_at = _utc_now()
         warnings: list[str] = []
         old_sigint = signal.getsignal(signal.SIGINT)
@@ -488,7 +496,12 @@ class Runner:
             self._start_sandboxes(pack_ids, warnings)
             pack_results: list[PackResult] = []
             for pack_id in pack_ids:
-                pack_result = self.run_pack(pack_id, repeat=repeat, warnings=warnings)
+                pack_result = self.run_pack(
+                    pack_id,
+                    repeat=repeat,
+                    warnings=warnings,
+                    scenario_ids=selection.get(pack_id) if selection is not None else None,
+                )
                 pack_results.append(pack_result)
                 if self._on_pack_complete is not None:
                     self._on_pack_complete(pack_result)
@@ -532,6 +545,7 @@ class Runner:
                 sampling_overrides=dict(self.sampling_overrides) if self.sampling_overrides else None,
                 sampling_source="server" if self.sampling_from_server else None,
                 server_defaults=self._server_defaults if self.sampling_from_server else None,
+                selection=selection_ids,
             )
         finally:
             self._stop_sandboxes()
@@ -836,8 +850,20 @@ class Runner:
             return None
         return statistics.mean(samples)
 
-    def run_pack(self, pack_id: str, *, repeat: int = 1, warnings: list[str] | None = None) -> PackResult:
+    def run_pack(
+        self,
+        pack_id: str,
+        *,
+        repeat: int = 1,
+        warnings: list[str] | None = None,
+        scenario_ids: list[str] | None = None,
+    ) -> PackResult:
         meta, scenarios = load_pack(pack_id)
+        catalog_scenario_count = len(scenarios)
+        if scenario_ids is not None:
+            wanted = set(scenario_ids)
+            scenarios = [scenario for scenario in scenarios if scenario["id"] in wanted]
+        selected_catalog_count = catalog_scenario_count if scenario_ids is not None else None
         if meta.get("requires_dataset_access"):
             warning = meta.get("dataset_access_note") or f"skipping {pack_id}: dataset access required"
             if warnings is not None:
@@ -856,6 +882,7 @@ class Runner:
                 status="dataset-unavailable",
                 warnings=[warning],
                 thinking_enabled=resolve_thinking_enabled(meta, self.thinking_override),
+                catalog_scenario_count=selected_catalog_count,
             )
         if meta.get("supports_sandboxed_only") and not self.enable_sandboxed_packs:
             warning = f"skipping {pack_id}: sandboxed verifier not enabled"
@@ -875,6 +902,7 @@ class Runner:
                 status="stubbed",
                 warnings=[warning],
                 thinking_enabled=resolve_thinking_enabled(meta, self.thinking_override),
+                catalog_scenario_count=selected_catalog_count,
             )
         if meta.get("supports_sandboxed_only") and pack_id not in self._sandbox_clients:
             warning = f"skipping {pack_id}: sandbox unavailable"
@@ -894,6 +922,7 @@ class Runner:
                 status="sandbox-unavailable",
                 warnings=[warning],
                 thinking_enabled=resolve_thinking_enabled(meta, self.thinking_override),
+                catalog_scenario_count=selected_catalog_count,
             )
 
         runs: list[ScenarioRun] = []
@@ -947,6 +976,7 @@ class Runner:
                     scenarios=runs,
                     status=sb_status,
                     thinking_enabled=resolve_thinking_enabled(meta, self.thinking_override),
+                    catalog_scenario_count=selected_catalog_count,
                     variance=_repeat_variance(runs, repeat),
                 )
 
@@ -964,6 +994,7 @@ class Runner:
             scenarios=runs,
             status="ok" if total else "stubbed",
             thinking_enabled=resolve_thinking_enabled(meta, self.thinking_override),
+            catalog_scenario_count=selected_catalog_count,
             variance=_repeat_variance(runs, repeat),
         )
 

--- a/benchlocal_cli/selection.py
+++ b/benchlocal_cli/selection.py
@@ -1,0 +1,92 @@
+"""Scenario selection parsing and validation shared by targeted runs and resume."""
+
+from __future__ import annotations
+
+import difflib
+from collections.abc import Iterable
+from pathlib import Path
+
+from benchlocal_cli.runner import list_packs, load_pack
+
+
+def parse_scenarios_file(path: str | Path) -> list[str]:
+    source = Path(path)
+    if not source.is_file():
+        raise FileNotFoundError(f"--scenarios-file not found: {path}")
+    selected: list[str] = []
+    for line_number, raw_line in enumerate(source.read_text(encoding="utf-8").splitlines(), 1):
+        value = raw_line.split("#", 1)[0].strip()
+        if not value:
+            continue
+        if any(char.isspace() for char in value):
+            raise ValueError(
+                f"{source}:{line_number}: expected one PACK_ID/SCENARIO_ID per line"
+            )
+        selected.append(value)
+    return selected
+
+
+def requested_ids(cli_values: Iterable[str] | None, scenarios_file: str | None) -> list[str]:
+    values = list(cli_values or [])
+    if scenarios_file:
+        values.extend(parse_scenarios_file(scenarios_file))
+    return list(dict.fromkeys(values))
+
+
+def scenario_catalog() -> tuple[list[str], dict[str, list[str]]]:
+    pack_order = [str(meta["pack_id"]) for meta in list_packs()]
+    catalog: dict[str, list[str]] = {}
+    for pack_id in pack_order:
+        _meta, scenarios = load_pack(pack_id)
+        catalog[pack_id] = [str(scenario["id"]) for scenario in scenarios]
+    return pack_order, catalog
+
+
+def validate_selection(values: Iterable[str]) -> tuple[list[str], dict[str, list[str]]]:
+    """Return canonical qualified IDs and a pack-indexed selection."""
+    requested = list(dict.fromkeys(values))
+    if not requested:
+        return [], {}
+
+    pack_order, catalog = scenario_catalog()
+    qualified = [
+        f"{pack_id}/{scenario_id}"
+        for pack_id in pack_order
+        for scenario_id in catalog[pack_id]
+    ]
+    known = set(qualified)
+    unknown = [value for value in requested if value not in known]
+    if unknown:
+        details: list[str] = []
+        for value in unknown:
+            matches = difflib.get_close_matches(value, qualified, n=3, cutoff=0.45)
+            suffix = f"; near matches: {', '.join(matches)}" if matches else ""
+            details.append(f"{value!r}{suffix}")
+        raise ValueError("unknown scenario selection: " + "; ".join(details))
+
+    requested_set = set(requested)
+    canonical = [value for value in qualified if value in requested_set]
+    by_pack: dict[str, list[str]] = {}
+    for value in canonical:
+        pack_id, scenario_id = value.split("/", 1)
+        by_pack.setdefault(pack_id, []).append(scenario_id)
+    return canonical, by_pack
+
+
+def intersect_selection(
+    canonical: list[str],
+    by_pack: dict[str, list[str]],
+    allowed_pack_ids: Iterable[str] | None,
+) -> tuple[list[str], dict[str, list[str]]]:
+    if allowed_pack_ids is None:
+        return canonical, by_pack
+    allowed = set(allowed_pack_ids)
+    filtered = [value for value in canonical if value.split("/", 1)[0] in allowed]
+    filtered_by_pack = {
+        pack_id: ids for pack_id, ids in by_pack.items() if pack_id in allowed
+    }
+    if not filtered:
+        raise ValueError(
+            "scenario selection is empty after intersecting with the requested pack set"
+        )
+    return filtered, filtered_by_pack

--- a/benchlocal_cli/types.py
+++ b/benchlocal_cli/types.py
@@ -103,9 +103,12 @@ class PackResult:
     warnings: list[str] = field(default_factory=list)
     thinking_enabled: bool = False
     variance: dict[str, float | int | None] | None = None
+    # Present only for a selected subset. scenario_count is the selected count;
+    # this records the pack's complete catalog size for honest human rendering.
+    catalog_scenario_count: int | None = None
 
     def to_dict(self) -> dict:
-        return {
+        out = {
             "pack_id": self.pack_id,
             "version": self.version,
             "upstream_commit": self.upstream_commit,
@@ -121,6 +124,9 @@ class PackResult:
             "variance": self.variance,
             "scenarios": [scenario.to_dict() for scenario in self.scenarios],
         }
+        if self.catalog_scenario_count is not None:
+            out["catalog_scenario_count"] = self.catalog_scenario_count
+        return out
 
 
 @dataclass
@@ -154,6 +160,9 @@ class RunResult:
     # or None if the endpoint didn't expose them (vLLM). Only populated
     # when sampling_source == "server".
     server_defaults: dict | None = None
+    # Ordered, pack-qualified IDs for targeted runs. Optional/additive so schema
+    # version 1 readers remain compatible with ordinary and historical results.
+    selection: list[str] | None = None
 
     def to_dict(self) -> dict:
         out = {
@@ -178,4 +187,6 @@ class RunResult:
             out["sampling_source"] = self.sampling_source
         if self.server_defaults is not None:
             out["server_defaults"] = self.server_defaults
+        if self.selection is not None:
+            out["selection"] = self.selection
         return out

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from benchlocal_cli.cli import main
+from benchlocal_cli.history import append_run
+from benchlocal_cli.selection import (
+    intersect_selection,
+    parse_scenarios_file,
+    requested_ids,
+    validate_selection,
+)
+
+
+def _response(content: str) -> dict:
+    return {
+        "choices": [{"message": {"content": content}}],
+        "usage": {"completion_tokens": 3},
+    }
+
+
+def _run_args(tmp_path, *selection: str) -> tuple[list[str], object]:
+    mock_path = tmp_path / "mock.json"
+    result_path = tmp_path / "result.json"
+    mock_path.write_text(
+        json.dumps(
+            {
+                "SO-01": _response('{"title":"The Great Gatsby","year":1925}'),
+                "RM-04": _response("ANSWER: not-correct"),
+            }
+        )
+    )
+    args = [
+        "run",
+        "--endpoint",
+        "mock",
+        "--model",
+        "mock",
+        "--measured-tps",
+        "100",
+        "--mock-responses-from-json",
+        str(mock_path),
+        "--save-json",
+        str(result_path),
+    ]
+    for value in selection:
+        args.extend(["--scenario", value])
+    return args, result_path
+
+
+def test_parse_scenarios_file_supports_comments_and_deduplicates(tmp_path):
+    source = tmp_path / "selection.txt"
+    source.write_text(
+        "# targeted checks\n"
+        "cli-40/CLI-34  # safety case\n"
+        "\n"
+        "reasonmath-15/RM-04\n"
+        "cli-40/CLI-34\n"
+    )
+
+    assert requested_ids([], str(source)) == [
+        "cli-40/CLI-34",
+        "reasonmath-15/RM-04",
+    ]
+    assert parse_scenarios_file(source)[0] == "cli-40/CLI-34"
+
+
+def test_validate_selection_reports_near_matches():
+    with pytest.raises(ValueError) as exc_info:
+        validate_selection(["cli-40/CLI-034"])
+
+    message = str(exc_info.value)
+    assert "unknown scenario selection" in message
+    assert "near matches:" in message
+    assert "cli-40/CLI-34" in message
+
+
+def test_selection_intersects_with_pack_set():
+    canonical, by_pack = validate_selection(
+        ["structoutput-15/SO-01", "reasonmath-15/RM-04"]
+    )
+
+    filtered, filtered_by_pack = intersect_selection(
+        canonical, by_pack, ["structoutput-15"]
+    )
+
+    assert filtered == ["structoutput-15/SO-01"]
+    assert filtered_by_pack == {"structoutput-15": ["SO-01"]}
+
+
+def test_cli_selection_marks_json_and_stdout_partial(tmp_path, capsys):
+    args, result_path = _run_args(
+        tmp_path,
+        "structoutput-15/SO-01",
+        "reasonmath-15/RM-04",
+    )
+
+    assert main(args) == 0
+
+    output = capsys.readouterr().out
+    data = json.loads(result_path.read_text())
+    assert data["selection"] == [
+        "reasonmath-15/RM-04",
+        "structoutput-15/SO-01",
+    ]
+    assert data["mode"] == "custom"
+    assert data["totals"]["total"] == 2
+    assert {
+        pack["pack_id"]: (pack["scenario_count"], pack["catalog_scenario_count"])
+        for pack in data["packs"]
+    } == {
+        "reasonmath-15": (1, 15),
+        "structoutput-15": (1, 15),
+    }
+    assert "[PARTIAL SELECTION: 2 scenarios]" in output
+    assert "partial — 1 of 15 selected" in output
+
+
+def test_selected_subset_delta_compares_only_selected_scenarios(tmp_path):
+    previous = tmp_path / "previous.json"
+    previous.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "packs": [
+                    {
+                        "pack_id": "reasonmath-15",
+                        "scenarios": [{"id": "RM-04", "passed": True}],
+                    },
+                    {
+                        "pack_id": "structoutput-15",
+                        "scenarios": [
+                            {"id": "SO-01", "passed": True},
+                            {"id": "SO-02", "passed": True},
+                        ],
+                    },
+                ],
+            }
+        )
+    )
+    args, result_path = _run_args(
+        tmp_path,
+        "structoutput-15/SO-01",
+        "reasonmath-15/RM-04",
+    )
+    args.extend(["--previous-result", str(previous)])
+
+    assert main(args) == 0
+
+    data = json.loads(result_path.read_text())
+    assert data["delta"]["total_regressions"] == 1
+    assert data["delta"]["total_stable_pass"] == 1
+    assert data["delta"]["total_dropped"] == 0
+
+
+def test_partial_history_and_rescore_require_explicit_opt_in(tmp_path, capsys):
+    partial = {
+        "selection": ["structoutput-15/SO-01"],
+        "packs": [],
+        "totals": {"passed": 0, "total": 0, "score": 0.0},
+    }
+    history = tmp_path / "history.csv"
+    with pytest.raises(ValueError, match="--allow-partial"):
+        append_run(partial, history)
+    append_run(partial, history, allow_partial=True)
+    assert history.is_file()
+
+    source = tmp_path / "partial.json"
+    source.write_text(json.dumps(partial))
+    assert main(["rescore", str(source)]) == 1
+    assert "--allow-partial" in capsys.readouterr().err


### PR DESCRIPTION
Closes #83.

Adds scenario-level run selection as the shared foundation for resume:

- repeatable `--scenario PACK_ID/SCENARIO_ID`
- newline-delimited `--scenarios-file` with comments
- metadata validation with near-match errors
- intersection with existing pack/mode selectors
- explicit partial-result JSON and human-output labels
- partial-result guards for history/rescore, with `--allow-partial`
- selected-set semantics for `--previous-result` and `--exit-on-regression`

The optional additive fields keep `schema_version=1` and old result JSON readable. The conventional commit subject is the changelog entry; `CHANGELOG.md` remains release-generated per repository policy.

Downstream API consumers: club-3090 `quality-test.sh` can pass these flags through alongside `--previous-result`/`--repeat`, and club-3090 #678 can replace its failed-pack loop with exact failed-scenario selection.

Tests: `pytest -q` (274 passed). `ruff` was not available in the checkout; `py_compile` and `git diff --check` pass.