### PR TITLE
fix(hermes): support thinking-only endpoints

### DIFF
--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -830,10 +830,11 @@ class Runner:
                 "temperature": 0,
                 "top_p": 1,
                 "max_tokens": 200,
-                # Probe content-decode TPS deterministically: force thinking OFF so
-                # we never measure reasoning-decode rate on a server whose chat
-                # template defaults to reasoning when no toggle is sent (#54).
-                "chat_template_kwargs": {"enable_thinking": False},
+                # Probe content-decode TPS with the same universal near-off
+                # mapping as Hermes. Thinking-only endpoints reject false, while
+                # a one-token budget avoids measuring reasoning-decode rate.
+                "chat_template_kwargs": {"enable_thinking": True},
+                "thinking_budget": 1,
             }
             started = time.perf_counter()
             # The probe must never be the thing that hangs a run: bounded read
@@ -1394,6 +1395,15 @@ class Runner:
                     "model_name": self.model,
                     "model_api_key": self.api_key or "dummy",  # forward the real key for cloud endpoints; "dummy" for local vLLM (doesn't validate)
                     "sampling": dict(sampling),
+                    # HermesAgent makes its own model calls, so the resolved
+                    # thinking mode and arm budget must cross the sandbox
+                    # protocol explicitly. They are not generation overrides.
+                    "enable_thinking": bool(
+                        dict(sampling.get("chat_template_kwargs") or {}).get(
+                            "enable_thinking", False
+                        )
+                    ),
+                    "thinking_budget": self.thinking_max_tokens,
                 }
             elif pack_id == "aider-polyglot-30":
                 # v0.9.0: aider needs a container-reachable URL. Apply the

--- a/benchlocal_cli/sandbox.py
+++ b/benchlocal_cli/sandbox.py
@@ -438,6 +438,8 @@ class SandboxClient:
         model_name: str | None = None,
         model_api_key: str | None = None,
         sampling: dict | None = None,
+        enable_thinking: bool | None = None,
+        thinking_budget: int | None = None,
     ) -> dict:
         """Initialize a sandbox-owned multi-turn scenario state.
 
@@ -458,6 +460,10 @@ class SandboxClient:
             payload["model_api_key"] = model_api_key
         if sampling is not None:
             payload["sampling"] = sampling
+        if enable_thinking is not None:
+            payload["enable_thinking"] = enable_thinking
+        if thinking_budget is not None:
+            payload["thinking_budget"] = thinking_budget
         return self._post("/verify-start", payload)
 
     def verify_multiturn_turn(self, scenario_state_id: str, model_response: dict) -> dict:

--- a/docs/SANDBOX_PROTOCOL.md
+++ b/docs/SANDBOX_PROTOCOL.md
@@ -133,10 +133,22 @@ POST /verify-end       # explicit "model gave up" or runner hit turn limit
 ## Hermes-specific: v0.7.3 model-endpoint passthrough
 
 Hermes `/verify-start` requires the runner to pass `model_endpoint`,
-`model_name`, optional `model_api_key` (default `"dummy"` for vLLM), and
-`sampling` (the same dict the runner uses for direct chat-completions calls).
-Upstream `agent-runner.py` makes its own LLM calls against this endpoint, so
-the bench is testing the *real* agent loop against the *real* model under test.
+`model_name`, optional `model_api_key` (default `"dummy"` for vLLM), `sampling`
+(the same dict the runner uses for direct chat-completions calls), and the
+resolved `enable_thinking` and `thinking_budget` values. Upstream
+`agent-runner.py` makes its own LLM calls against this endpoint, so the bench is
+testing the *real* agent loop against the *real* model under test.
+
+The Hermes adapter writes the resolved thinking controls to `extra_body` for
+the primary model and every auxiliary model (`session_search`, `web_extract`,
+and `approval`). It also passes the primary model's `extra_body` directly to
+the programmatic `AIAgent` request path. Thinking-only endpoints cannot accept
+`enable_thinking: false`, so BenchLocal represents the off arm as
+`enable_thinking: true` with `thinking_budget: 1`; the on arm uses the requested
+budget.
+The decode-TPS probe uses the same one-token mapping so timeout calibration
+does not send a forbidden false value before a thinking-only run.
+
 
 If `model_endpoint` is missing from the request body, the sandbox returns
 `server_error` with a message asking to upgrade to v0.7.3+.

--- a/sandboxes/hermes/server.py
+++ b/sandboxes/hermes/server.py
@@ -82,6 +82,11 @@ UPSTREAM_RAW_MAX_BYTES = 16384
 # upstream_status/upstream_score/etc. instead of grading.tool_event_count.
 SCHEMA_VERSION = "2"
 
+# Thinking-only endpoints reject enable_thinking=false. Hermes therefore
+# emulates its off arm with one reasoning token instead of sending false.
+THINKING_BUDGET_FLOOR = 1
+DEFAULT_THINKING_BUDGET = 16384
+
 
 def _commit_from_path(path: Path) -> str:
     if not path.is_dir():
@@ -142,7 +147,7 @@ def _endpoint_failure_reason(endpoint: str, exc: Exception) -> str:
     return f"could not reach {endpoint}: {text}"
 
 
-def _detect_model_endpoint_reachable(endpoint: str) -> dict:
+def _detect_model_endpoint_reachable(endpoint: str, api_key: str | None = None) -> dict:
     """Cached sanity check that the sandbox can reach the model endpoint."""
     global _MODEL_ENDPOINT_REACHABLE_CACHE
     if _MODEL_ENDPOINT_REACHABLE_CACHE is not None:
@@ -151,9 +156,12 @@ def _detect_model_endpoint_reachable(endpoint: str) -> dict:
         _MODEL_ENDPOINT_REACHABLE_CACHE = {"ok": False, "reason": "no model endpoint provided to sandbox"}
         return _MODEL_ENDPOINT_REACHABLE_CACHE
     probe_url = _model_models_url(endpoint)
+    headers = {}
+    if api_key and api_key != "dummy":
+        headers["Authorization"] = f"Bearer {api_key}"
     try:
         with httpx.Client(timeout=5.0, follow_redirects=True, max_redirects=1) as client:
-            resp = client.get(probe_url)
+            resp = client.get(probe_url, headers=headers)
         if resp.status_code != 200:
             _MODEL_ENDPOINT_REACHABLE_CACHE = {
                 "ok": False,
@@ -283,11 +291,41 @@ def _filter_generation(sampling: dict | None) -> dict:
     return out
 
 
+def _thinking_extra_body(req: dict) -> dict:
+    """Build HermesAgent's provider-specific request body.
+
+    Thinking controls deliberately bypass _filter_generation: the pinned
+    framework consumes them as extra_body, not generation overrides.
+    """
+    enabled = req.get("enable_thinking")
+    sampling = req.get("sampling") or {}
+    if not isinstance(enabled, bool):
+        chat_template_kwargs = sampling.get("chat_template_kwargs") or {}
+        enabled = bool(chat_template_kwargs.get("enable_thinking", False))
+
+    budget = req.get("thinking_budget")
+    if isinstance(budget, bool) or not isinstance(budget, int) or budget < 1:
+        sampling_budget = sampling.get("max_tokens")
+        budget = (
+            sampling_budget
+            if isinstance(sampling_budget, int)
+            and not isinstance(sampling_budget, bool)
+            and sampling_budget > 0
+            else DEFAULT_THINKING_BUDGET
+        )
+
+    return {
+        "enable_thinking": True,
+        "thinking_budget": budget if enabled else THINKING_BUDGET_FLOOR,
+    }
+
+
 def _translate_request(req: dict) -> dict:
     """Map runner's /verify-start payload → upstream's POST /run-scenario shape.
 
     Runner sends:
-      { scenario_id, scenario, model_endpoint, model_name, model_api_key, sampling }
+      { scenario_id, scenario, model_endpoint, model_name, model_api_key,
+        sampling, enable_thinking, thinking_budget }
 
     Upstream expects:
       { scenarioId, runId, model: {id, exposedModel, providerModel,
@@ -309,6 +347,7 @@ def _translate_request(req: dict) -> dict:
             "apiKey": str(req.get("model_api_key") or "dummy"),
             "provider": "custom",
             "authMode": "bearer",
+            "extraBody": _thinking_extra_body(req),
         },
         "generation": _filter_generation(req.get("sampling")),
     }
@@ -507,7 +546,10 @@ def _verify_start_via_upstream(req: dict) -> dict:
     if not _upstream_node_ready():
         return _upstream_unreachable_response(scenario_id, "/health probe failed")
 
-    reach = _detect_model_endpoint_reachable(str(req.get("model_endpoint") or ""))
+    reach = _detect_model_endpoint_reachable(
+        str(req.get("model_endpoint") or ""),
+        str(req.get("model_api_key") or ""),
+    )
     if not reach.get("ok"):
         return _endpoint_preflight_response(scenario_id, reach)
 

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -294,7 +294,7 @@ def test_runner_explicit_timeout_per_case_disables_dynamic_scaling(monkeypatch):
     assert runner._timeout_budget_for_meta({"timeout_per_case_default": 300, "timeout_reference_tps": 100}) == 45
 
 
-def test_probe_sends_enable_thinking_false(monkeypatch):
+def test_probe_clamps_thinking_to_one_token(monkeypatch):
     runner = Runner(endpoint="http://localhost:9999", model="fake")
     requests = []
 
@@ -311,7 +311,8 @@ def test_probe_sends_enable_thinking_false(monkeypatch):
 
     assert runner._probe_decode_tps() == 50.0
     assert len(requests) == 3
-    assert all(req["chat_template_kwargs"] == {"enable_thinking": False} for req in requests)
+    assert all(req["chat_template_kwargs"] == {"enable_thinking": True} for req in requests)
+    assert all(req["thinking_budget"] == 1 for req in requests)
 
 
 def test_thinking_multiplier_applies_without_timeout_reference():
@@ -822,11 +823,19 @@ def test_runner_preserves_hermes_non_loopback_endpoint_without_env(monkeypatch):
     assert run.result.passed is True
     assert fake.start_kwargs["model_endpoint"] == "http://host.docker.internal:9999/v1"
 
-def test_runner_uses_hermes_verify_start_early_out_and_passes_endpoint():
+@pytest.mark.parametrize(
+    ("thinking_enabled", "thinking_budget", "expected_temperature"),
+    [(False, 16384, 0.0), (True, 4096, 1.0)],
+)
+def test_runner_uses_hermes_verify_start_early_out_and_passes_endpoint(
+    thinking_enabled, thinking_budget, expected_temperature
+):
     runner = Runner(
         endpoint="http://10.0.0.5:8001",
         model="qwen3.6-27b-autoround",
         enable_sandboxed_packs=True,
+        thinking_enabled=thinking_enabled,
+        thinking_max_tokens=thinking_budget,
     )
     fake = FakeHermesEarlyOutSandbox()
     runner._sandbox_clients["hermesagent-20"] = fake
@@ -854,8 +863,12 @@ def test_runner_uses_hermes_verify_start_early_out_and_passes_endpoint():
     assert fake.start_kwargs["model_endpoint"] == "http://10.0.0.5:8001"
     assert fake.start_kwargs["model_name"] == "qwen3.6-27b-autoround"
     assert fake.start_kwargs["model_api_key"] == "dummy"
-    assert fake.start_kwargs["sampling"]["temperature"] == 0.0
-    assert fake.start_kwargs["sampling"]["max_tokens"] == 256
+    assert fake.start_kwargs["sampling"]["temperature"] == expected_temperature
+    expected_max_tokens = thinking_budget if thinking_enabled else 256
+    assert fake.start_kwargs["sampling"]["max_tokens"] == expected_max_tokens
+    assert fake.start_kwargs["enable_thinking"] is thinking_enabled
+    assert fake.start_kwargs["thinking_budget"] == thinking_budget
+
     # verifier_trace populated from upstream payload — preserves the
     # `trace` sub-dict the sandbox returned (one level of nesting because
     # the runner strips top-level action/passed/failure_mode/detail keys).

--- a/tests/test_sandbox_verifiers.py
+++ b/tests/test_sandbox_verifiers.py
@@ -5,6 +5,8 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -57,6 +59,7 @@ class _FakeHTTPClient:
         self.response = response or _FakeHTTPResponse()
         self.exc = exc
         self.urls: list[str] = []
+        self.headers: list[dict] = []
 
     def __call__(self, **_kwargs):
         return self
@@ -67,8 +70,9 @@ class _FakeHTTPClient:
     def __exit__(self, exc_type, exc, tb) -> None:
         return None
 
-    def get(self, url: str):
+    def get(self, url: str, *, headers: dict | None = None):
         self.urls.append(url)
+        self.headers.append(headers or {})
         if self.exc:
             raise self.exc
         return self.response
@@ -196,11 +200,12 @@ def test_hermes_detect_model_endpoint_reachable_ok(monkeypatch):
     monkeypatch.setattr(server, "_MODEL_ENDPOINT_REACHABLE_CACHE", None)
     monkeypatch.setattr(server.httpx, "Client", fake_client)
 
-    out = server._detect_model_endpoint_reachable("http://host:8000/v1/chat/completions")
+    out = server._detect_model_endpoint_reachable("http://host:8000/v1/chat/completions", "sk-test")
 
     assert out["ok"] is True
     assert out["probe_url"] == "http://host:8000/v1/models"
     assert fake_client.urls == ["http://host:8000/v1/models"]
+    assert fake_client.headers == [{"Authorization": "Bearer sk-test"}]
 
 
 def test_hermes_detect_model_endpoint_reachable_fails_on_refused(monkeypatch):
@@ -213,6 +218,7 @@ def test_hermes_detect_model_endpoint_reachable_fails_on_refused(monkeypatch):
 
     assert out["ok"] is False
     assert "model server not running" in out["reason"]
+    assert fake_client.headers == [{}]
 
 
 def test_hermes_detect_model_endpoint_reachable_fails_on_timeout(monkeypatch):
@@ -256,7 +262,7 @@ def test_hermes_verify_start_fails_fast_on_unreachable_endpoint(monkeypatch, tmp
     monkeypatch.setattr(
         server,
         "_detect_model_endpoint_reachable",
-        lambda endpoint: {"ok": False, "reason": f"model server not running at {endpoint}"},
+        lambda endpoint, api_key=None: {"ok": False, "reason": f"model server not running at {endpoint}"},
     )
 
     def fail_post(*_args, **_kwargs):
@@ -340,6 +346,8 @@ def test_hermes_translate_request_normalizes_endpoint_and_filters_generation():
         "model_name": "qwen3.6-27b-autoround",
         "model_api_key": "sk-test",
         "sampling": {"temperature": 0.6, "top_p": 0.95, "max_tokens": 256, "ignored": "x"},
+        "enable_thinking": True,
+        "thinking_budget": 4096,
     }
     out = server._translate_request(req)
     assert out["scenarioId"] == "HA-01"
@@ -348,6 +356,54 @@ def test_hermes_translate_request_normalizes_endpoint_and_filters_generation():
     assert out["model"]["apiKey"] == "sk-test"
     assert out["generation"] == {"temperature": 0.6, "top_p": 0.95, "max_tokens": 256}
     assert "runId" in out and len(out["runId"]) > 0
+    assert out["model"]["extraBody"] == {"enable_thinking": True, "thinking_budget": 4096}
+
+
+@pytest.mark.parametrize(
+    ("thinking_enabled", "expected_budget"),
+    [(True, 4096), (False, 1)],
+)
+def test_hermes_config_emits_thinking_extra_body_for_all_models(
+    tmp_path, thinking_enabled, expected_budget
+):
+    server = _hermes_server()
+    translated = server._translate_request(
+        {
+            "scenario_id": "HA-01",
+            "scenario": {"id": "HA-01"},
+            "model_endpoint": "http://host:8001/v1",
+            "model_name": "qwen",
+            "sampling": {},
+            "enable_thinking": thinking_enabled,
+            "thinking_budget": 4096,
+        }
+    )
+    script = r'''
+import { readFile } from "node:fs/promises";
+import { writeHermesConfig } from "./vendor/HermesAgent-20/verification/hermes-runtime.mjs";
+const [home, workspace, modelJson] = process.argv.slice(1);
+await writeHermesConfig(home, workspace, JSON.parse(modelJson), 10);
+process.stdout.write(await readFile(`${home}/config.yaml`, "utf8"));
+'''
+    proc = subprocess.run(
+        [
+            "node",
+            "--input-type=module",
+            "-e",
+            script,
+            str(tmp_path / "hermes-home"),
+            str(tmp_path / "workspace"),
+            json.dumps(translated["model"]),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    config = proc.stdout
+    assert config.count("extra_body:") == 4
+    assert config.count("enable_thinking: true") == 4
+    assert config.count(f"thinking_budget: {expected_budget}") == 4
 
 
 def test_hermes_normalize_base_url_ensures_v1_suffix():

--- a/vendor/HermesAgent-20/verification/agent-runner.py
+++ b/vendor/HermesAgent-20/verification/agent-runner.py
@@ -54,7 +54,9 @@ def _guess_provider(base_url: str, requested_provider: str) -> str:
     return "custom"
 
 
-def _request_overrides(generation: Dict[str, Any]) -> Dict[str, Any]:
+def _request_overrides(
+    generation: Dict[str, Any], extra_body: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
     overrides: Dict[str, Any] = {}
 
     # The pinned Hermes runtime forwards request_overrides directly into its
@@ -73,6 +75,9 @@ def _request_overrides(generation: Dict[str, Any]) -> Dict[str, Any]:
         value = generation.get(key)
         if value is not None:
             overrides[key] = value
+
+    if extra_body:
+        overrides["extra_body"] = dict(extra_body)
 
     return overrides
 
@@ -239,7 +244,9 @@ def main() -> int:
             skip_context_files=True,
             session_id=session_id,
             session_db=session_db,
-            request_overrides=_request_overrides(request.get("generation") or {}),
+            request_overrides=_request_overrides(
+                request.get("generation") or {}, model.get("extraBody")
+            ),
             tool_start_callback=_tool_started,
             tool_complete_callback=_tool_completed,
             clarify_callback=clarify_callback,

--- a/vendor/HermesAgent-20/verification/hermes-runtime.mjs
+++ b/vendor/HermesAgent-20/verification/hermes-runtime.mjs
@@ -142,7 +142,23 @@ function buildHermesProviderEnv(model) {
   return env;
 }
 
-async function writeHermesConfig(hermesHomeDir, workspaceDir, model, maxTurns, options = {}) {
+function appendExtraBody(lines, indent, extraBody) {
+  if (!extraBody || typeof extraBody !== "object" || Array.isArray(extraBody)) {
+    return;
+  }
+
+  const entries = Object.entries(extraBody).filter(([, value]) => value !== undefined);
+  if (entries.length === 0) {
+    return;
+  }
+
+  lines.push(`${indent}extra_body:`);
+  for (const [key, value] of entries) {
+    lines.push(`${indent}  ${key}: ${yamlScalar(value)}`);
+  }
+}
+
+export async function writeHermesConfig(hermesHomeDir, workspaceDir, model, maxTurns, options = {}) {
   await mkdir(hermesHomeDir, { recursive: true });
   const configPath = path.join(hermesHomeDir, "config.yaml");
   // benchlocal-cli v0.7.4 patch: hermes-agent v0.13+ enforces a 64K minimum
@@ -161,6 +177,7 @@ async function writeHermesConfig(hermesHomeDir, workspaceDir, model, maxTurns, o
     `  base_url: ${yamlScalar(model.inferenceBaseUrl)}`
   ];
   if (ctxLine) lines.push(ctxLine);
+  appendExtraBody(lines, "  ", model.extraBody);
 
   if (model.authMode === "bearer" && model.apiKey) {
     lines.push(`  api_key: ${yamlScalar(model.apiKey)}`);
@@ -217,6 +234,7 @@ async function writeHermesConfig(hermesHomeDir, workspaceDir, model, maxTurns, o
       if (model.authMode === "bearer" && model.apiKey) {
         lines.push(`    api_key: ${yamlScalar(model.apiKey)}`);
       }
+      appendExtraBody(lines, "    ", model.extraBody);
     }
   }
 


### PR DESCRIPTION
## Summary
- thread the resolved thinking mode and budget through Hermes `/verify-start` and generated primary/auxiliary model configuration
- clamp no-thinking mode and the decode-TPS probe to `enable_thinking=true` with `thinking_budget=1` for thinking-only endpoints
- authenticate the Hermes endpoint preflight while preserving the local dummy-key path

## Verification
- `pytest -q` — 280 passed
- rebuilt `benchlocal-sandbox-hermes:latest` and passed the Hermes health smoke test
- thinking-on against `qwen3.8-max`: 15/20, with no `enable_thinking=false` rejection in LiteLLM logs
- no-thinking against `qwen3.8-max-nothink`: 13/20, with no `enable_thinking=false` rejection in LiteLLM logs

Fixes #86