### PR TITLE
feat(run): add failure retry diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,24 @@ For agentic packs (e.g. `aider-polyglot-30`), the headline number is `pass_rate`
 
 When `--repeat N` is greater than 1, the markdown table adds per-pack `Std` and `CV` columns derived from repeat-arm pass rates. The saved JSON includes the same data under each pack result as `variance: {"repeat", "mean", "std", "cv"}` so cross-rig runs can distinguish real deltas from run-to-run noise.
 
+
+`--repeat N` is the rigorous whole-benchmark variance tool: it re-runs passes and failures, so it can detect flaky passes as well as flaky failures. The CLI default is `--repeat 0`, where `0` means the normal single attempt; `--repeat 3` executes every selected scenario three times.
+
+For the cheaper everyday question "are the failures in this saved run systematic or flaky?", retry only its failed pass@1 scenarios:
+
+```bash
+benchlocal-cli run --retry-failed --previous-result baseline.json \
+  --api-key "$BENCHLOCAL_API_KEY" --save-json failure-retries.json
+
+# Bare --retry-failed means 3 attempts per failed scenario; choose another count explicitly.
+benchlocal-cli run --retry-failed 5 --previous-result baseline.json \
+  --save-json failure-retries-5x.json
+```
+
+The source must be a pass@1 result; a prior `--repeat N` artifact already contains the rigorous variance signal and is rejected as a retry baseline.
+
+The endpoint, model, thinking mode, and recorded sampling overrides are inherited when available; current credentials still come from the CLI or environment. Pack-set flags such as `--pack` intersect with the generated failed-scenario selection. Human output keeps the baseline pass@1 score first and labels retry totals as `RETRY SAMPLE`; JSON remains an honest partial-selection artifact and adds top-level `retry_failed` consistency metadata. `0/N` is `systematic`; any passing retry is `flaky` because the baseline arm failed. This diagnostic cannot use `--exit-on-regression` and cannot overwrite its `--previous-result`.
+
 ## Inspecting failures
 
 The `Failure breakdown:` block above is the quickest read — `failure_mode` + full detail per failed scenario, printed at the end of every run. For deeper forensics, any run with `--save-json` (which `quality-test.sh` sets) records per-scenario tokens, latency, and the full verifier trace; the `inspect` subcommand reads it back:

--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -153,7 +153,21 @@ def _parser() -> argparse.ArgumentParser:
         metavar="RESULTS_JSON_OR_PARTIAL_JSONL",
         help="resume missing scenarios from a saved result or per-scenario partial journal",
     )
-    run.add_argument("--repeat", type=int, default=1, help="repeat each scenario N times (default: 1)")
+    run.add_argument(
+        "--repeat",
+        type=int,
+        default=0,
+        help="rigorous whole-benchmark variance: run every scenario N times; "
+             "0 or absent means one attempt (default: 0)",
+    )
+    run.add_argument(
+        "--retry-failed",
+        type=int,
+        nargs="?",
+        const=3,
+        help="diagnostic: retry each failed pass@1 scenario from --previous-result N times "
+             "(bare flag: 3); does not replace the baseline score",
+    )
     # v0.9.3: incremental progress (#23) — live output during long runs
     run.add_argument(
         "--progress",
@@ -455,6 +469,21 @@ def _markdown(result: RunResult) -> str:
         f"=== benchlocal-cli --{result.mode}  (endpoint: {result.endpoint}, model: {result.model}, thinking={thinking}, {result.started_at}){canonical_tag}{selection_tag} ===",
         "",
     ]
+    retry_diagnostic = result.retry_failed
+    if retry_diagnostic is not None:
+        baseline = retry_diagnostic.get("baseline_totals") or {}
+        lines.extend(
+            [
+                f"Baseline pass@1 (official): {baseline.get('passed', 0)} / "
+                f"{baseline.get('total', 0)} ({float(baseline.get('score') or 0.0):.0%})",
+                f"Retry diagnostic: {retry_diagnostic.get('failed_scenario_count', 0)} "
+                f"baseline failures × {retry_diagnostic.get('attempts_per_scenario', 0)} attempts.",
+                "Retry outcomes are diagnostic only and do not replace the baseline score.",
+                "",
+                "Retry sample:",
+                "",
+            ]
+        )
     show_variance = delta_pack_index is None and any(pack.variance for pack in result.packs)
     if delta_pack_index is None:
         if show_variance:
@@ -518,11 +547,12 @@ def _markdown(result: RunResult) -> str:
                 f"{pack.pack_id} (v{pack.version}) | {pack.passed} / {pack.total} | {score} | {delta_cell} | {p50} | {p95} | {status}"
             )
 
+    total_label = "RETRY SAMPLE" if retry_diagnostic is not None else "TOTAL"
     if delta_pack_index is None:
         lines.extend(
             [
                 "",
-                f"TOTAL | {result.totals['passed']} / {result.totals['total']} | {result.totals['score']:.0%} |  |  |  |  |" if show_variance else f"TOTAL | {result.totals['passed']} / {result.totals['total']} | {result.totals['score']:.0%} |  |  |",
+                f"{total_label} | {result.totals['passed']} / {result.totals['total']} | {result.totals['score']:.0%} |  |  |  |  |" if show_variance else f"{total_label} | {result.totals['passed']} / {result.totals['total']} | {result.totals['score']:.0%} |  |  |",
             ]
         )
     else:
@@ -533,13 +563,29 @@ def _markdown(result: RunResult) -> str:
         lines.extend(
             [
                 "",
-                f"TOTAL | {result.totals['passed']} / {result.totals['total']} | {result.totals['score']:.0%} | {delta_summary} |  |  |",
+                f"{total_label} | {result.totals['passed']} / {result.totals['total']} | {result.totals['score']:.0%} | {delta_summary} |  |  |",
             ]
         )
         if d.get("warnings"):
             lines.append("")
             lines.append("Delta warnings:")
             lines.extend(f"- {w}" for w in d["warnings"])
+    if retry_diagnostic is not None:
+        lines.extend(
+            [
+                "",
+                "Failure consistency:",
+                "",
+                "Scenario | Retry passes | Classification",
+                "---|---:|---",
+            ]
+        )
+        for scenario in retry_diagnostic.get("scenarios") or []:
+            lines.append(
+                f"{scenario['pack_id']}/{scenario['scenario_id']} | "
+                f"{scenario['retry_passed']} / {scenario['retry_total']} | "
+                f"{scenario['classification']}"
+            )
     failures: list[str] = []
     for pack in result.packs:
         for scenario in pack.scenarios:
@@ -547,7 +593,7 @@ def _markdown(result: RunResult) -> str:
                 failures.append(
                     f"{pack.pack_id} {scenario.id}: {scenario.result.failure_mode} ({scenario.result.detail})"
                 )
-    if failures:
+    if failures and retry_diagnostic is None:
         lines.append("")
         lines.append("Failure breakdown:")
         lines.extend(f"- {failure}" for failure in failures)
@@ -698,6 +744,10 @@ def main(argv: list[str] | None = None) -> int:
             from benchlocal_cli.rescore import rescore_result
             return rescore_result(args.path, args)
 
+        if args.repeat < 0:
+            raise ValueError("--repeat must be 0 or greater")
+        retry_failed_context: dict | None = None
+
         resume_state = None
         if args.resume:
             from benchlocal_cli.persistence import load_resume
@@ -710,7 +760,9 @@ def main(argv: list[str] | None = None) -> int:
             )
             if conflicting_selector:
                 raise ValueError("--resume cannot be combined with scenario or pack-set selectors")
-            if args.repeat != 1:
+            if args.retry_failed is not None:
+                raise ValueError("--resume restores an existing retry diagnostic; do not pass --retry-failed")
+            if args.repeat != 0:
                 raise ValueError("--resume uses the original run repeat count; do not pass --repeat")
             if args.thinking_override is not None or args.thinking_max_tokens is not None:
                 raise ValueError("--resume uses the original thinking configuration")
@@ -725,6 +777,7 @@ def main(argv: list[str] | None = None) -> int:
                 raise ValueError("--resume uses the original sampling configuration")
 
             config = resume_state.config
+            retry_failed_context = config.get("retry_failed")
             args.endpoint = args.endpoint or config.get("endpoint")
             args.model = args.model or config.get("model")
             args.save_json = args.save_json or str(resume_state.final_path)
@@ -765,6 +818,58 @@ def main(argv: list[str] | None = None) -> int:
                     )
                 return 0
 
+        if args.retry_failed is not None:
+            if not args.previous_result:
+                raise ValueError("--retry-failed requires --previous-result")
+            if args.scenario or args.scenarios_file:
+                raise ValueError("--retry-failed constructs the scenario selection; do not pass --scenario or --scenarios-file")
+            if args.repeat != 0:
+                raise ValueError("--retry-failed cannot be combined with --repeat")
+            if args.exit_on_regression:
+                raise ValueError("--retry-failed is diagnostic and cannot be used with --exit-on-regression")
+            if (
+                args.save_json
+                and Path(args.save_json).resolve() == Path(args.previous_result).resolve()
+            ):
+                raise ValueError("--retry-failed --save-json must not overwrite --previous-result")
+
+            from benchlocal_cli.retry_failed import load_retry_context
+
+            baseline, retry_failed_context = load_retry_context(
+                args.previous_result,
+                args.retry_failed,
+            )
+            if not retry_failed_context["selection"]:
+                print(
+                    f"benchlocal-cli: retry-failed complete — no failed pass@1 scenarios "
+                    f"in {args.previous_result}"
+                )
+                return 0
+
+            args.endpoint = args.endpoint or baseline.get("endpoint")
+            args.model = args.model or baseline.get("model")
+            if args.thinking_override is None:
+                if baseline.get("thinking_mode") == "force-on":
+                    args.thinking_override = True
+                elif baseline.get("thinking_mode") == "force-off":
+                    args.thinking_override = False
+            for key, value in (baseline.get("sampling_overrides") or {}).items():
+                attr = "repeat_penalty" if key == "repeat_penalty" else key.replace("-", "_")
+                if hasattr(args, attr) and getattr(args, attr) is None:
+                    setattr(args, attr, value)
+            explicit_distribution = any(
+                value is not None
+                for value in (
+                    args.temperature,
+                    args.top_p,
+                    args.top_k,
+                    args.min_p,
+                    args.repeat_penalty,
+                )
+            )
+            if baseline.get("sampling_source") == "server" and not explicit_distribution:
+                args.sampling_from_server = True
+            args.repeat = args.retry_failed
         # #65: --reasoning is a deprecated alias for --reasoning-packs.
         if getattr(args, "reasoning", False):
             print(
@@ -812,10 +917,16 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 pack_ids = PACK_MODES[mode]
 
-            raw_selection = requested_ids(args.scenario, args.scenarios_file)
+            raw_selection = (
+                list(retry_failed_context["selection"])
+                if retry_failed_context is not None
+                else requested_ids(args.scenario, args.scenarios_file)
+            )
             selection_ids: list[str] | None = None
             selection_by_pack: dict[str, list[str]] | None = None
-            selection_requested = bool(args.scenario or args.scenarios_file)
+            selection_requested = (
+                retry_failed_context is not None or bool(args.scenario or args.scenarios_file)
+            )
             if selection_requested:
                 if not raw_selection:
                     raise ValueError("scenario selection is empty")
@@ -839,6 +950,8 @@ def main(argv: list[str] | None = None) -> int:
                 if selection_ids is not None
                 else selection_for_packs(pack_ids)[0]
             )
+            if retry_failed_context is not None:
+                retry_failed_context["selection"] = list(selection_ids or [])
 
         # --full implies sandboxed packs by default; --no-sandboxed-packs opts out.
         # --sandboxed-only also implies sandbox is enabled (no point otherwise).
@@ -948,6 +1061,7 @@ def main(argv: list[str] | None = None) -> int:
             "timeout_scale_down": args.timeout_scale_down,
             "sandboxed_enabled": sandboxed_enabled,
             "request_delay": args.request_delay,
+            "retry_failed": retry_failed_context,
             "save_json": args.save_json,
         }
 
@@ -1053,6 +1167,11 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 2
+
+        if retry_failed_context is not None:
+            from benchlocal_cli.retry_failed import build_retry_diagnostic
+
+            result.retry_failed = build_retry_diagnostic(result, retry_failed_context)
 
         # v0.8: --previous-result delta classification
         if args.previous_result:

--- a/benchlocal_cli/persistence.py
+++ b/benchlocal_cli/persistence.py
@@ -227,7 +227,7 @@ def _build_result(
 
     total = sum(pack.total for pack in packs)
     passed = sum(pack.passed for pack in packs)
-    return RunResult(
+    result = RunResult(
         schema_version=str(config.get("schema_version") or "1"),
         runner_version=str(config.get("runner_version") or __version__),
         endpoint=str(config.get("endpoint") or ""),
@@ -245,6 +245,12 @@ def _build_result(
         server_defaults=config.get("server_defaults"),
         selection=config.get("result_selection"),
     )
+    retry_context = config.get("retry_failed")
+    if retry_context is not None:
+        from benchlocal_cli.retry_failed import build_retry_diagnostic
+
+        result.retry_failed = build_retry_diagnostic(result, retry_context)
+    return result
 
 
 def result_from_journal(path: str | Path) -> dict:

--- a/benchlocal_cli/retry_failed.py
+++ b/benchlocal_cli/retry_failed.py
@@ -1,0 +1,120 @@
+"""Failure-conditioned retry diagnostics for saved benchmark results."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from benchlocal_cli.delta import load_previous_result
+
+if TYPE_CHECKING:
+    from benchlocal_cli.types import RunResult
+
+
+def _qualified_runs(result: dict) -> dict[str, list[dict]]:
+    grouped: dict[str, list[dict]] = {}
+    for pack in result.get("packs") or []:
+        pack_id = str(pack.get("pack_id") or "")
+        if not pack_id:
+            continue
+        for run in pack.get("scenarios") or []:
+            scenario_id = str(run.get("id") or "")
+            if scenario_id:
+                grouped.setdefault(f"{pack_id}/{scenario_id}", []).append(run)
+    return grouped
+
+
+def failed_selection(result: dict) -> list[str]:
+    """Return scenarios that failed their first (pass@1) arm, in result order."""
+    failed: list[str] = []
+    for qualified_id, runs in _qualified_runs(result).items():
+        baseline = min(
+            runs,
+            key=lambda run: int(run.get("repeat_index") or 1),
+        )
+        if (
+            not bool(baseline.get("passed"))
+            and baseline.get("failure_mode") != "verifier_not_implemented"
+        ):
+            failed.append(qualified_id)
+    return failed
+
+
+def load_retry_context(path: str | Path, attempts: int) -> tuple[dict, dict]:
+    if attempts < 1:
+        raise ValueError("--retry-failed must be at least 1")
+    baseline = load_previous_result(path)
+    grouped = _qualified_runs(baseline)
+    if not grouped:
+        raise ValueError("--previous-result contains no scenario results")
+    if any(
+        int(run.get("repeat_index") or 1) > 1
+        for runs in grouped.values()
+        for run in runs
+    ):
+        raise ValueError(
+            "--retry-failed requires a pass@1 result; --repeat results already characterize variance"
+        )
+    selection = failed_selection(baseline)
+    totals = baseline.get("totals") or {}
+    context = {
+        "source": str(path),
+        "attempts_per_scenario": attempts,
+        "baseline_totals": {
+            "passed": int(totals.get("passed") or 0),
+            "total": int(totals.get("total") or 0),
+            "score": float(totals.get("score") or 0.0),
+        },
+        "selection": selection,
+    }
+    return baseline, context
+
+
+def build_retry_diagnostic(result: RunResult, context: dict) -> dict:
+    grouped: dict[str, list] = {}
+    for pack in result.packs:
+        for run in pack.scenarios:
+            grouped.setdefault(f"{pack.pack_id}/{run.id}", []).append(run)
+
+    scenarios: list[dict] = []
+    systematic = 0
+    flaky = 0
+    not_run = 0
+    for qualified_id in context.get("selection") or []:
+        runs = [
+            run for run in grouped.get(qualified_id, [])
+            if run.result.failure_mode != "verifier_not_implemented"
+        ]
+        passed = sum(1 for run in runs if run.result.passed)
+        total = len(runs)
+        if total == 0:
+            classification = "not-run"
+            not_run += 1
+        elif passed == 0:
+            classification = "systematic"
+            systematic += 1
+        else:
+            # The baseline arm failed, so any passing retry proves inconsistency.
+            classification = "flaky"
+            flaky += 1
+        pack_id, scenario_id = qualified_id.split("/", 1)
+        scenarios.append(
+            {
+                "pack_id": pack_id,
+                "scenario_id": scenario_id,
+                "retry_passed": passed,
+                "retry_total": total,
+                "classification": classification,
+            }
+        )
+
+    return {
+        "source": str(context.get("source") or ""),
+        "attempts_per_scenario": int(context.get("attempts_per_scenario") or 0),
+        "baseline_totals": dict(context.get("baseline_totals") or {}),
+        "failed_scenario_count": len(scenarios),
+        "systematic": systematic,
+        "flaky": flaky,
+        "not_run": not_run,
+        "scenarios": scenarios,
+    }

--- a/benchlocal_cli/types.py
+++ b/benchlocal_cli/types.py
@@ -163,6 +163,9 @@ class RunResult:
     # Ordered, pack-qualified IDs for targeted runs. Optional/additive so schema
     # version 1 readers remain compatible with ordinary and historical results.
     selection: list[str] | None = None
+    # Failure-conditioned retries are diagnostic only; baseline pass@1 remains
+    # authoritative and is recorded alongside per-scenario consistency here.
+    retry_failed: dict | None = None
 
     def to_dict(self) -> dict:
         out = {
@@ -189,4 +192,6 @@ class RunResult:
             out["server_defaults"] = self.server_defaults
         if self.selection is not None:
             out["selection"] = self.selection
+        if self.retry_failed is not None:
+            out["retry_failed"] = self.retry_failed
         return out

--- a/tests/test_retry_failed.py
+++ b/tests/test_retry_failed.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from benchlocal_cli.cli import _parser, main
+from benchlocal_cli.retry_failed import failed_selection, load_retry_context
+from benchlocal_cli.runner import Runner
+
+
+def _response(content: str) -> dict:
+    return {
+        "choices": [{"message": {"content": content}}],
+        "usage": {"completion_tokens": 3},
+    }
+
+
+def _baseline(*, all_passed: bool = False) -> dict:
+    return {
+        "schema_version": "1",
+        "runner_version": "0.9.8",
+        "endpoint": "mock",
+        "model": "mock",
+        "mode": "full",
+        "started_at": "2026-07-22T00:00:00+00:00",
+        "finished_at": "2026-07-22T00:01:00+00:00",
+        "thinking_enabled": False,
+        "thinking_mode": "force-off",
+        "totals": {
+            "passed": 2 if all_passed else 0,
+            "total": 2,
+            "score": 1.0 if all_passed else 0.0,
+        },
+        "packs": [
+            {
+                "pack_id": "reasonmath-15",
+                "scenarios": [
+                    {
+                        "id": "RM-04",
+                        "passed": all_passed,
+                        "failure_mode": "passed" if all_passed else "wrong_answer",
+                    }
+                ],
+            },
+            {
+                "pack_id": "structoutput-15",
+                "scenarios": [
+                    {
+                        "id": "SO-01",
+                        "passed": all_passed,
+                        "failure_mode": "passed" if all_passed else "verifier_fail",
+                    }
+                ],
+            },
+        ],
+    }
+
+
+def test_parser_defaults_retry_failed_to_three_and_repeat_to_zero():
+    parser = _parser()
+
+    absent = parser.parse_args(["run"])
+    bare = parser.parse_args(["run", "--retry-failed"])
+
+    assert absent.repeat == 0
+    assert absent.retry_failed is None
+    assert bare.retry_failed == 3
+
+
+def test_failed_selection_uses_pass_at_one_not_later_repeat_arms():
+    result = {
+        "packs": [
+            {
+                "pack_id": "reasonmath-15",
+                "scenarios": [
+                    {"id": "RM-04", "repeat_index": 1, "passed": False},
+                    {"id": "RM-04", "repeat_index": 2, "passed": True},
+                    {"id": "RM-05", "repeat_index": 1, "passed": True},
+                    {"id": "RM-05", "repeat_index": 2, "passed": False},
+                ],
+            }
+        ]
+    }
+
+    assert failed_selection(result) == ["reasonmath-15/RM-04"]
+
+
+def test_retry_failed_runs_only_failures_and_reports_consistency(tmp_path, capsys):
+    previous = tmp_path / "baseline.json"
+    previous.write_text(json.dumps(_baseline()))
+    mock = tmp_path / "mock.json"
+    mock.write_text(
+        json.dumps(
+            {
+                "RM-04": _response("ANSWER: not-correct"),
+                "SO-01": _response('{"title":"The Great Gatsby","year":1925}'),
+            }
+        )
+    )
+    result_path = tmp_path / "retry.json"
+
+    exit_code = main(
+        [
+            "run",
+            "--retry-failed",
+            "--previous-result",
+            str(previous),
+            "--measured-tps",
+            "100",
+            "--mock-responses-from-json",
+            str(mock),
+            "--save-json",
+            str(result_path),
+        ]
+    )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    result = json.loads(result_path.read_text())
+    assert result["selection"] == [
+        "reasonmath-15/RM-04",
+        "structoutput-15/SO-01",
+    ]
+    assert result["totals"] == {"passed": 3, "total": 6, "score": 0.5}
+    assert result["retry_failed"]["baseline_totals"] == {
+        "passed": 0,
+        "total": 2,
+        "score": 0.0,
+    }
+    assert result["retry_failed"]["systematic"] == 1
+    assert result["retry_failed"]["flaky"] == 1
+    assert result["retry_failed"]["scenarios"] == [
+        {
+            "pack_id": "reasonmath-15",
+            "scenario_id": "RM-04",
+            "retry_passed": 0,
+            "retry_total": 3,
+            "classification": "systematic",
+        },
+        {
+            "pack_id": "structoutput-15",
+            "scenario_id": "SO-01",
+            "retry_passed": 3,
+            "retry_total": 3,
+            "classification": "flaky",
+        },
+    ]
+    assert "Baseline pass@1 (official): 0 / 2 (0%)" in output
+    assert "RETRY SAMPLE | 3 / 6 | 50%" in output
+    assert "reasonmath-15/RM-04 | 0 / 3 | systematic" in output
+    assert "structoutput-15/SO-01 | 3 / 3 | flaky" in output
+    assert "Failure breakdown:" not in output
+
+
+def test_retry_failed_intersects_with_pack_selector(tmp_path):
+    previous = tmp_path / "baseline.json"
+    previous.write_text(json.dumps(_baseline()))
+    mock = tmp_path / "mock.json"
+    mock.write_text(json.dumps({"SO-01": _response('{"title":"The Great Gatsby","year":1925}')}))
+    result_path = tmp_path / "retry.json"
+
+    assert main(
+        [
+            "run",
+            "--retry-failed",
+            "2",
+            "--previous-result",
+            str(previous),
+            "--pack",
+            "structoutput-15",
+            "--measured-tps",
+            "100",
+            "--mock-responses-from-json",
+            str(mock),
+            "--save-json",
+            str(result_path),
+            "--output",
+            "json",
+        ]
+    ) == 0
+
+    result = json.loads(result_path.read_text())
+    assert result["selection"] == ["structoutput-15/SO-01"]
+    assert result["totals"]["total"] == 2
+    assert result["retry_failed"]["failed_scenario_count"] == 1
+
+
+def test_retry_failed_completed_baseline_is_clear_noop(tmp_path, capsys):
+    previous = tmp_path / "baseline.json"
+    previous.write_text(json.dumps(_baseline(all_passed=True)))
+
+    assert main(["run", "--retry-failed", "--previous-result", str(previous)]) == 0
+    assert "no failed pass@1 scenarios" in capsys.readouterr().out
+
+
+def test_retry_failed_rejects_canonical_gate_and_source_overwrite(tmp_path, capsys):
+    previous = tmp_path / "baseline.json"
+    previous.write_text(json.dumps(_baseline()))
+
+    assert main(
+        [
+            "run",
+            "--retry-failed",
+            "--previous-result",
+            str(previous),
+            "--exit-on-regression",
+        ]
+    ) == 1
+    assert "diagnostic" in capsys.readouterr().err
+
+    assert main(
+        [
+            "run",
+            "--retry-failed",
+            "--previous-result",
+            str(previous),
+            "--save-json",
+            str(previous),
+        ]
+    ) == 1
+    assert "must not overwrite" in capsys.readouterr().err
+
+
+def test_retry_failed_completed_sidecar_keeps_diagnostics(
+    tmp_path, monkeypatch, capsys
+):
+    previous = tmp_path / "baseline.json"
+    previous.write_text(json.dumps(_baseline()))
+    mock = tmp_path / "mock.json"
+    mock.write_text(
+        json.dumps(
+            {
+                "RM-04": _response("ANSWER: not-correct"),
+                "SO-01": _response('{"title":"The Great Gatsby","year":1925}'),
+            }
+        )
+    )
+    result_path = tmp_path / "retry.json"
+    original_run = Runner.run
+
+    def crash_after_last_retry(self, *run_args, **run_kwargs):
+        original_run(self, *run_args, **run_kwargs)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(Runner, "run", crash_after_last_retry)
+    with pytest.raises(KeyboardInterrupt):
+        main(
+            [
+                "run",
+                "--retry-failed",
+                "2",
+                "--previous-result",
+                str(previous),
+                "--measured-tps",
+                "100",
+                "--mock-responses-from-json",
+                str(mock),
+                "--incremental",
+                "--save-json",
+                str(result_path),
+            ]
+        )
+    monkeypatch.setattr(Runner, "run", original_run)
+    capsys.readouterr()
+
+    sidecar = Path(f"{result_path}.partial.jsonl")
+    assert sidecar.is_file()
+    assert len(sidecar.read_text().splitlines()) == 4
+
+    assert main(["run", "--resume", str(sidecar)]) == 0
+    assert not sidecar.exists()
+    result = json.loads(result_path.read_text())
+    assert result["retry_failed"]["attempts_per_scenario"] == 2
+    assert result["retry_failed"]["systematic"] == 1
+    assert result["retry_failed"]["flaky"] == 1
+
+
+def test_retry_failed_rejects_an_already_repeated_baseline(tmp_path):
+    baseline = _baseline()
+    baseline["packs"][0]["scenarios"].append(
+        {
+            "id": "RM-04",
+            "repeat_index": 2,
+            "passed": True,
+            "failure_mode": "passed",
+        }
+    )
+    previous = tmp_path / "repeated.json"
+    previous.write_text(json.dumps(baseline))
+
+    with pytest.raises(ValueError, match="requires a pass@1 result"):
+        load_retry_context(previous, 3)


### PR DESCRIPTION
## Summary
- add optional-value --retry-failed (bare = 3) using failed pass@1 scenarios from --previous-result
- keep baseline pass@1 authoritative while reporting retry consistency as systematic or flaky
- route generated failures through scenario selection/intersection and preserve diagnostics across incremental resume
- reposition --repeat as whole-suite variance with 0 meaning the normal single attempt

## Result contract
- retry JSON remains marked as a partial selection
- additive top-level retry_failed metadata carries baseline totals and per-scenario consistency
- diagnostic mode cannot gate with --exit-on-regression or overwrite its source result

## Verification
- python3 -m pytest tests/test_retry_failed.py tests/test_selection.py tests/test_resume.py -q (17 passed)
- python3 -m pytest -q (304 passed)
- python3 -m py_compile benchlocal_cli/cli.py benchlocal_cli/retry_failed.py benchlocal_cli/persistence.py benchlocal_cli/types.py

Closes #107