### PR TITLE
feat(run): add scenario-level persistence and resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,19 @@ Selection alone defines the run set. With `--pack`, `--quick`, `--medium`, `--fu
 
 Selected results are intentionally explicit: JSON includes top-level `selection`, each pack's `scenario_count` is the selected subset, and `catalog_scenario_count` records the complete pack size. Human output labels subset scores `partial`. These are optional additive fields, so `schema_version` remains `1` and older result JSON stays readable. Partial results are refused by history ingestion and `rescore` unless `--allow-partial` is supplied. `--exit-on-regression` is allowed: with `--previous-result` it gates only selected scenario keys, while non-canonical sampling overrides remain blocked as before.
 
+## Incremental persistence and resume
+
+`--incremental` writes one scored scenario per line to a crash-safe sidecar named `<save-json>.partial.jsonl`. On normal completion the journal is folded into the ordinary result JSON and deleted; the final artifact shape and `schema_version` are unchanged. If the process is interrupted, inspect or resume the surviving journal directly:
+
+```bash
+benchlocal-cli run --full --incremental --save-json r.json \
+  --endpoint http://localhost:8010 --model qwen3.6-27b-autoround
+benchlocal-cli inspect r.json.partial.jsonl --failed
+benchlocal-cli run --resume r.json.partial.jsonl
+```
+
+`--resume` also accepts an incomplete or completed result JSON. It reconstructs the original target set, repeat count, thinking mode, sampling, and timeout configuration; internally it runs #83's selection complement for only missing `(pack, scenario, repeat_index)` arms, then merges them in canonical order. Endpoint and model are restored from the journal, while credentials still come from the current CLI/environment. A completed result is a successful no-op with a clear message.
+
 ## Running against a cloud / managed endpoint
 
 The same packs run against any cloud OpenAI-compatible endpoint — a managed API, a router, your own hosted model — for a like-for-like local-vs-cloud comparison (identical prompts, identical verifiers).

--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -141,6 +141,11 @@ def _parser() -> argparse.ArgumentParser:
     run.add_argument("--timeout-scale-down", action="store_true", help="allow dynamic timeout scaling to shrink budgets for faster-than-reference models; off by default")
     run.add_argument("--output", choices=["markdown", "json"], default="markdown", help="output format (default: markdown)")
     run.add_argument("--save-json", help="also save raw JSON results to this path")
+    run.add_argument(
+        "--resume",
+        metavar="RESULTS_JSON_OR_PARTIAL_JSONL",
+        help="resume missing scenarios from a saved result or per-scenario partial journal",
+    )
     run.add_argument("--repeat", type=int, default=1, help="repeat each scenario N times (default: 1)")
     # v0.9.3: incremental progress (#23) — live output during long runs
     run.add_argument(
@@ -152,8 +157,8 @@ def _parser() -> argparse.ArgumentParser:
     run.add_argument(
         "--incremental",
         action="store_true",
-        help="flush partial JSON to --save-json after each pack completes (not just at end). "
-             "Requires --save-json. A crash mid-run preserves whatever packs finished.",
+        help="append each scored scenario to <save-json>.partial.jsonl and fold it into "
+             "the final JSON on success. Requires --save-json; crashes leave the journal readable.",
     )
     run.add_argument(
         "--enable-sandboxed-packs",
@@ -686,6 +691,70 @@ def main(argv: list[str] | None = None) -> int:
             from benchlocal_cli.rescore import rescore_result
             return rescore_result(args.path, args)
 
+        resume_state = None
+        if args.resume:
+            from benchlocal_cli.persistence import load_resume
+
+            resume_state = load_resume(args.resume)
+            conflicting_selector = bool(
+                args.scenario or args.scenarios_file or args.pack or args.quick
+                or args.medium or args.full or args.reasoning_packs or args.reasoning
+                or args.sandboxed_only
+            )
+            if conflicting_selector:
+                raise ValueError("--resume cannot be combined with scenario or pack-set selectors")
+            if args.repeat != 1:
+                raise ValueError("--resume uses the original run repeat count; do not pass --repeat")
+            if args.thinking_override is not None or args.thinking_max_tokens is not None:
+                raise ValueError("--resume uses the original thinking configuration")
+            if any(
+                value is not None
+                for value in (
+                    args.temperature, args.top_p, args.top_k, args.min_p,
+                    args.repeat_penalty, args.max_tokens, args.extra_body,
+                    args.thinking_sampler,
+                )
+            ) or args.sampling_from_server:
+                raise ValueError("--resume uses the original sampling configuration")
+
+            config = resume_state.config
+            args.endpoint = args.endpoint or config.get("endpoint")
+            args.model = args.model or config.get("model")
+            args.save_json = args.save_json or str(resume_state.final_path)
+            args.repeat = int(config.get("repeat") or 1)
+            args.thinking_override = config.get("thinking_override")
+            args.thinking_max_tokens = config.get("thinking_max_tokens")
+            for key, value in (config.get("sampling_overrides") or {}).items():
+                attr = "repeat_penalty" if key == "repeat_penalty" else key.replace("-", "_")
+                if hasattr(args, attr):
+                    setattr(args, attr, value)
+            args.sampling_from_server = config.get("sampling_source") == "server"
+            if config.get("extra_body") is not None:
+                args.extra_body = json.dumps(config["extra_body"])
+            if config.get("thinking_sampler") is not None:
+                args.thinking_sampler = json.dumps(config["thinking_sampler"])
+            args.measured_tps = args.measured_tps or config.get("measured_tps")
+            args.reference_tps = args.reference_tps or config.get("reference_tps")
+            args.timeout_per_case = args.timeout_per_case or config.get("timeout_per_case")
+            args.timeout_scale_down = bool(config.get("timeout_scale_down"))
+            args.enable_sandboxed_packs = bool(config.get("sandboxed_enabled"))
+            args.request_delay = float(config.get("request_delay") or args.request_delay)
+
+            if resume_state.complete:
+                if str(resume_state.source_path).endswith(".partial.jsonl"):
+                    from benchlocal_cli.persistence import finalize_completed_journal
+
+                    finalize_completed_journal(resume_state)
+                    print(
+                        f"benchlocal-cli: resume complete — no scenarios remain; "
+                        f"finalized {resume_state.final_path}"
+                    )
+                else:
+                    print(
+                        f"benchlocal-cli: resume complete — no scenarios remain in {args.resume}"
+                    )
+                return 0
+
         # #65: --reasoning is a deprecated alias for --reasoning-packs.
         if getattr(args, "reasoning", False):
             print(
@@ -706,43 +775,60 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 1
 
-        mode = _mode_from_args(args)
-        if args.sandboxed_only:
-            from benchlocal_cli.runner import SANDBOXED_PACK_IDS
-            pack_ids = list(SANDBOXED_PACK_IDS)
-            mode = "sandboxed-only"
-        elif args.pack:
-            pack_ids = [args.pack]
-        else:
-            pack_ids = PACK_MODES[mode]
-
         from benchlocal_cli.selection import (
             intersect_selection,
             requested_ids,
+            selection_for_packs,
             validate_selection,
         )
-        raw_selection = requested_ids(args.scenario, args.scenarios_file)
-        selection_ids: list[str] | None = None
-        selection_by_pack: dict[str, list[str]] | None = None
-        selection_requested = bool(args.scenario or args.scenarios_file)
-        if selection_requested:
-            if not raw_selection:
-                raise ValueError("scenario selection is empty")
-            selection_ids, selection_by_pack = validate_selection(raw_selection)
-            explicit_pack_set = bool(
-                args.pack or args.quick or args.medium or args.full
-                or args.reasoning_packs or args.reasoning or args.sandboxed_only
-            )
-            selection_ids, selection_by_pack = intersect_selection(
-                selection_ids,
-                selection_by_pack,
-                pack_ids if explicit_pack_set else None,
-            )
-            if explicit_pack_set:
-                pack_ids = [pack_id for pack_id in pack_ids if pack_id in selection_by_pack]
+
+        if resume_state is not None:
+            mode = str(resume_state.config.get("mode") or "custom")
+            pack_ids = [
+                pack_id for pack_id in resume_state.config["pack_ids"]
+                if pack_id in resume_state.missing_by_pack
+            ]
+            selection_ids = resume_state.config.get("result_selection")
+            selection_by_pack = resume_state.missing_by_pack
+            target_selection = list(resume_state.config["target_selection"])
+        else:
+            mode = _mode_from_args(args)
+            if args.sandboxed_only:
+                from benchlocal_cli.runner import SANDBOXED_PACK_IDS
+                pack_ids = list(SANDBOXED_PACK_IDS)
+                mode = "sandboxed-only"
+            elif args.pack:
+                pack_ids = [args.pack]
             else:
-                pack_ids = list(selection_by_pack)
-                mode = "custom"
+                pack_ids = PACK_MODES[mode]
+
+            raw_selection = requested_ids(args.scenario, args.scenarios_file)
+            selection_ids: list[str] | None = None
+            selection_by_pack: dict[str, list[str]] | None = None
+            selection_requested = bool(args.scenario or args.scenarios_file)
+            if selection_requested:
+                if not raw_selection:
+                    raise ValueError("scenario selection is empty")
+                selection_ids, selection_by_pack = validate_selection(raw_selection)
+                explicit_pack_set = bool(
+                    args.pack or args.quick or args.medium or args.full
+                    or args.reasoning_packs or args.reasoning or args.sandboxed_only
+                )
+                selection_ids, selection_by_pack = intersect_selection(
+                    selection_ids,
+                    selection_by_pack,
+                    pack_ids if explicit_pack_set else None,
+                )
+                if explicit_pack_set:
+                    pack_ids = [pack_id for pack_id in pack_ids if pack_id in selection_by_pack]
+                else:
+                    pack_ids = list(selection_by_pack)
+                    mode = "custom"
+            target_selection = (
+                list(selection_ids)
+                if selection_ids is not None
+                else selection_for_packs(pack_ids)[0]
+            )
 
         # --full implies sandboxed packs by default; --no-sandboxed-packs opts out.
         # --sandboxed-only also implies sandbox is enabled (no point otherwise).
@@ -811,60 +897,83 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 1
 
-        # Build progress callbacks (#23)
-        on_pack_complete = None
-        on_scenario_complete = None
-        on_progress_event = None
-
-        if args.progress:
-            on_scenario_complete = _scenario_progress
-            on_progress_event = _sandbox_progress_event
-
-        # For incremental output, we need to track state for partial JSON saves
-        incremental_state = {
-            "packs": [],
-            "started_at": None,
-            "save_path": args.save_json if args.incremental else None,
+        # Per-scenario durability (#82). The journal metadata is repeated on every
+        # line so any intact scored-scenario record is independently recoverable.
+        effective_extra_body = _load_extra_body(args.extra_body)
+        effective_thinking_sampler = _load_thinking_sampler(args.thinking_sampler)
+        run_started_at = (
+            str(resume_state.config.get("started_at"))
+            if resume_state is not None
+            else _utc_now()
+        )
+        run_config = {
+            "schema_version": "1",
+            "runner_version": __version__,
+            "endpoint": args.endpoint,
+            "model": args.model,
+            "mode": mode,
+            "started_at": run_started_at,
+            "pack_ids": (
+                list(resume_state.config["pack_ids"])
+                if resume_state is not None else list(pack_ids)
+            ),
+            "target_selection": target_selection,
+            "result_selection": selection_ids,
+            "repeat": max(1, args.repeat),
+            "thinking_override": args.thinking_override,
+            "thinking_mode": (
+                "force-on" if args.thinking_override is True
+                else "force-off" if args.thinking_override is False
+                else "pack-defaults"
+            ),
+            "thinking_max_tokens": effective_thinking_max,
+            "thinking_sampler": effective_thinking_sampler,
+            "sampling_overrides": sampling_overrides or None,
+            "sampling_source": "server" if args.sampling_from_server else None,
+            "extra_body": effective_extra_body,
+            "timeout_per_case": args.timeout_per_case,
+            "measured_tps": args.measured_tps,
+            "reference_tps": args.reference_tps,
+            "timeout_scale_down": args.timeout_scale_down,
+            "sandboxed_enabled": sandboxed_enabled,
+            "request_delay": args.request_delay,
+            "save_json": args.save_json,
         }
 
+        journal_writer = None
+        journal_path = None
+        incremental_active = bool(args.incremental or resume_state is not None)
+        if incremental_active:
+            from benchlocal_cli.persistence import JournalWriter, sidecar_path
+
+            journal_path = (
+                resume_state.sidecar_path
+                if resume_state is not None
+                else sidecar_path(args.save_json)
+            )
+            append_journal = bool(resume_state is not None and journal_path.is_file())
+            journal_writer = JournalWriter(
+                journal_path,
+                resume_state.config if resume_state is not None else run_config,
+                append=append_journal,
+            )
+
+        def _on_scenario_complete(run: ScenarioRun, index: int, total: int) -> None:
+            if args.progress:
+                _scenario_progress(run, index, total)
+            if journal_writer is not None:
+                journal_writer.append(run, index, total)
+
         def _on_pack_complete_incremental(pack: PackResult) -> None:
-            """Callback for per-pack incremental output (#23)."""
-            # Print the pack line immediately
             print(_pack_line(pack), file=sys.stderr, flush=True)
 
-            # Track for incremental JSON save
-            if incremental_state["save_path"]:
-                incremental_state["packs"].append(pack)
-                # Build a partial RunResult and save it
-                partial_result = RunResult(
-                    schema_version="1",
-                    runner_version=__version__,
-                    endpoint=args.endpoint,
-                    model=args.model,
-                    mode=mode,
-                    started_at=incremental_state["started_at"],
-                    finished_at=_utc_now(),
-                    packs=incremental_state["packs"],
-                    totals=_compute_partial_totals(incremental_state["packs"]),
-                    thinking_enabled=bool(args.thinking_override),
-                    thinking_mode=(
-                        "force-on" if args.thinking_override is True
-                        else "force-off" if args.thinking_override is False
-                        else "pack-defaults"
-                    ),
-                    warnings=[],
-                    sampling_overrides=sampling_overrides or None,
-                    sampling_source="server" if args.sampling_from_server else None,
-                    selection=selection_ids,
-                )
-                try:
-                    with Path(incremental_state["save_path"]).open("w", encoding="utf-8") as handle:
-                        json.dump(partial_result.to_dict(), handle, indent=2, sort_keys=True)
-                except Exception as exc:
-                    print(f"benchlocal-cli: warning — incremental save failed: {exc}", file=sys.stderr)
-
-        if args.progress or args.incremental:
-            on_pack_complete = _on_pack_complete_incremental
+        on_scenario_complete = (
+            _on_scenario_complete if args.progress or journal_writer is not None else None
+        )
+        on_pack_complete = (
+            _on_pack_complete_incremental if args.progress or incremental_active else None
+        )
+        on_progress_event = _sandbox_progress_event if args.progress else None
 
         # Block --exit-on-regression when sampling is non-canonical
         if args.exit_on_regression and (sampling_overrides or args.sampling_from_server):
@@ -875,10 +984,6 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 1
-
-        # Set started_at for incremental saves before runner.run() sets its own
-        if incremental_state["save_path"]:
-            incremental_state["started_at"] = _utc_now()
 
         runner = Runner(
             endpoint=args.endpoint,
@@ -892,7 +997,7 @@ def main(argv: list[str] | None = None) -> int:
             negative_control=args.negative_control_text if args.negative_control else None,
             thinking_enabled=args.thinking_override,
             thinking_max_tokens=effective_thinking_max,
-            extra_body=_load_extra_body(args.extra_body),
+            extra_body=effective_extra_body,
             api_key=args.api_key,
             max_total_tokens=args.max_total_tokens,
             request_delay=args.request_delay,
@@ -907,7 +1012,7 @@ def main(argv: list[str] | None = None) -> int:
             retry_on_timeout=args.retry_on_timeout,
             sampling_overrides=sampling_overrides or None,
             sampling_from_server=args.sampling_from_server,
-            thinking_sampler=_load_thinking_sampler(args.thinking_sampler),
+            thinking_sampler=effective_thinking_sampler,
             on_pack_complete=on_pack_complete,
             on_scenario_complete=on_scenario_complete,
             on_progress_event=on_progress_event,
@@ -919,12 +1024,20 @@ def main(argv: list[str] | None = None) -> int:
                 repeat=max(1, args.repeat),
                 selection=selection_by_pack,
                 selection_ids=selection_ids,
+                completed_repeats=(
+                    resume_state.completed_repeats if resume_state is not None else None
+                ),
+                started_at=run_started_at,
             )
+            if resume_state is not None:
+                from benchlocal_cli.persistence import merge_resume
+
+                result = merge_resume(resume_state, result)
         except _SpendGuardExceeded as exc:
             print(f"\n[spend-guard] {exc}", file=sys.stderr)
             print(
                 f"[spend-guard] run stopped after {exc.tokens_used} tokens (cap {exc.cap}); "
-                "completed packs preserved only if --incremental + --save-json were set.",
+                "completed scenarios are preserved in the partial journal when incremental mode is active.",
                 file=sys.stderr,
             )
             return 2
@@ -951,6 +1064,8 @@ def main(argv: list[str] | None = None) -> int:
         if args.save_json:
             with Path(args.save_json).open("w", encoding="utf-8") as handle:
                 json.dump(result_dict, handle, indent=2, sort_keys=True)
+            if journal_path is not None and journal_path.is_file():
+                journal_path.unlink()
 
         # v0.8 — opt-in history append (--history-file PATH or BENCHLOCAL_HISTORY_FILE env)
         history_path = args.history_file or os.environ.get("BENCHLOCAL_HISTORY_FILE")

--- a/benchlocal_cli/inspect.py
+++ b/benchlocal_cli/inspect.py
@@ -178,9 +178,11 @@ def inspect_result(
     if not path.is_file():
         print(f"benchlocal-cli inspect: file not found: {result_path}", file=sys.stderr)
         return 1
+    from benchlocal_cli.persistence import load_result
+
     try:
-        result = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        result = load_result(path)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"benchlocal-cli inspect: failed to read {result_path}: {exc}", file=sys.stderr)
         return 1
 
@@ -193,8 +195,8 @@ def inspect_result(
             print(f"benchlocal-cli inspect: --diff file not found: {diff_path}", file=sys.stderr)
             return 1
         try:
-            diff_result = json.loads(diff_p.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
+            diff_result = load_result(diff_p)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
             print(f"benchlocal-cli inspect: failed to read --diff: {exc}", file=sys.stderr)
             return 1
         diff_index = _build_index(diff_result)
@@ -412,9 +414,9 @@ def add_inspect_subparser(subparsers) -> None:
     """Wire inspect into the main CLI parser. Imported by cli.py."""
     parser = subparsers.add_parser(
         "inspect",
-        help="surface forensics from a saved RunResult JSON",
+        help="surface forensics from a saved result JSON or partial JSONL journal",
         description=(
-            "Read a saved --save-json output and surface per-scenario "
+            "Read a saved --save-json output or .partial.jsonl journal and surface "
             "details (final response, verifier trace, conversation) "
             "without manual JSON grepping."
         ),
@@ -427,7 +429,7 @@ def add_inspect_subparser(subparsers) -> None:
             "  benchlocal-cli inspect results/run.json --full --format json | jq\n"
         ),
     )
-    parser.add_argument("path", help="path to saved RunResult JSON (--save-json output)")
+    parser.add_argument("path", help="saved RunResult JSON or .partial.jsonl journal")
     parser.add_argument("--scenario", help="show only this scenario id (e.g. HA-01)")
     parser.add_argument("--pack", help="show only scenarios in this pack (e.g. hermesagent-20)")
     parser.add_argument("--failed", action="store_true", help="show only failed scenarios")

--- a/benchlocal_cli/persistence.py
+++ b/benchlocal_cli/persistence.py
@@ -1,0 +1,437 @@
+"""Per-scenario incremental journal and resume reconstruction."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, fields
+from pathlib import Path
+from benchlocal_cli import __version__
+from benchlocal_cli.runner import (
+    PACK_MODES,
+    _latency,
+    _repeat_variance,
+    _utc_now,
+    load_pack,
+    resolve_thinking_enabled,
+)
+from benchlocal_cli.selection import selection_for_packs, validate_selection
+from benchlocal_cli.types import PackResult, RunResult, ScenarioResult, ScenarioRun
+
+JOURNAL_VERSION = "1"
+
+
+def sidecar_path(save_json: str | Path) -> Path:
+    return Path(f"{save_json}.partial.jsonl")
+
+
+def final_path_for(source: str | Path) -> Path:
+    value = str(source)
+    suffix = ".partial.jsonl"
+    return Path(value[: -len(suffix)] if value.endswith(suffix) else value)
+
+
+class JournalWriter:
+    def __init__(self, path: str | Path, run_config: dict, *, append: bool) -> None:
+        self.path = Path(path)
+        self.run_config = dict(run_config)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not append:
+            self.path.write_text("", encoding="utf-8")
+        self._pack_meta: dict[str, dict] = {}
+
+    def append(self, run: ScenarioRun, _index: int, _total: int) -> None:
+        pack_id = str(run.raw_scenario.get("pack_id") or "")
+        if not pack_id:
+            raise ValueError(f"scenario {run.id} is missing pack_id")
+        if pack_id not in self._pack_meta:
+            meta, scenarios = load_pack(pack_id)
+            self._pack_meta[pack_id] = {
+                "pack_id": pack_id,
+                "version": meta["version"],
+                "upstream_commit": meta["upstream_commit"],
+                "catalog_scenario_count": len(scenarios),
+            }
+        record = {
+            "journal_version": JOURNAL_VERSION,
+            "written_at": _utc_now(),
+            "run": self.run_config,
+            "pack": self._pack_meta[pack_id],
+            "scenario": run.to_dict(),
+        }
+        payload = (json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n").encode()
+        fd = os.open(self.path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        try:
+            os.write(fd, payload)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+
+def _read_journal(path: Path) -> list[dict]:
+    records: list[dict] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_number}: invalid partial journal line: {exc}") from exc
+            if not isinstance(record, dict) or record.get("journal_version") != JOURNAL_VERSION:
+                raise ValueError(f"{path}:{line_number}: unsupported partial journal record")
+            if not isinstance(record.get("scenario"), dict):
+                raise ValueError(f"{path}:{line_number}: journal record has no scored scenario")
+            records.append(record)
+    if not records:
+        raise ValueError(f"partial journal is empty: {path}")
+    return records
+
+
+def _scenario_run(data: dict) -> ScenarioRun:
+    result_data = data.get("result") if isinstance(data.get("result"), dict) else data
+    result_names = {item.name for item in fields(ScenarioResult)}
+    result_values = {key: value for key, value in result_data.items() if key in result_names}
+    result_values.setdefault("scenario_id", str(data.get("id") or "?"))
+    result_values.setdefault("passed", bool(data.get("passed")))
+    result_values.setdefault("failure_mode", str(data.get("failure_mode") or "verifier_fail"))
+    result_values.setdefault("detail", str(data.get("detail") or ""))
+    result = ScenarioResult(**result_values)
+
+    run_names = {item.name for item in fields(ScenarioRun)}
+    run_values = {key: value for key, value in data.items() if key in run_names and key != "result"}
+    run_values.setdefault("id", result.scenario_id)
+    run_values.setdefault("raw_scenario", {})
+    run_values.setdefault("raw_response", None)
+    run_values.setdefault("request", {})
+    run_values.setdefault("sampling_params", {})
+    run_values.setdefault("status_code", None)
+    return ScenarioRun(result=result, **run_values)
+
+
+def _aggregate_pack(
+    pack_id: str,
+    runs: list[ScenarioRun],
+    *,
+    scenario_count: int,
+    catalog_scenario_count: int | None,
+    repeat: int,
+    thinking_override: bool | None,
+) -> PackResult:
+    meta, _scenarios = load_pack(pack_id)
+    counted = [run for run in runs if run.result.failure_mode != "verifier_not_implemented"]
+    latencies = [run.result.latency_seconds for run in counted if run.result.latency_seconds > 0]
+
+    if meta.get("_architecture") == "single-scoreboard" and counted:
+        scenario_result = counted[0].result
+        if scenario_result.total_count is not None:
+            passed = scenario_result.passed_count or 0
+            total = scenario_result.total_count
+            score = (
+                scenario_result.pass_rate
+                if scenario_result.pass_rate is not None
+                else (passed / total if total else 0.0)
+            )
+            status = (
+                scenario_result.failure_mode
+                if scenario_result.failure_mode
+                in {
+                    "agent_runner_timeout",
+                    "agent_runner_crashed",
+                    "model_endpoint_unreachable",
+                    "server_error",
+                    "result_json_malformed",
+                }
+                else "ok"
+            )
+            return PackResult(
+                pack_id=pack_id,
+                version=meta["version"],
+                upstream_commit=meta["upstream_commit"],
+                scenario_count=scenario_count,
+                passed=passed,
+                total=total,
+                score=score,
+                latency=_latency(latencies),
+                scenarios=runs,
+                status=status,
+                thinking_enabled=resolve_thinking_enabled(meta, thinking_override),
+                variance=_repeat_variance(runs, repeat),
+                catalog_scenario_count=catalog_scenario_count,
+            )
+
+    passed = sum(1 for run in counted if run.result.passed)
+    total = len(counted)
+    return PackResult(
+        pack_id=pack_id,
+        version=meta["version"],
+        upstream_commit=meta["upstream_commit"],
+        scenario_count=scenario_count,
+        passed=passed,
+        total=total,
+        score=passed / total if total else 0.0,
+        latency=_latency(latencies),
+        scenarios=runs,
+        status="ok" if total else "stubbed",
+        thinking_enabled=resolve_thinking_enabled(meta, thinking_override),
+        variance=_repeat_variance(runs, repeat),
+        catalog_scenario_count=catalog_scenario_count,
+    )
+
+
+def _unique_warnings(*groups: list[str] | None) -> list[str]:
+    return list(dict.fromkeys(item for group in groups for item in (group or [])))
+
+
+def _build_result(
+    config: dict,
+    scenario_rows: list[tuple[str, dict]],
+    *,
+    finished_at: str,
+    warnings: list[str] | None = None,
+    pack_templates: dict[str, PackResult] | None = None,
+) -> RunResult:
+    target_selection = list(config["target_selection"])
+    _canonical, target_by_pack = validate_selection(target_selection)
+    repeat = int(config.get("repeat") or 1)
+    thinking_override = config.get("thinking_override")
+    pack_order = list(config["pack_ids"])
+    rows_by_pack: dict[str, dict[tuple[str, int], ScenarioRun]] = {}
+    for pack_id, row in scenario_rows:
+        run = _scenario_run(row)
+        rows_by_pack.setdefault(pack_id, {})[(run.id, run.repeat_index)] = run
+
+    packs: list[PackResult] = []
+    templates = pack_templates or {}
+    for pack_id in pack_order:
+        scenario_ids = target_by_pack.get(pack_id, [])
+        order = {scenario_id: index for index, scenario_id in enumerate(scenario_ids)}
+        runs = list(rows_by_pack.get(pack_id, {}).values())
+        runs.sort(key=lambda run: (run.repeat_index, order.get(run.id, len(order))))
+        if not runs and pack_id in templates:
+            packs.append(templates[pack_id])
+            continue
+        _meta, catalog = load_pack(pack_id)
+        packs.append(
+            _aggregate_pack(
+                pack_id,
+                runs,
+                scenario_count=len(scenario_ids),
+                catalog_scenario_count=(
+                    len(catalog) if config.get("result_selection") is not None else None
+                ),
+                repeat=repeat,
+                thinking_override=thinking_override,
+            )
+        )
+
+    total = sum(pack.total for pack in packs)
+    passed = sum(pack.passed for pack in packs)
+    return RunResult(
+        schema_version=str(config.get("schema_version") or "1"),
+        runner_version=str(config.get("runner_version") or __version__),
+        endpoint=str(config.get("endpoint") or ""),
+        model=str(config.get("model") or ""),
+        mode=str(config.get("mode") or "custom"),
+        started_at=str(config.get("started_at") or _utc_now()),
+        finished_at=finished_at,
+        packs=packs,
+        totals={"passed": passed, "total": total, "score": passed / total if total else 0.0},
+        thinking_enabled=bool(thinking_override),
+        thinking_mode=str(config.get("thinking_mode") or "pack-defaults"),
+        warnings=warnings or [],
+        sampling_overrides=config.get("sampling_overrides"),
+        sampling_source=config.get("sampling_source"),
+        server_defaults=config.get("server_defaults"),
+        selection=config.get("result_selection"),
+    )
+
+
+def result_from_journal(path: str | Path) -> dict:
+    records = _read_journal(Path(path))
+    config = records[0]["run"]
+    rows = [(str(record["pack"]["pack_id"]), record["scenario"]) for record in records]
+    result = _build_result(
+        config,
+        rows,
+        finished_at=str(records[-1].get("written_at") or _utc_now()),
+        warnings=["partial per-scenario journal; run is incomplete"],
+    )
+    return result.to_dict()
+
+
+def load_result(path: str | Path) -> dict:
+    source = Path(path)
+    if not source.is_file():
+        raise FileNotFoundError(f"result not found: {path}")
+    if str(source).endswith(".partial.jsonl"):
+        return result_from_journal(source)
+    try:
+        data = json.loads(source.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return result_from_journal(source)
+    if not isinstance(data, dict):
+        raise ValueError(f"result JSON must be an object: {path}")
+    return data
+
+
+def _infer_config(data: dict, source: Path) -> dict:
+    packs = [pack for pack in data.get("packs") or [] if isinstance(pack, dict)]
+    mode = str(data.get("mode") or "custom")
+    result_selection = data.get("selection")
+    if result_selection is not None:
+        target_selection, target_by_pack = validate_selection(result_selection)
+        pack_ids = list(target_by_pack)
+    else:
+        present_pack_ids = [str(pack.get("pack_id")) for pack in packs if pack.get("pack_id")]
+        pack_ids = list(PACK_MODES.get(mode) or present_pack_ids)
+        target_selection, _target_by_pack = selection_for_packs(pack_ids)
+    repeat = max(
+        (
+            int(run.get("repeat_index") or 1)
+            for pack in packs
+            for run in pack.get("scenarios") or []
+            if isinstance(run, dict)
+        ),
+        default=1,
+    )
+    thinking_mode = str(data.get("thinking_mode") or "pack-defaults")
+    thinking_override = True if thinking_mode == "force-on" else False if thinking_mode == "force-off" else None
+    return {
+        "schema_version": str(data.get("schema_version") or "1"),
+        "runner_version": str(data.get("runner_version") or __version__),
+        "endpoint": data.get("endpoint"),
+        "model": data.get("model"),
+        "mode": mode,
+        "started_at": data.get("started_at"),
+        "pack_ids": pack_ids,
+        "target_selection": target_selection,
+        "result_selection": result_selection,
+        "repeat": repeat,
+        "thinking_override": thinking_override,
+        "thinking_mode": thinking_mode,
+        "sampling_overrides": data.get("sampling_overrides"),
+        "sampling_source": data.get("sampling_source"),
+        "server_defaults": data.get("server_defaults"),
+        "save_json": str(final_path_for(source)),
+    }
+
+
+@dataclass
+class ResumeState:
+    source_path: Path
+    final_path: Path
+    sidecar_path: Path
+    config: dict
+    previous_result: dict
+    missing_selection: list[str]
+    missing_by_pack: dict[str, list[str]]
+    completed_repeats: dict[str, dict[str, set[int]]]
+
+    @property
+    def complete(self) -> bool:
+        return not self.missing_selection
+
+
+def load_resume(path: str | Path) -> ResumeState:
+    source = Path(path)
+    if not source.is_file():
+        raise FileNotFoundError(f"--resume not found: {path}")
+    if str(source).endswith(".partial.jsonl"):
+        records = _read_journal(source)
+        config = dict(records[0]["run"])
+        previous_result = result_from_journal(source)
+        final_path = final_path_for(source)
+        journal_path = source
+    else:
+        previous_result = load_result(source)
+        config = _infer_config(previous_result, source)
+        final_path = source
+        journal_path = sidecar_path(final_path)
+
+    target_selection, target_by_pack = validate_selection(config["target_selection"])
+    config["target_selection"] = target_selection
+    config.setdefault("pack_ids", list(target_by_pack))
+    config.setdefault("result_selection", previous_result.get("selection"))
+    config.setdefault("repeat", 1)
+    config.setdefault("save_json", str(final_path))
+
+    completed: dict[str, dict[str, set[int]]] = {}
+    for pack in previous_result.get("packs") or []:
+        pack_id = str(pack.get("pack_id") or "")
+        for row in pack.get("scenarios") or []:
+            scenario_id = str(row.get("id") or "")
+            completed.setdefault(pack_id, {}).setdefault(scenario_id, set()).add(
+                int(row.get("repeat_index") or 1)
+            )
+
+    repeat = int(config["repeat"])
+    missing = [
+        qualified
+        for qualified in target_selection
+        if len(
+            completed.get(qualified.split("/", 1)[0], {}).get(
+                qualified.split("/", 1)[1], set()
+            )
+        )
+        < repeat
+    ]
+    missing, missing_by_pack = validate_selection(missing) if missing else ([], {})
+    return ResumeState(
+        source_path=source,
+        final_path=final_path,
+        sidecar_path=journal_path,
+        config=config,
+        previous_result=previous_result,
+        missing_selection=missing,
+        missing_by_pack=missing_by_pack,
+        completed_repeats=completed,
+    )
+
+
+def finalize_completed_journal(state: ResumeState) -> dict:
+    result = json.loads(json.dumps(state.previous_result))
+    result["warnings"] = [
+        warning
+        for warning in result.get("warnings") or []
+        if warning != "partial per-scenario journal; run is incomplete"
+    ]
+    state.final_path.parent.mkdir(parents=True, exist_ok=True)
+    state.final_path.write_text(
+        json.dumps(result, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    state.sidecar_path.unlink()
+    return result
+
+
+def merge_resume(state: ResumeState, new_result: RunResult) -> RunResult:
+    rows: list[tuple[str, dict]] = []
+    for source in (state.previous_result, new_result.to_dict()):
+        for pack in source.get("packs") or []:
+            pack_id = str(pack.get("pack_id") or "")
+            rows.extend((pack_id, row) for row in pack.get("scenarios") or [])
+
+    templates = {
+        pack.pack_id: pack
+        for pack in new_result.packs
+        if pack.skipped or not pack.scenarios
+    }
+    config = dict(state.config)
+    config["runner_version"] = new_result.runner_version
+    config["server_defaults"] = new_result.server_defaults
+    previous_warnings = [
+        warning
+        for warning in state.previous_result.get("warnings") or []
+        if warning != "partial per-scenario journal; run is incomplete"
+    ]
+    return _build_result(
+        config,
+        rows,
+        finished_at=new_result.finished_at,
+        warnings=_unique_warnings(
+            previous_warnings,
+            new_result.warnings,
+        ),
+        pack_templates=templates,
+    )

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -473,8 +473,10 @@ class Runner:
         repeat: int = 1,
         selection: dict[str, list[str]] | None = None,
         selection_ids: list[str] | None = None,
+        completed_repeats: dict[str, dict[str, set[int]]] | None = None,
+        started_at: str | None = None,
     ) -> RunResult:
-        started_at = _utc_now()
+        started_at = started_at or _utc_now()
         warnings: list[str] = []
         old_sigint = signal.getsignal(signal.SIGINT)
         old_sigterm = signal.getsignal(signal.SIGTERM)
@@ -501,6 +503,7 @@ class Runner:
                     repeat=repeat,
                     warnings=warnings,
                     scenario_ids=selection.get(pack_id) if selection is not None else None,
+                    completed_repeats=(completed_repeats or {}).get(pack_id),
                 )
                 pack_results.append(pack_result)
                 if self._on_pack_complete is not None:
@@ -857,6 +860,7 @@ class Runner:
         repeat: int = 1,
         warnings: list[str] | None = None,
         scenario_ids: list[str] | None = None,
+        completed_repeats: dict[str, set[int]] | None = None,
     ) -> PackResult:
         meta, scenarios = load_pack(pack_id)
         catalog_scenario_count = len(scenarios)
@@ -926,10 +930,18 @@ class Runner:
             )
 
         runs: list[ScenarioRun] = []
-        total_scenarios = len(scenarios) * repeat
+        completed_repeats = completed_repeats or {}
+        total_scenarios = sum(
+            1
+            for repeat_index in range(1, repeat + 1)
+            for scenario in scenarios
+            if repeat_index not in completed_repeats.get(scenario["id"], set())
+        )
         scenario_index = 0
         for repeat_index in range(1, repeat + 1):
             for scenario in scenarios:
+                if repeat_index in completed_repeats.get(scenario["id"], set()):
+                    continue
                 scenario_index += 1
                 run = self.run_scenario(meta, scenario, repeat_index=repeat_index)
                 runs.append(run)

--- a/benchlocal_cli/selection.py
+++ b/benchlocal_cli/selection.py
@@ -73,6 +73,18 @@ def validate_selection(values: Iterable[str]) -> tuple[list[str], dict[str, list
     return canonical, by_pack
 
 
+def selection_for_packs(pack_ids: Iterable[str]) -> tuple[list[str], dict[str, list[str]]]:
+    allowed = set(pack_ids)
+    pack_order, catalog = scenario_catalog()
+    selected = [
+        f"{pack_id}/{scenario_id}"
+        for pack_id in pack_order
+        if pack_id in allowed
+        for scenario_id in catalog[pack_id]
+    ]
+    return validate_selection(selected)
+
+
 def intersect_selection(
     canonical: list[str],
     by_pack: dict[str, list[str]],

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from benchlocal_cli.cli import main
+from benchlocal_cli.runner import Runner
+
+
+def _response(content: str) -> dict:
+    return {
+        "choices": [{"message": {"content": content}}],
+        "usage": {"completion_tokens": 3},
+    }
+
+
+def _base_args(tmp_path: Path, result_path: Path) -> list[str]:
+    mock_path = tmp_path / "mock.json"
+    mock_path.write_text(
+        json.dumps(
+            {
+                "SO-01": _response('{"title":"The Great Gatsby","year":1925}'),
+                "SO-04": _response("[package]\nname = \"my_cli\""),
+            }
+        )
+    )
+    return [
+        "run",
+        "--scenario",
+        "structoutput-15/SO-01",
+        "--scenario",
+        "structoutput-15/SO-04",
+        "--endpoint",
+        "mock",
+        "--model",
+        "mock",
+        "--measured-tps",
+        "100",
+        "--repeat",
+        "2",
+        "--mock-responses-from-json",
+        str(mock_path),
+        "--save-json",
+        str(result_path),
+    ]
+
+
+def _without_timestamps(data: dict) -> dict:
+    copied = json.loads(json.dumps(data))
+    copied.pop("started_at", None)
+    copied.pop("finished_at", None)
+    return copied
+
+
+def test_kill_mid_run_journal_inspect_resume_matches_reference(
+    tmp_path, monkeypatch, capsys
+):
+    # Mock scoring latency is normally real wall time. Freeze it so two logically
+    # identical mock runs can be compared with only timestamps removed.
+    monkeypatch.setattr("benchlocal_cli.runner.time.perf_counter", lambda: 1.0)
+
+    reference_path = tmp_path / "reference.json"
+    assert main(_base_args(tmp_path, reference_path)) == 0
+    capsys.readouterr()
+
+    resumed_path = tmp_path / "resumed.json"
+    interrupted_args = _base_args(tmp_path, resumed_path) + ["--incremental"]
+    original_run_scenario = Runner.run_scenario
+    calls = 0
+
+    def interrupt_after_two(self, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 3:
+            raise KeyboardInterrupt
+        return original_run_scenario(self, *args, **kwargs)
+
+    monkeypatch.setattr(Runner, "run_scenario", interrupt_after_two)
+    with pytest.raises(KeyboardInterrupt):
+        main(interrupted_args)
+    monkeypatch.setattr(Runner, "run_scenario", original_run_scenario)
+
+    sidecar = Path(f"{resumed_path}.partial.jsonl")
+    assert sidecar.is_file()
+    records = [json.loads(line) for line in sidecar.read_text().splitlines()]
+    assert len(records) == 2
+    assert all(record["journal_version"] == "1" for record in records)
+    assert [(record["scenario"]["id"], record["scenario"]["repeat_index"]) for record in records] == [
+        ("SO-01", 1),
+        ("SO-04", 1),
+    ]
+
+    assert main(["inspect", str(sidecar), "--format", "json"]) == 0
+    inspected = json.loads(capsys.readouterr().out)
+    assert {(row["id"], row["repeat_index"]) for row in inspected} == {
+        ("SO-01", 1),
+        ("SO-04", 1),
+    }
+
+    mock_path = tmp_path / "mock.json"
+    assert main(
+        [
+            "run",
+            "--resume",
+            str(sidecar),
+            "--mock-responses-from-json",
+            str(mock_path),
+        ]
+    ) == 0
+
+    assert not sidecar.exists()
+    resumed = json.loads(resumed_path.read_text())
+    reference = json.loads(reference_path.read_text())
+    assert _without_timestamps(resumed) == _without_timestamps(reference)
+    assert [
+        (row["id"], row["repeat_index"])
+        for row in resumed["packs"][0]["scenarios"]
+    ] == [
+        ("SO-01", 1),
+        ("SO-04", 1),
+        ("SO-01", 2),
+        ("SO-04", 2),
+    ]
+
+
+def test_resume_completed_result_is_clear_noop(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("benchlocal_cli.runner.time.perf_counter", lambda: 1.0)
+    result_path = tmp_path / "complete.json"
+    assert main(_base_args(tmp_path, result_path)) == 0
+    capsys.readouterr()
+
+    assert main(["run", "--resume", str(result_path)]) == 0
+    output = capsys.readouterr().out
+    assert "resume complete" in output
+    assert "no scenarios remain" in output
+
+def test_resume_complete_sidecar_finalizes_without_model_call(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setattr("benchlocal_cli.runner.time.perf_counter", lambda: 1.0)
+    result_path = tmp_path / "crashed-after-last.json"
+    args = _base_args(tmp_path, result_path) + ["--incremental"]
+    original_run = Runner.run
+
+    def crash_after_last_scenario(self, *run_args, **run_kwargs):
+        original_run(self, *run_args, **run_kwargs)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(Runner, "run", crash_after_last_scenario)
+    with pytest.raises(KeyboardInterrupt):
+        main(args)
+    monkeypatch.setattr(Runner, "run", original_run)
+
+    sidecar = Path(f"{result_path}.partial.jsonl")
+    assert sidecar.is_file()
+    assert not result_path.exists()
+    assert len(sidecar.read_text().splitlines()) == 4
+
+    assert main(["run", "--resume", str(sidecar)]) == 0
+    output = capsys.readouterr().out
+    assert "no scenarios remain" in output
+    assert f"finalized {result_path}" in output
+    assert result_path.is_file()
+    assert not sidecar.exists()
+    assert json.loads(result_path.read_text())["totals"] == {
+        "passed": 4,
+        "score": 1.0,
+        "total": 4,
+    }


### PR DESCRIPTION
Closes #82.

Stacked on #84 because resume consumes the scenario-selection engine introduced for #83.

- extends `--incremental` from pack snapshots to an fsynced `<save-json>.partial.jsonl` journal with one scored scenario per line
- `run --resume <results.json|partial.jsonl>` computes the missing scenario/repeat complement and skips completed repeat arms
- restores the original repeat, thinking, sampling, timeout, pack-set, and selection configuration
- merges old and new scenarios into the normal final `RunResult` shape, then removes the sidecar
- finalizes a complete sidecar without another model call
- makes `inspect` auto-detect partial JSONL journals
- leaves `schema_version=1` and old result JSON readable

The conventional commit subject is the changelog entry; `CHANGELOG.md` remains release-generated per repository policy.

Downstream API consumers: club-3090 `quality-test.sh` can pass `--incremental`/`--resume` through, and club-3090 #678 can combine resume durability with exact failed-scenario selection after #84 lands.

Verification:

- `python3 -m pytest -q`: 277 passed
- kill-mid-run mock simulation: 2 valid journal records, inspect succeeds, resume executes only missing repeat arms, final JSON equals uninterrupted reference modulo timestamps
- crash after final scenario: resume folds the complete sidecar without a model call
- completed result resume: clear successful no-op
- `py_compile` and `git diff --check` pass
- `ruff` is not installed in this checkout