### PR TITLE
fix(cloud): span minute-window 429 throttles

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ benchlocal-cli run --pack toolcall-15 \
 | Flag | Role |
 |---|---|
 | `--request-delay <sec>` | **proactive** — minimum seconds between requests, to stay under the endpoint's RPM ceiling (env `BENCHLOCAL_REQUEST_DELAY`) |
-| `--max-transient-retries <N>` | **reactive** — auto-retry 429 / transient failures before failing a scenario (default 3) |
+| `--max-transient-retries <N>` | **reactive** — auto-retry 429 / transient failures before failing a scenario (default 3). Server `Retry-After` is honored up to 120s; without it, 429 retries wait 10s, 20s, then 40s so the default spans a minute window. |
 
 Leave `--retry-on-timeout` **off** for cloud — a timeout means the token budget was genuinely exhausted, so retrying just burns another budget.
 

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -1164,6 +1164,7 @@ class Runner:
                     return self._scenario_run(scenario, raw_response, request, sampling, status_code, result, repeat_index)
                 if status_code >= 400:
                     result = ScenarioResult(scenario["id"], False, "http_error", f"HTTP {status_code}", latency)
+                    result = self._inject_transient_trace(result, transient_trace)
                     return self._scenario_run(scenario, raw_response, request, sampling, status_code, result, repeat_index)
             except _TransientPostFailure as exc:
                 latency = time.perf_counter() - started
@@ -1324,7 +1325,11 @@ class Runner:
                         if response.status_code == 429
                         else None
                     )
-                    self._sleep_before_transient_retry(attempt, retry_after=retry_after)
+                    self._sleep_before_transient_retry(
+                        attempt,
+                        retry_after=retry_after,
+                        status_code=response.status_code,
+                    )
                     continue
 
             # Spend guard: accumulate reported usage (cloud-cost safety). Trips on
@@ -1402,11 +1407,19 @@ class Runner:
         return replace(result, verifier_trace=existing)
 
     @staticmethod
-    def _sleep_before_transient_retry(attempt: int, retry_after: float | None = None) -> None:
-        # Honor a server-provided Retry-After (429/503) when present + sane; else
-        # exponential backoff. Capped so a hostile/large header can't stall the run.
+    def _sleep_before_transient_retry(
+        attempt: int,
+        retry_after: float | None = None,
+        status_code: int | None = None,
+    ) -> None:
+        # A minute-window throttle needs materially longer recovery than a brief
+        # connection/server error. Honor Retry-After first; otherwise let three
+        # default 429 retries span 70 seconds (10 + 20 + 40) while preserving the
+        # existing short exponential schedule for other transient failures.
         if retry_after is not None and retry_after > 0:
-            delay = min(float(retry_after), 30.0)
+            delay = min(float(retry_after), 120.0)
+        elif status_code == 429:
+            delay = min(10 * (2 ** (attempt - 1)), 60.0)
         else:
             delay = 2 ** (attempt - 1)
         if delay > 0:

--- a/tests/test_transient_retries.py
+++ b/tests/test_transient_retries.py
@@ -175,6 +175,13 @@ def test_single_turn_429_exhausted_is_http_error(monkeypatch):
     assert run.result.passed is False
     assert run.result.failure_mode == "http_error"
     assert SequenceHTTPClient.calls == 3
+    assert run.result.verifier_trace is not None
+    assert run.result.verifier_trace["transient_retries"] == 2
+    assert run.result.verifier_trace["transient_errors"] == [
+        "attempt 1: HTTP 429",
+        "attempt 2: HTTP 429",
+        "attempt 3: HTTP 429",
+    ]
 
 
 def test_retry_after_header_honored_and_capped(monkeypatch):
@@ -188,9 +195,22 @@ def test_retry_after_header_honored_and_capped(monkeypatch):
             self.headers = {"retry-after": value}
 
     Runner._sleep_before_transient_retry(1, retry_after=Runner._retry_after_seconds(_RespWithHeader("7")))    # honored
-    Runner._sleep_before_transient_retry(1, retry_after=Runner._retry_after_seconds(_RespWithHeader("999")))  # capped at 30s
+    Runner._sleep_before_transient_retry(1, retry_after=Runner._retry_after_seconds(_RespWithHeader("999")))  # capped at 120s
     Runner._sleep_before_transient_retry(2, retry_after=Runner._retry_after_seconds(object()))                # no header → backoff 2**(2-1)
-    assert slept == [7.0, 30.0, 2.0]
+    assert slept == [7.0, 120.0, 2.0]
+
+
+def test_429_fallback_backoff_spans_a_minute_window(monkeypatch):
+    import benchlocal_cli.runner as runner_module
+
+    slept: list[float] = []
+    monkeypatch.setattr(runner_module.time, "sleep", lambda delay: slept.append(delay))
+
+    for attempt in range(1, 4):
+        Runner._sleep_before_transient_retry(attempt, status_code=429)
+
+    assert slept == [10.0, 20.0, 40.0]
+    assert sum(slept) >= 60.0
 
 
 def test_request_delay_paces_requests(monkeypatch):


### PR DESCRIPTION
## Summary
- use a 10s/20s/40s fallback schedule for HTTP 429 retries while preserving short backoff for other transient failures
- honor Retry-After values up to 120 seconds
- retain exhausted-429 retry traces in scenario results

## Verification
- python3 -m pytest tests/test_transient_retries.py -q (16 passed)
- python3 -m pytest -q (296 passed)

Closes #106