### PR TITLE
feat(run): add retry, timeout, and reasoning guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,12 @@ Each scenario's timeout is sized by precedence (highest wins):
    - `thinking_multiplier` = `thinking_max_tokens / nominal_max_tokens`, applied only when thinking is enabled and the budget exceeds the nominal output. Prevents thinking-on runs from spuriously timing out (#54).
    - `max(1, …)` means a faster rig never shrinks the budget below `base`. The result deliberately **over-budgets** — a timeout is a ceiling, not a target.
 3. **Static default** — the pack's `default_max_seconds`, when no `reference_tps` is set or the probe is unavailable.
+
+The automatic or static result is then capped by `--timeout-ceiling-s N` (env `BENCHLOCAL_TIMEOUT_CEILING_S`) when set. A pack may provide the same guard as `timeout_ceiling_s` metadata; the CLI/environment value wins, and `--timeout-ceiling-s 0` explicitly disables a pack ceiling. The exact `--timeout-per-case` override is never capped.
+
 Runner-owned model calls in sandboxed packs have a second, independent watchdog: `--model-turn-timeout N` (default `300` seconds; env `BENCHLOCAL_MODEL_TURN_TIMEOUT`). It caps one endpoint call even when speed/thinking scaling gives the scenario a much larger overall budget. Pass `0` to disable the cap. Sandbox-owned agent processes retain their own subprocess watchdogs.
 
-A **timeout is not retried** as transient (a timeout means the budget was genuinely hit); connection errors and HTTP 5xx still retry. `--retry-on-timeout` (default off) restores the old retry behavior.
+A **request timeout is not retried** by the transport retry loop (a timeout means the request budget was genuinely hit); connection errors and HTTP 5xx still are. `--retry-on-timeout` (default off) restores the old transport behavior. Scenario-level timeout/runaway retries are separately controlled by `--retry-runaways`.
 
 ## Repo layout
 
@@ -182,6 +185,12 @@ benchlocal-cli run --quick --endpoint http://localhost:8020 --model qwen3.6-27b-
 
 # run full mode with custom timeout per scenario
 benchlocal-cli run --full --endpoint http://localhost:8010 --model qwen3.6-27b-autoround --timeout-per-case 60
+
+# retain automatic speed/thinking scaling, but never allow more than 20 minutes per scenario
+benchlocal-cli run --full --endpoint http://localhost:8010 --model qwen3.6-27b-autoround --timeout-ceiling-s 1200
+
+# disable model-verdict inline retries (infrastructure recovery still applies)
+benchlocal-cli run --quick --endpoint http://localhost:8020 --model qwen3.6-27b-autoround --no-retry
 
 # run full mode including Docker-backed verifier packs
 benchlocal-cli run --full --enable-sandboxed-packs --endpoint http://localhost:8010 --model qwen3.6-27b-autoround
@@ -274,31 +283,37 @@ Leave `--retry-on-timeout` **off** for cloud — a timeout means the token budge
 
 `benchlocal-cli` uses each pack's `default_thinking` metadata by default. Reasoning-rewarding packs such as `reasonmath-15`, `bugfind-15`, `instructfollow-15`, `hermesagent-20`, and every `--reasoning-packs` pack run with `chat_template_kwargs.enable_thinking=true`; execution/format packs such as `toolcall-15`, `structoutput-15`, `dataextract-15`, and `cli-40` run answer-only. Use `--enable-thinking` to force thinking on for every pack, or `--no-thinking` to force it off for every pack. Whenever thinking is enabled for a pack, request `max_tokens` is raised to `--thinking-max-tokens` (default `16384`) and the request uses the recommended thinking sampler (`temperature=1.0`, `top_p=0.95`, `top_k=20`, `min_p=0.0`) instead of the deterministic pack's greedy sampler. Override it with `--thinking-sampler '{"temperature":0.7,"top_p":0.9}'`, override individual sampling keys with `--temperature`/`--top-p`/`--top-k`/`--min-p`, or use `--sampling-from-server` to omit sampler params entirely. HumanEval+ and LiveCodeBench also carry 16K scenario budgets so thinking-on code runs do not measure a 4K truncation failure; hardest LCB items may still exceed 16K, so compare against `--no-thinking` for budget-runaway diagnostics. Use `--extra-body` to pass any other OpenAI-compatible server extension fields. Saved JSON records `thinking_enabled` per pack plus the run-level `thinking_mode`.
 
+In multi-turn CLI and Hermes agent loops, captured assistant reasoning stays in the saved result for inspection, but prior `reasoning`, `reasoning_content`, `reasoning_details`, and `codex_reasoning_items` fields are stripped from the next outgoing request by default. This avoids replaying provider-private or stale reasoning state. Use `--preserve-reasoning-history` only when an endpoint explicitly requires that history for signed or encrypted reasoning continuity.
+
 ## Output
 
 ```
 === benchlocal-cli --medium  (endpoint: http://localhost:8020, model: qwen3.6-27b-autoround, 2026-05-09T10:30) ===
 
-Pack                      | Pass / Total | Score | p50 latency | p95 latency | Status
-ToolCall-15 (v1.0.1)      |   14 / 15    |  93%  |     8.2s    |     12.1s   | ✅
-InstructFollow-15 (v1.0.0)|   13 / 15    |  87%  |    11.4s    |     17.8s   | ✅
-StructOutput-15 (v1.0.0)  |   15 / 15    | 100%  |     6.9s    |      9.2s   | ✅
-DataExtract-15 (v1.0.0)   |   12 / 15    |  80%  |     7.3s    |     10.5s   | ✅
-─────────────────────────|──────────────|───────|─────────────|─────────────|──────
-TOTAL                     |   54 / 60    |  90%  |             |             |
+Pack                      | Pass@1       | Pass@3         | Flaky | p50 latency | p95 latency | Status
+ToolCall-15 (v1.0.1)      | 14 / 15 (93%)| 15 / 15 (100%) |   1   |     8.2s    |     12.1s   | ✅
+InstructFollow-15 (v1.0.0)| 13 / 15 (87%)| 14 / 15 (93%)  |   1   |    11.4s    |     17.8s   | ✅
+StructOutput-15 (v1.0.0)  | 15 / 15 (100%)|15 / 15 (100%) |   0   |     6.9s    |      9.2s   | ✅
+DataExtract-15 (v1.0.0)   | 12 / 15 (80%)| 12 / 15 (80%)  |   0   |     7.3s    |     10.5s   | ✅
+─────────────────────────|──────────────|─────────────────|───────|─────────────|─────────────|──────
+TOTAL                     | 54 / 60 (90%)| 56 / 60 (93%)  |   2   |             |             |
 
 Failure breakdown:
-- toolcall-15 TC-07: verifier_fail (wrong arg value for "filename": expected report.pdf, got output.pdf)
-- instructfollow-15 IF-03: verifier_fail (word count 247, target 250 ±5)
+- toolcall-15 TC-07: pass@2 (wrong arg value on pass@1; recovered on retry)
+- instructfollow-15 IF-03: pass@2 (word count missed on pass@1; recovered on retry)
 - dataextract-15 DE-05: verifier_fail (7/14 atomic fields correct (50%). product_name: mismatch)
 ```
+
+Normal runs use failure-only inline retries by default: `--retry-failures 3` means at most three total attempts, stops on the first pass, and never reruns a clean pass@1. The official `passed`, `score`, and regression fields remain strict pass@1; the additive `pass_at_k` summary and `pass@1`/`pass@2`/`pass@3`/`fail` labels expose recovery without rewriting the baseline. Saved JSON keeps the baseline scenario at its existing location and nests complete later attempts under `retry_attempts`.
+
+Completed content failures are eligible by default. Harness/infrastructure failures are also retried, even with `--retry-failures 0`; expensive `token_limit`, `timeout`, and `agent_runner_timeout` runaways require `--retry-runaways`, while `verifier_not_implemented` is never retried. Use `--no-retry` for strict content pass@1-only execution. Pack authors can mark a safety-sensitive scenario with `no_best_of_n: true`: retries and their labels remain visible, but a later pass receives no pass@k credit.
 
 For agentic packs (e.g. `aider-polyglot-30`), the headline number is `pass_rate` over 30 exercises rather than per-scenario pass/fail; per-exercise breakdown is surfaced in the JSON `verifier_trace.upstream_per_exercise`. See [docs/AIDER_POLYGLOT_30.md](docs/AIDER_POLYGLOT_30.md) for the full output shape.
 
 When `--repeat N` is greater than 1, the markdown table adds per-pack `Std` and `CV` columns derived from repeat-arm pass rates. The saved JSON includes the same data under each pack result as `variance: {"repeat", "mean", "std", "cv"}` so cross-rig runs can distinguish real deltas from run-to-run noise.
 
 
-`--repeat N` is the rigorous whole-benchmark variance tool: it re-runs passes and failures, so it can detect flaky passes as well as flaky failures. The CLI default is `--repeat 0`, where `0` means the normal single attempt; `--repeat 3` executes every selected scenario three times.
+`--repeat N` is the rigorous whole-benchmark variance tool: it re-runs passes and failures, so it can detect flaky passes as well as flaky failures. The CLI default is `--repeat 0`, where `0` selects the normal failure-only inline path; `--repeat 3` disables inline retries and executes every selected scenario three times.
 
 For the cheaper everyday question "are the failures in this saved run systematic or flaky?", retry only its failed pass@1 scenarios:
 

--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -137,6 +137,14 @@ def _parser() -> argparse.ArgumentParser:
     )
     run.add_argument("--timeout-per-case", type=float, default=None, help="per-scenario HTTP timeout override (default: pack metadata, usually 60s; agentic packs may use larger budgets)")
     run.add_argument(
+        "--timeout-ceiling-s",
+        type=float,
+        default=_env_optional_float("BENCHLOCAL_TIMEOUT_CEILING_S"),
+        help="maximum auto-scaled per-scenario budget in seconds, applied after speed/token "
+             "scaling; 0 disables any pack ceiling, unset uses pack metadata or remains "
+             "unbounded (env BENCHLOCAL_TIMEOUT_CEILING_S)",
+    )
+    run.add_argument(
         "--model-turn-timeout",
         type=float,
         default=_env_float("BENCHLOCAL_MODEL_TURN_TIMEOUT", 300.0),
@@ -159,6 +167,27 @@ def _parser() -> argparse.ArgumentParser:
         default=0,
         help="rigorous whole-benchmark variance: run every scenario N times; "
              "0 or absent means one attempt (default: 0)",
+    )
+    inline_retry = run.add_mutually_exclusive_group()
+    inline_retry.add_argument(
+        "--retry-failures",
+        type=int,
+        default=3,
+        metavar="N",
+        help="total attempts for retry-eligible failed scenarios (default: 3; "
+             "0 disables model-verdict retries)",
+    )
+    inline_retry.add_argument(
+        "--no-retry",
+        dest="retry_failures",
+        action="store_const",
+        const=0,
+        help="alias for --retry-failures 0",
+    )
+    run.add_argument(
+        "--retry-runaways",
+        action="store_true",
+        help="also retry token-limit and timeout runaways; off by default because each attempt is expensive",
     )
     run.add_argument(
         "--retry-failed",
@@ -239,6 +268,12 @@ def _parser() -> argparse.ArgumentParser:
         action="store_const",
         const=False,
         help="force reasoning/thinking off for every pack, ignoring pack defaults",
+    )
+    run.add_argument(
+        "--preserve-reasoning-history",
+        action="store_true",
+        help="replay prior assistant reasoning fields in multi-turn agent loops; default strips "
+             "them from outgoing history while retaining them in captured results",
     )
     run.add_argument(
         "--thinking-max-tokens",
@@ -390,6 +425,13 @@ def _pack_line(pack: PackResult) -> str:
         )
     score = f"{pack.score:.0%}" if pack.total else "-"
     p50 = "-" if pack.latency["p50"] is None else f"{pack.latency['p50']:.2f}s"
+    if pack.pass_at_k is not None:
+        best = pack.pass_at_k
+        return (
+            f"{pack.pack_id} (v{pack.version}) | pass@1 {pack.passed} / {pack.total} ({score}) | "
+            f"pass@{best['k']} {best['passed']} / {best['total']} "
+            f"({float(best['score']):.0%}) | {p50} | {status}"
+        )
     return f"{pack.pack_id} (v{pack.version}) | {pack.passed} / {pack.total} | {score} | {p50} | {status}"
 
 
@@ -411,8 +453,9 @@ def _scenario_progress(run: ScenarioRun, index: int, total: int) -> None:
     """Print per-scenario progress line to stderr (#23)."""
     result_char = "✓" if run.result.passed else "✗"
     latency = f"{run.result.latency_seconds:.1f}s" if run.result.latency_seconds > 0 else "?"
+    label = f" {run.label}" if run.label else ""
     print(
-        f"  [{index}/{total}] {run.id} {result_char} {run.result.failure_mode} ({latency})",
+        f"  [{index}/{total}] {run.id} {result_char} {run.result.failure_mode}{label} ({latency})",
         file=sys.stderr,
         flush=True,
     )
@@ -484,8 +527,21 @@ def _markdown(result: RunResult) -> str:
                 "",
             ]
         )
+    inline_pass_at_k = result.pass_at_k if retry_diagnostic is None else None
     show_variance = delta_pack_index is None and any(pack.variance for pack in result.packs)
-    if delta_pack_index is None:
+    if inline_pass_at_k is not None:
+        k = int(inline_pass_at_k["k"])
+        if delta_pack_index is None:
+            lines.append(
+                f"Pack | Pass@1 | Pass@{k} | Flaky | p50 latency | p95 latency | Status"
+            )
+            lines.append("---|---:|---:|---:|---:|---:|---")
+        else:
+            lines.append(
+                f"Pack | Pass@1 | Pass@{k} | Flaky | Δ (vs prev) | p50 latency | p95 latency | Status"
+            )
+            lines.append("---|---:|---:|---:|---|---:|---:|---")
+    elif delta_pack_index is None:
         if show_variance:
             lines.append("Pack | Pass / Total | Score | Std | CV | p50 latency | p95 latency | Status")
             lines.append("---|---:|---:|---:|---:|---:|---:|---")
@@ -516,7 +572,35 @@ def _markdown(result: RunResult) -> str:
         score = f"{pack.score:.0%}" if pack.total else "-"
         p50 = "-" if pack.latency["p50"] is None else f"{pack.latency['p50']:.2f}s"
         p95 = "-" if pack.latency["p95"] is None else f"{pack.latency['p95']:.2f}s"
-        if delta_pack_index is None:
+        if inline_pass_at_k is not None:
+            best = pack.pass_at_k
+            if best is None:
+                pass_k = "-"
+                flaky = "-"
+            else:
+                pass_k = f"{best['passed']} / {best['total']} ({float(best['score']):.0%})"
+                flaky = str(best.get("credited_flaky", 0))
+                if best.get("safety_flaky"):
+                    flaky += f" (+{best['safety_flaky']} safety, no credit)"
+            pass_one = f"{pack.passed} / {pack.total} ({score})"
+            row = f"{pack.pack_id} (v{pack.version}) | {pass_one} | {pass_k} | {flaky}"
+            if delta_pack_index is not None:
+                d = delta_pack_index.get(pack.pack_id)
+                if d and d.get("regressions"):
+                    delta_cell = f"⚠ {d['regressions']} regr / {d.get('fixes', 0)} fix"
+                elif d and d.get("fixes"):
+                    delta_cell = f"+{d['fixes']} fix"
+                elif d and (d.get("new") or d.get("dropped")):
+                    delta_cell = (
+                        f"new={d.get('new', 0)}, dropped={d.get('dropped', 0)}"
+                    )
+                elif d:
+                    delta_cell = "stable"
+                else:
+                    delta_cell = "-"
+                row += f" | {delta_cell}"
+            lines.append(f"{row} | {p50} | {p95} | {status}")
+        elif delta_pack_index is None:
             if show_variance:
                 variance = pack.variance or {}
                 std = "-" if variance.get("std") is None else f"{float(variance['std']):.1%}"
@@ -548,7 +632,24 @@ def _markdown(result: RunResult) -> str:
             )
 
     total_label = "RETRY SAMPLE" if retry_diagnostic is not None else "TOTAL"
-    if delta_pack_index is None:
+    if inline_pass_at_k is not None:
+        pass_one = (
+            f"{result.totals['passed']} / {result.totals['total']} "
+            f"({result.totals['score']:.0%})"
+        )
+        pass_k = (
+            f"{inline_pass_at_k['passed']} / {inline_pass_at_k['total']} "
+            f"({float(inline_pass_at_k['score']):.0%})"
+        )
+        row = f"TOTAL | {pass_one} | {pass_k} | {inline_pass_at_k.get('credited_flaky', 0)}"
+        if delta_pack_index is not None:
+            d = result.delta or {}
+            regr = d.get("total_regressions", 0)
+            fixes = d.get("total_fixes", 0)
+            delta_summary = f"⚠ {regr} regressions, {fixes} fixes" if regr else f"+{fixes} fixes" if fixes else "stable"
+            row += f" | {delta_summary}"
+        lines.extend(["", f"{row} |  |  |"])
+    elif delta_pack_index is None:
         lines.extend(
             [
                 "",
@@ -586,12 +687,38 @@ def _markdown(result: RunResult) -> str:
                 f"{scenario['retry_passed']} / {scenario['retry_total']} | "
                 f"{scenario['classification']}"
             )
+    if inline_pass_at_k is not None:
+        classified = [
+            (pack.pack_id, scenario)
+            for pack in result.packs
+            for scenario in pack.scenarios
+            if scenario.label and scenario.label != "pass@1"
+        ]
+        lines.extend(
+            [
+                "",
+                "Inline retry classification (clean pass@1 rows omitted):",
+                "",
+                "Scenario | Label | Attempts | Pass@k credit",
+                "---|---|---:|---",
+            ]
+        )
+        if classified:
+            for pack_id, scenario in classified:
+                credit = "yes" if scenario.pass_at_k else "no"
+                lines.append(
+                    f"{pack_id}/{scenario.id} | {scenario.label} | "
+                    f"{scenario.attempt_count} | {credit}"
+                )
+        else:
+            lines.append("all scenarios | pass@1 | 1 | yes")
     failures: list[str] = []
     for pack in result.packs:
         for scenario in pack.scenarios:
             if not scenario.result.passed and scenario.result.failure_mode != "verifier_not_implemented":
                 failures.append(
-                    f"{pack.pack_id} {scenario.id}: {scenario.result.failure_mode} ({scenario.result.detail})"
+                    f"{pack.pack_id} {scenario.id}: {scenario.result.failure_mode} "
+                    f"[{scenario.label or 'fail'}] ({scenario.result.detail})"
                 )
     if failures and retry_diagnostic is None:
         lines.append("")
@@ -683,6 +810,16 @@ def _env_float(name: str, default: float) -> float:
         raise ValueError(f"{name} must be a number") from exc
 
 
+def _env_optional_float(name: str) -> float | None:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a number") from exc
+
+
 def _env_bool(name: str, default: bool) -> bool:
     value = os.environ.get(name)
     if value is None or value == "":
@@ -746,6 +883,10 @@ def main(argv: list[str] | None = None) -> int:
 
         if args.repeat < 0:
             raise ValueError("--repeat must be 0 or greater")
+        if args.retry_failures < 0:
+            raise ValueError("--retry-failures must be 0 or greater")
+        if args.timeout_ceiling_s is not None and args.timeout_ceiling_s < 0:
+            raise ValueError("--timeout-ceiling-s must be 0 or greater")
         retry_failed_context: dict | None = None
 
         resume_state = None
@@ -799,7 +940,17 @@ def main(argv: list[str] | None = None) -> int:
                 config.get("model_turn_timeout", args.model_turn_timeout)
             )
             args.timeout_per_case = args.timeout_per_case or config.get("timeout_per_case")
+            args.timeout_ceiling_s = (
+                args.timeout_ceiling_s
+                if args.timeout_ceiling_s is not None
+                else config.get("timeout_ceiling_s")
+            )
             args.timeout_scale_down = bool(config.get("timeout_scale_down"))
+            args.preserve_reasoning_history = bool(
+                config.get("preserve_reasoning_history")
+            )
+            args.retry_failures = int(config.get("retry_failures") or 0)
+            args.retry_runaways = bool(config.get("retry_runaways"))
             args.enable_sandboxed_packs = bool(config.get("sandboxed_enabled"))
             args.request_delay = float(config.get("request_delay") or args.request_delay)
 
@@ -1022,6 +1173,21 @@ def main(argv: list[str] | None = None) -> int:
 
         # Per-scenario durability (#82). The journal metadata is repeated on every
         # line so any intact scored-scenario record is independently recoverable.
+        inline_retry_failures = args.retry_failures
+        inline_retry_runaways = args.retry_runaways
+        inline_retries_enabled = (
+            bool(resume_state.config.get("inline_retries_enabled", True))
+            if resume_state is not None
+            else True
+        )
+
+        if args.repeat > 1 or retry_failed_context is not None or args.negative_control:
+            # --repeat owns symmetric variance, the post-hoc diagnostic owns its
+            # retry sample, and negative controls are deterministic grader probes.
+            inline_retry_failures = 0
+            inline_retry_runaways = False
+            inline_retries_enabled = False
+
         effective_extra_body = _load_extra_body(args.extra_body)
         effective_thinking_sampler = _load_thinking_sampler(args.thinking_sampler)
         run_started_at = (
@@ -1055,10 +1221,15 @@ def main(argv: list[str] | None = None) -> int:
             "sampling_source": "server" if args.sampling_from_server else None,
             "extra_body": effective_extra_body,
             "timeout_per_case": args.timeout_per_case,
+            "timeout_ceiling_s": args.timeout_ceiling_s,
             "model_turn_timeout": args.model_turn_timeout,
             "measured_tps": args.measured_tps,
             "reference_tps": args.reference_tps,
             "timeout_scale_down": args.timeout_scale_down,
+            "preserve_reasoning_history": args.preserve_reasoning_history,
+            "retry_failures": inline_retry_failures,
+            "retry_runaways": inline_retry_runaways,
+            "inline_retries_enabled": inline_retries_enabled,
             "sandboxed_enabled": sandboxed_enabled,
             "request_delay": args.request_delay,
             "retry_failed": retry_failed_context,
@@ -1114,6 +1285,7 @@ def main(argv: list[str] | None = None) -> int:
             endpoint=args.endpoint,
             model=args.model,
             timeout_per_case=args.timeout_per_case,
+            timeout_ceiling_s=args.timeout_ceiling_s,
             model_turn_timeout=args.model_turn_timeout,
             measured_tps=args.measured_tps,
             reference_tps=args.reference_tps,
@@ -1136,6 +1308,10 @@ def main(argv: list[str] | None = None) -> int:
             ),
             max_transient_retries=args.max_transient_retries,
             retry_on_timeout=args.retry_on_timeout,
+            preserve_reasoning_history=args.preserve_reasoning_history,
+            retry_failures=inline_retry_failures,
+            retry_runaways=inline_retry_runaways,
+            inline_retries_enabled=inline_retries_enabled,
             sampling_overrides=sampling_overrides or None,
             sampling_from_server=args.sampling_from_server,
             thinking_sampler=effective_thinking_sampler,

--- a/benchlocal_cli/persistence.py
+++ b/benchlocal_cli/persistence.py
@@ -6,10 +6,14 @@ import json
 import os
 from dataclasses import dataclass, fields
 from pathlib import Path
+
 from benchlocal_cli import __version__
 from benchlocal_cli.runner import (
+    DEFAULT_INLINE_RETRY_ATTEMPTS,
     PACK_MODES,
+    _combine_pass_at_k,
     _latency,
+    _pass_at_k_summary,
     _repeat_variance,
     _utc_now,
     load_pack,
@@ -117,8 +121,16 @@ def _aggregate_pack(
     catalog_scenario_count: int | None,
     repeat: int,
     thinking_override: bool | None,
+    retry_failures: int,
+    retry_runaways: bool,
 ) -> PackResult:
     meta, _scenarios = load_pack(pack_id)
+    configured_k = 0
+    if repeat == 1 and meta.get("_architecture") != "single-scoreboard":
+        if retry_failures > 1:
+            configured_k = retry_failures
+        elif retry_runaways:
+            configured_k = DEFAULT_INLINE_RETRY_ATTEMPTS
     counted = [run for run in runs if run.result.failure_mode != "verifier_not_implemented"]
     latencies = [run.result.latency_seconds for run in counted if run.result.latency_seconds > 0]
 
@@ -158,6 +170,7 @@ def _aggregate_pack(
                 thinking_enabled=resolve_thinking_enabled(meta, thinking_override),
                 variance=_repeat_variance(runs, repeat),
                 catalog_scenario_count=catalog_scenario_count,
+                pass_at_k=_pass_at_k_summary(runs, configured_k),
             )
 
     passed = sum(1 for run in counted if run.result.passed)
@@ -176,6 +189,7 @@ def _aggregate_pack(
         thinking_enabled=resolve_thinking_enabled(meta, thinking_override),
         variance=_repeat_variance(runs, repeat),
         catalog_scenario_count=catalog_scenario_count,
+        pass_at_k=_pass_at_k_summary(runs, configured_k),
     )
 
 
@@ -194,6 +208,8 @@ def _build_result(
     target_selection = list(config["target_selection"])
     _canonical, target_by_pack = validate_selection(target_selection)
     repeat = int(config.get("repeat") or 1)
+    retry_failures = int(config.get("retry_failures") or 0)
+    retry_runaways = bool(config.get("retry_runaways"))
     thinking_override = config.get("thinking_override")
     pack_order = list(config["pack_ids"])
     rows_by_pack: dict[str, dict[tuple[str, int], ScenarioRun]] = {}
@@ -222,6 +238,8 @@ def _build_result(
                 ),
                 repeat=repeat,
                 thinking_override=thinking_override,
+                retry_failures=retry_failures,
+                retry_runaways=retry_runaways,
             )
         )
 
@@ -244,6 +262,7 @@ def _build_result(
         sampling_source=config.get("sampling_source"),
         server_defaults=config.get("server_defaults"),
         selection=config.get("result_selection"),
+        pass_at_k=_combine_pass_at_k(packs),
     )
     retry_context = config.get("retry_failed")
     if retry_context is not None:
@@ -319,6 +338,8 @@ def _infer_config(data: dict, source: Path) -> dict:
         "sampling_overrides": data.get("sampling_overrides"),
         "sampling_source": data.get("sampling_source"),
         "server_defaults": data.get("server_defaults"),
+        "retry_failures": int((data.get("pass_at_k") or {}).get("k") or 0),
+        "retry_runaways": False,
         "save_json": str(final_path_for(source)),
     }
 
@@ -360,6 +381,8 @@ def load_resume(path: str | Path) -> ResumeState:
     config.setdefault("pack_ids", list(target_by_pack))
     config.setdefault("result_selection", previous_result.get("selection"))
     config.setdefault("repeat", 1)
+    config.setdefault("retry_failures", 0)
+    config.setdefault("retry_runaways", False)
     config.setdefault("save_json", str(final_path))
 
     completed: dict[str, dict[str, set[int]]] = {}

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -103,6 +103,46 @@ _CONTENT_FAILURE_MODES = frozenset({
     "wrong_structure",
 })
 
+# Inline failure-only retries (#111) deliberately distinguish model verdicts
+# from harness failures and expensive runaway behavior.
+DEFAULT_INLINE_RETRY_ATTEMPTS = 3
+_INFRA_FAILURE_MODES = frozenset({
+    "http_error",
+    "server_error",
+    "agent_runner_crashed",
+    "model_endpoint_unreachable",
+    "result_json_malformed",
+})
+_RUNAWAY_FAILURE_MODES = frozenset({
+    "token_limit",
+    "timeout",
+    "agent_runner_timeout",
+})
+
+_REASONING_HISTORY_FIELDS = frozenset({
+    "reasoning",
+    "reasoning_content",
+    "reasoning_details",
+    "codex_reasoning_items",
+})
+
+
+def strip_reasoning_history(messages: list[dict]) -> list[dict]:
+    """Return an outgoing-history copy without prior assistant reasoning fields.
+
+    Captured messages remain untouched. This intentionally operates only on the
+    request copy so saved raw responses, assistant_messages, and conversation
+    forensics retain the model's complete output.
+    """
+    sanitized: list[dict] = []
+    for message in messages:
+        outgoing = dict(message)
+        if outgoing.get("role") == "assistant":
+            for field in _REASONING_HISTORY_FIELDS:
+                outgoing.pop(field, None)
+        sanitized.append(outgoing)
+    return sanitized
+
 
 def pack_default_thinking(meta: dict) -> bool:
     """Return the pack-declared default thinking mode. Missing means off."""
@@ -395,6 +435,70 @@ def _repeat_variance(runs: list[ScenarioRun], repeat: int) -> dict[str, float | 
     return {"repeat": repeat, "mean": mean, "std": std, "cv": cv}
 
 
+def _pass_at_k_summary(
+    runs: list[ScenarioRun], configured_k: int
+) -> dict[str, float | int] | None:
+    """Aggregate nested inline retries without changing strict pass@1 fields."""
+    counted = [
+        run for run in runs
+        if run.result.failure_mode != "verifier_not_implemented"
+    ]
+    if not counted:
+        return None
+    max_attempts = max((run.attempt_count for run in counted), default=1)
+    if configured_k <= 1 and any(run.retry_eligible for run in counted):
+        # Infra failures retain the standard three-attempt ceiling even when
+        # model-verdict retries are disabled.
+        configured_k = DEFAULT_INLINE_RETRY_ATTEMPTS
+    k = max(int(configured_k), max_attempts)
+    if k <= 1:
+        return None
+    passed = sum(
+        1
+        for run in counted
+        if (run.result.passed if run.pass_at_k is None else bool(run.pass_at_k))
+    )
+    flaky = [
+        run for run in counted
+        if (run.label or "").startswith("pass@") and run.label != "pass@1"
+    ]
+    credited_flaky = sum(1 for run in flaky if bool(run.pass_at_k))
+    safety_flaky = sum(1 for run in flaky if not run.best_of_n_eligible)
+    total = len(counted)
+    return {
+        "k": k,
+        "passed": passed,
+        "total": total,
+        "score": passed / total if total else 0.0,
+        "credited_flaky": credited_flaky,
+        "safety_flaky": safety_flaky,
+        "systematic": sum(
+            1 for run in counted if not run.result.passed and run.label == "fail"
+        ),
+        "retried_scenarios": sum(1 for run in counted if run.attempt_count > 1),
+        "retry_attempts": sum(max(0, run.attempt_count - 1) for run in counted),
+    }
+
+
+def _combine_pass_at_k(packs: list[PackResult]) -> dict[str, float | int] | None:
+    summaries = [pack.pass_at_k for pack in packs if pack.pass_at_k is not None]
+    if not summaries:
+        return None
+    passed = sum(int(summary["passed"]) for summary in summaries)
+    total = sum(int(summary["total"]) for summary in summaries)
+    return {
+        "k": max(int(summary["k"]) for summary in summaries),
+        "passed": passed,
+        "total": total,
+        "score": passed / total if total else 0.0,
+        "credited_flaky": sum(int(summary.get("credited_flaky", 0)) for summary in summaries),
+        "safety_flaky": sum(int(summary.get("safety_flaky", 0)) for summary in summaries),
+        "systematic": sum(int(summary.get("systematic", 0)) for summary in summaries),
+        "retried_scenarios": sum(int(summary.get("retried_scenarios", 0)) for summary in summaries),
+        "retry_attempts": sum(int(summary.get("retry_attempts", 0)) for summary in summaries),
+    }
+
+
 class Runner:
     def __init__(
         self,
@@ -402,6 +506,7 @@ class Runner:
         endpoint: str,
         model: str,
         timeout_per_case: float | None = None,
+        timeout_ceiling_s: float | None = None,
         model_turn_timeout: float | None = 300.0,
         measured_tps: float | None = None,
         reference_tps: float | None = None,
@@ -419,6 +524,10 @@ class Runner:
         sandbox_log_dir: str | None = None,
         max_transient_retries: int = 3,
         retry_on_timeout: bool = False,
+        preserve_reasoning_history: bool = False,
+        retry_failures: int = DEFAULT_INLINE_RETRY_ATTEMPTS,
+        retry_runaways: bool = False,
+        inline_retries_enabled: bool = True,
         sampling_overrides: dict | None = None,
         sampling_from_server: bool = False,
         thinking_sampler: dict | None = None,
@@ -429,6 +538,11 @@ class Runner:
         self.endpoint = endpoint
         self.model = model
         self.timeout_per_case = None if timeout_per_case is None else float(timeout_per_case)
+        if timeout_ceiling_s is not None and float(timeout_ceiling_s) < 0:
+            raise ValueError("timeout_ceiling_s must be non-negative")
+        self.timeout_ceiling_s = (
+            None if timeout_ceiling_s is None else float(timeout_ceiling_s)
+        )
         if model_turn_timeout is not None and float(model_turn_timeout) < 0:
             raise ValueError("model_turn_timeout must be non-negative")
         self.model_turn_timeout = (
@@ -476,6 +590,15 @@ class Runner:
         # failing fast on the first timeout. Connection errors / HTTP 5xx are
         # genuinely transient and keep retrying regardless of this flag.
         self.retry_on_timeout = bool(retry_on_timeout)
+        # Reasoning is output-only for the default OpenAI-compatible/Qwen/R1
+        # path. Providers whose tool loops require signed/encrypted reasoning
+        # continuity can opt back into replay explicitly.
+        self.preserve_reasoning_history = bool(preserve_reasoning_history)
+        if int(retry_failures) < 0:
+            raise ValueError("retry_failures must be non-negative")
+        self.retry_failures = int(retry_failures)
+        self.retry_runaways = bool(retry_runaways)
+        self.inline_retries_enabled = bool(inline_retries_enabled)
         # CLI-level sampling overrides (--temperature, --top-p, etc.).
         # When set, the run is tagged as non-canonical in the output.
         self.sampling_overrides = sampling_overrides or {}
@@ -585,6 +708,7 @@ class Runner:
                 sampling_source="server" if self.sampling_from_server else None,
                 server_defaults=self._server_defaults if self.sampling_from_server else None,
                 selection=selection_ids,
+                pass_at_k=_combine_pass_at_k(pack_results),
             )
         finally:
             self._stop_sandboxes()
@@ -772,12 +896,31 @@ class Runner:
                 f"token-budget-multiplier={effective_max}/{baseline}={multiplier:.2f}"
             )
 
+        ceiling = self._timeout_ceiling_for_meta(meta)
+        if ceiling is not None and budget > ceiling:
+            budget = ceiling
+            note_parts.append(f"ceiling-clamped={ceiling:.0f}s")
+
         if note_parts:
             if not note_parts[0].startswith("timeout scaling active"):
                 note_parts.insert(0, "timeout scaling active")
             self._timeout_scaling_note = ", ".join(note_parts)
             self._emit_timeout_scaling_note_once()
         return budget
+
+    def _timeout_ceiling_for_meta(self, meta: dict) -> float | None:
+        value = (
+            self.timeout_ceiling_s
+            if self.timeout_ceiling_s is not None
+            else meta.get("timeout_ceiling_s")
+        )
+        if value is None:
+            return None
+        try:
+            ceiling = float(value)
+        except (TypeError, ValueError):
+            return None
+        return ceiling if ceiling > 0 else None
 
     def _reference_speed_scale(self, meta: dict) -> float | None:
         """rig-speed scale (reference_tps / measured_tps), or None when inapplicable."""
@@ -947,6 +1090,82 @@ class Runner:
             return None
         return statistics.mean(samples)
 
+    def _inline_retry_limit(self, meta: dict, run: ScenarioRun) -> int:
+        """Return the total-attempt cap for the latest failed attempt."""
+        if run.result.passed or run.result.failure_mode == "verifier_not_implemented":
+            return 1
+        mode = run.result.failure_mode
+        if mode in _CONTENT_FAILURE_MODES:
+            # A single-scoreboard scenario represents many independent units;
+            # best-of-N at the outer boolean would misstate its real pass rate.
+            if meta.get("_architecture") == "single-scoreboard":
+                return 1
+            return max(1, self.retry_failures)
+        if mode in _INFRA_FAILURE_MODES:
+            # Harness failures remain retryable even when model-verdict retries
+            # are disabled. This complements request-level transient retries.
+            return max(DEFAULT_INLINE_RETRY_ATTEMPTS, self.retry_failures)
+        if mode in _RUNAWAY_FAILURE_MODES and self.retry_runaways:
+            return max(DEFAULT_INLINE_RETRY_ATTEMPTS, self.retry_failures)
+        return 1
+
+    @staticmethod
+    def _best_of_n_eligible(scenario: dict) -> bool:
+        raw = scenario.get("raw_scenario")
+        return not bool(
+            scenario.get("no_best_of_n")
+            or (isinstance(raw, dict) and raw.get("no_best_of_n"))
+        )
+
+    def _run_scenario_with_inline_retries(
+        self,
+        meta: dict,
+        scenario: dict,
+        *,
+        repeat_index: int,
+    ) -> ScenarioRun:
+        """Run pass@1, then nest only retry-eligible failure attempts."""
+        baseline = self.run_scenario(meta, scenario, repeat_index=repeat_index)
+        baseline.best_of_n_eligible = self._best_of_n_eligible(scenario)
+        if baseline.result.failure_mode == "verifier_not_implemented":
+            return baseline
+
+        current = baseline
+        baseline.retry_eligible = self._inline_retry_limit(meta, current) > 1
+        while not current.result.passed:
+            attempt_limit = self._inline_retry_limit(meta, current)
+            if baseline.attempt_count >= attempt_limit:
+                break
+            current = self.run_scenario(meta, scenario, repeat_index=repeat_index)
+            baseline.retry_attempts.append(current.to_dict())
+            baseline.attempt_count += 1
+
+        passed_attempt: int | None = 1 if baseline.result.passed else None
+        if passed_attempt is None:
+            for attempt_index, retry in enumerate(baseline.retry_attempts, start=2):
+                if retry.get("passed"):
+                    passed_attempt = attempt_index
+                    break
+        baseline.label = f"pass@{passed_attempt}" if passed_attempt is not None else "fail"
+        baseline.pass_at_k = bool(
+            baseline.result.passed
+            or (passed_attempt is not None and baseline.best_of_n_eligible)
+        )
+        return baseline
+
+    def _configured_pass_at_k(self, meta: dict, repeat: int) -> int:
+        if (
+            repeat != 1
+            or self.negative_control is not None
+            or not self.inline_retries_enabled
+        ):
+            return 0
+        if meta.get("_architecture") == "single-scoreboard":
+            return 0
+        if self.retry_failures > 1:
+            return self.retry_failures
+        return DEFAULT_INLINE_RETRY_ATTEMPTS if self.retry_runaways else 0
+
     def run_pack(
         self,
         pack_id: str,
@@ -1037,7 +1256,18 @@ class Runner:
                 if repeat_index in completed_repeats.get(scenario["id"], set()):
                     continue
                 scenario_index += 1
-                run = self.run_scenario(meta, scenario, repeat_index=repeat_index)
+                if (
+                    repeat == 1
+                    and self.negative_control is None
+                    and self.inline_retries_enabled
+                ):
+                    run = self._run_scenario_with_inline_retries(
+                        meta, scenario, repeat_index=repeat_index
+                    )
+                else:
+                    # --repeat is the symmetric variance path and negative
+                    # controls must never multiply deterministic junk samples.
+                    run = self.run_scenario(meta, scenario, repeat_index=repeat_index)
                 runs.append(run)
                 if self._on_scenario_complete is not None:
                     self._on_scenario_complete(run, scenario_index, total_scenarios)
@@ -1084,6 +1314,10 @@ class Runner:
                     thinking_enabled=resolve_thinking_enabled(meta, self.thinking_override),
                     catalog_scenario_count=selected_catalog_count,
                     variance=_repeat_variance(runs, repeat),
+                    pass_at_k=_pass_at_k_summary(
+                        runs,
+                        self._configured_pass_at_k(meta, repeat),
+                    ),
                 )
 
         passed = sum(1 for run in counted if run.result.passed)
@@ -1102,6 +1336,10 @@ class Runner:
             thinking_enabled=resolve_thinking_enabled(meta, self.thinking_override),
             catalog_scenario_count=selected_catalog_count,
             variance=_repeat_variance(runs, repeat),
+            pass_at_k=_pass_at_k_summary(
+                runs,
+                self._configured_pass_at_k(meta, repeat),
+            ),
         )
 
     def run_scenario(self, meta: dict, scenario: dict, *, repeat_index: int = 1) -> ScenarioRun:
@@ -1517,6 +1755,7 @@ class Runner:
                         )
                     ),
                     "thinking_budget": self.thinking_max_tokens,
+                    "preserve_reasoning_history": self.preserve_reasoning_history,
                 }
             elif pack_id == "aider-polyglot-30":
                 # v0.9.0: aider needs a container-reachable URL. Apply the
@@ -1601,7 +1840,12 @@ class Runner:
             final_payload: dict | None = None
 
             for _turn in range(1, max_turns + 1):
-                request = build_chat_request(history, sampling, self.model, tools=tools)
+                request_history = (
+                    history
+                    if self.preserve_reasoning_history
+                    else strip_reasoning_history(history)
+                )
+                request = build_chat_request(request_history, sampling, self.model, tools=tools)
                 try:
                     status_code, raw_response, turn_transient_trace = self._post_chat(request, timeout)
                     transient_trace = _merge_transient_trace(transient_trace, turn_transient_trace)

--- a/benchlocal_cli/types.py
+++ b/benchlocal_cli/types.py
@@ -75,6 +75,18 @@ class ScenarioRun:
     # single-turn scenarios where the request `messages` field already captures
     # the full input. Populated by the runner's multi-turn loop.
     conversation: list[dict] = field(default_factory=list)
+    # Inline failure-only retry classification (#111). The top-level run is
+    # always attempt 1 and remains the authoritative pass@1 result. Retry
+    # attempts are nested so existing pass@1/delta/repeat consumers never
+    # accidentally count best-of-N samples as ordinary scenarios.
+    label: str | None = None
+    attempt_count: int = 1
+    retry_attempts: list[dict] = field(default_factory=list)
+    retry_eligible: bool = False
+    best_of_n_eligible: bool = True
+    # Whether this scenario receives pass@k credit. A safety scenario marked
+    # no_best_of_n can have label=pass@2 while this remains False.
+    pass_at_k: bool | None = None
 
     def to_dict(self) -> dict:
         data = asdict(self)
@@ -106,6 +118,8 @@ class PackResult:
     # Present only for a selected subset. scenario_count is the selected count;
     # this records the pack's complete catalog size for honest human rendering.
     catalog_scenario_count: int | None = None
+    # Additive best-of-k rollup; strict pass@1 remains in passed/total/score.
+    pass_at_k: dict[str, float | int] | None = None
 
     def to_dict(self) -> dict:
         out = {
@@ -126,6 +140,8 @@ class PackResult:
         }
         if self.catalog_scenario_count is not None:
             out["catalog_scenario_count"] = self.catalog_scenario_count
+        if self.pass_at_k is not None:
+            out["pass_at_k"] = self.pass_at_k
         return out
 
 
@@ -166,6 +182,8 @@ class RunResult:
     # Failure-conditioned retries are diagnostic only; baseline pass@1 remains
     # authoritative and is recorded alongside per-scenario consistency here.
     retry_failed: dict | None = None
+    # Additive best-of-k rollup for inline retries (#111).
+    pass_at_k: dict[str, float | int] | None = None
 
     def to_dict(self) -> dict:
         out = {
@@ -194,4 +212,6 @@ class RunResult:
             out["selection"] = self.selection
         if self.retry_failed is not None:
             out["retry_failed"] = self.retry_failed
+        if self.pass_at_k is not None:
+            out["pass_at_k"] = self.pass_at_k
         return out

--- a/docs/PACK_FORMAT.md
+++ b/docs/PACK_FORMAT.md
@@ -51,6 +51,7 @@ Field reference:
 | `default_max_seconds` | yes | int | Default per-scenario timeout from the upstream pack metadata |
 | `timeout_per_case_default` | no | int | Runner wall-clock timeout default for packs that need a larger local-model budget; overridden by `--timeout-per-case` |
 | `timeout_reference_tps` | no | number | Decode TPS used to calibrate `timeout_per_case_default`. When present and `--timeout-per-case` is not set, runner computes `effective_budget = base * max(1.0, timeout_reference_tps / measured_tps)`; `--timeout-scale-down` allows the scale to drop below 1.0 for faster models. |
+| `timeout_ceiling_s` | no | number | Maximum automatic/static scenario budget, applied after speed and thinking-token scaling. `--timeout-ceiling-s` / `BENCHLOCAL_TIMEOUT_CEILING_S` overrides it; an explicit CLI value of `0` disables the pack ceiling. Exact `--timeout-per-case` always wins. |
 | `verifier_module` | yes | string | Name of `benchlocal_cli/scoring/<name>.py` to dispatch to |
 | `supports_sandboxed_only` | no | bool | `true` for BugFind/HermesAgent/CLI/HumanEval+/LCB/Aider; runner skips with warning unless `--enable-sandboxed-packs` |
 | `safety_policy` | no | object / null | Optional benchmark-intent metadata for packs with safety/refusal scenarios. `mode: "implicit_benchmark_local"` means the pack uses terse task-local instructions and scores operational restraint under existing workspace/tool rules; it is not an explicit policy-following test. |
@@ -62,7 +63,9 @@ Field reference:
 
 ## Dynamic timeout scaling
 
-Agentic packs may include both `timeout_per_case_default` and `timeout_reference_tps`. The runner measures decode TPS once per `benchlocal-cli run` when a referenced pack needs scaling, unless `--measured-tps N` is provided. Slow models get proportionally larger wall-clock budgets; faster models keep the calibrated budget unless `--timeout-scale-down` is set. `--reference-tps N` overrides pack metadata for experiments. Explicit `--timeout-per-case` disables dynamic scaling and remains the exact per-scenario budget.
+Agentic packs may include both `timeout_per_case_default` and `timeout_reference_tps`. The runner measures decode TPS once per `benchlocal-cli run` when a referenced pack needs scaling, unless `--measured-tps N` is provided. Slow models get proportionally larger wall-clock budgets; faster models keep the calibrated budget unless `--timeout-scale-down` is set. `--reference-tps N` overrides pack metadata for experiments.
+
+After speed and thinking-token scaling, the runner applies `timeout_ceiling_s` when present. `--timeout-ceiling-s N` (or `BENCHLOCAL_TIMEOUT_CEILING_S`) overrides pack metadata, while `--timeout-ceiling-s 0` disables a pack ceiling. Explicit `--timeout-per-case` disables scaling and ceiling logic and remains the exact per-scenario budget.
 
 ## Scenario line
 
@@ -103,6 +106,7 @@ Agentic packs may include both `timeout_per_case_default` and `timeout_reference
   "sampling_overrides": {
     "max_tokens": 256
   },
+  "no_best_of_n": false,
   "max_seconds_override": null,
   "tags": ["single-tool", "date-format"],
   "upstream_scenario_id": "toolcall-15-001"
@@ -121,6 +125,7 @@ Scenario field reference:
 | `verifier.type` | yes | string | One of: `tool_call`, `instruct_follow`, `struct_output`, `reason_math`, `data_extract`, `answer_match`, `_stub` |
 | `verifier.asserts` | yes | array | Module-specific assertion objects (see below) |
 | `sampling_overrides` | no | object | Override metadata `sampling_defaults` for this scenario |
+| `no_best_of_n` | no | bool | Safety-sensitive best-of-N guard. Inline retries still run and are labeled, but a later pass does not receive pass@k credit. The same flag is honored inside `raw_scenario` for vendored payloads. |
 | `max_seconds_override` | no | int / null | Override metadata `default_max_seconds` |
 | `tags` | no | array | Free-form tags for filtering / grouping |
 | `upstream_scenario_id` | no | string | If this scenario was ported, the upstream id (usually same as `id`) |

--- a/sandboxes/hermes/server.py
+++ b/sandboxes/hermes/server.py
@@ -328,7 +328,7 @@ def _translate_request(req: dict) -> dict:
 
     Runner sends:
       { scenario_id, scenario, model_endpoint, model_name, model_api_key,
-        sampling, enable_thinking, thinking_budget }
+        sampling, enable_thinking, thinking_budget, preserve_reasoning_history }
 
     Upstream expects:
       { scenarioId, runId, model: {id, exposedModel, providerModel,
@@ -338,6 +338,11 @@ def _translate_request(req: dict) -> dict:
     scenario_id = req.get("scenario_id") or scenario.get("id") or "unknown"
     model_endpoint = req.get("model_endpoint") or ""
     model_name = req.get("model_name") or ""
+
+    generation = _filter_generation(req.get("sampling"))
+    generation["preserve_reasoning_history"] = bool(
+        req.get("preserve_reasoning_history")
+    )
 
     return {
         "scenarioId": scenario_id,
@@ -352,7 +357,7 @@ def _translate_request(req: dict) -> dict:
             "authMode": "bearer",
             "extraBody": _thinking_extra_body(req),
         },
-        "generation": _filter_generation(req.get("sampling")),
+        "generation": generation,
     }
 
 

--- a/tests/test_inline_retries.py
+++ b/tests/test_inline_retries.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from benchlocal_cli.cli import _markdown
+from benchlocal_cli.runner import Runner
+from benchlocal_cli.types import ScenarioResult, ScenarioRun
+
+
+def _scenario_run(scenario: dict, passed: bool, failure_mode: str, attempt: int) -> ScenarioRun:
+    return ScenarioRun(
+        id=scenario["id"],
+        result=ScenarioResult(
+            scenario_id=scenario["id"],
+            passed=passed,
+            failure_mode=failure_mode,  # type: ignore[arg-type]
+            detail=f"attempt {attempt}",
+            latency_seconds=float(attempt),
+        ),
+        raw_scenario=scenario,
+        raw_response={"attempt": attempt},
+        request={"attempt": attempt},
+        sampling_params={"temperature": 0},
+        status_code=200,
+    )
+
+
+def _runner_and_pack(
+    monkeypatch,
+    outcomes: Iterable[tuple[bool, str]],
+    *,
+    retry_failures: int = 3,
+    retry_runaways: bool = False,
+    scenario_overrides: dict | None = None,
+    repeat: int = 1,
+    inline_retries_enabled: bool = True,
+):
+    meta = {
+        "pack_id": "test-pack",
+        "version": "1.0.0",
+        "upstream_commit": "abc123",
+        "sampling_defaults": {"max_tokens": 32},
+    }
+    scenario = {
+        "id": "T-01",
+        "pack_id": "test-pack",
+        "messages": [{"role": "user", "content": "test"}],
+        **(scenario_overrides or {}),
+    }
+    monkeypatch.setattr(
+        "benchlocal_cli.runner.load_pack",
+        lambda _pack_id: (meta, [scenario]),
+    )
+    runner = Runner(
+        endpoint="mock",
+        model="mock",
+        retry_failures=retry_failures,
+        retry_runaways=retry_runaways,
+        inline_retries_enabled=inline_retries_enabled,
+    )
+    sequence = iter(outcomes)
+    calls: list[tuple[bool, str]] = []
+
+    def fake_run_scenario(_meta, current_scenario, *, repeat_index=1):
+        passed, failure_mode = next(sequence)
+        calls.append((passed, failure_mode))
+        run = _scenario_run(current_scenario, passed, failure_mode, len(calls))
+        run.repeat_index = repeat_index
+        return run
+
+    monkeypatch.setattr(runner, "run_scenario", fake_run_scenario)
+    return runner, runner.run_pack("test-pack", repeat=repeat), calls
+
+
+def test_inline_retry_rescues_content_failure_without_changing_pass_at_one(monkeypatch):
+    _runner, pack, calls = _runner_and_pack(
+        monkeypatch,
+        [(False, "wrong_answer"), (True, "passed")],
+    )
+
+    assert calls == [(False, "wrong_answer"), (True, "passed")]
+    assert (pack.passed, pack.total, pack.score) == (0, 1, 0.0)
+    assert pack.pass_at_k == {
+        "k": 3,
+        "passed": 1,
+        "total": 1,
+        "score": 1.0,
+        "credited_flaky": 1,
+        "safety_flaky": 0,
+        "systematic": 0,
+        "retried_scenarios": 1,
+        "retry_attempts": 1,
+    }
+    run = pack.scenarios[0]
+    assert run.result.passed is False
+    assert run.label == "pass@2"
+    assert run.attempt_count == 2
+    assert run.pass_at_k is True
+    assert run.retry_attempts[0]["raw_response"] == {"attempt": 2}
+
+
+def test_inline_retry_stops_after_first_pass(monkeypatch):
+    _runner, pack, calls = _runner_and_pack(
+        monkeypatch,
+        [(False, "wrong_answer"), (True, "passed")],
+        retry_failures=5,
+    )
+
+    assert len(calls) == 2
+    assert pack.scenarios[0].label == "pass@2"
+    assert pack.pass_at_k["k"] == 5
+
+
+def test_inline_retry_labels_all_failed_attempts_systematic(monkeypatch):
+    _runner, pack, calls = _runner_and_pack(
+        monkeypatch,
+        [
+            (False, "wrong_answer"),
+            (False, "wrong_answer"),
+            (False, "wrong_answer"),
+        ],
+    )
+
+    assert len(calls) == 3
+    assert pack.scenarios[0].label == "fail"
+    assert pack.scenarios[0].attempt_count == 3
+    assert pack.pass_at_k["passed"] == 0
+    assert pack.pass_at_k["systematic"] == 1
+
+
+def test_runaway_is_not_retried_without_opt_in(monkeypatch):
+    _runner, pack, calls = _runner_and_pack(
+        monkeypatch,
+        [(False, "token_limit")],
+    )
+
+    assert len(calls) == 1
+    assert pack.scenarios[0].retry_eligible is False
+    assert pack.scenarios[0].label == "fail"
+    assert pack.pass_at_k["systematic"] == 1
+
+
+def test_retry_runaways_opts_expensive_failures_back_in(monkeypatch):
+    _runner, pack, calls = _runner_and_pack(
+        monkeypatch,
+        [(False, "timeout"), (True, "passed")],
+        retry_runaways=True,
+    )
+
+    assert len(calls) == 2
+    assert pack.scenarios[0].label == "pass@2"
+    assert pack.pass_at_k["passed"] == 1
+
+
+def test_no_best_of_n_safety_scenario_keeps_retry_information_without_credit(monkeypatch):
+    _runner, pack, calls = _runner_and_pack(
+        monkeypatch,
+        [(False, "verifier_fail"), (True, "passed")],
+        scenario_overrides={"no_best_of_n": True},
+    )
+
+    assert len(calls) == 2
+    run = pack.scenarios[0]
+    assert run.label == "pass@2"
+    assert run.best_of_n_eligible is False
+    assert run.pass_at_k is False
+    assert pack.pass_at_k["passed"] == 0
+    assert pack.pass_at_k["credited_flaky"] == 0
+    assert pack.pass_at_k["safety_flaky"] == 1
+
+
+def test_infra_failure_retries_even_when_model_verdict_retries_are_disabled(monkeypatch):
+    _runner, pack, calls = _runner_and_pack(
+        monkeypatch,
+        [(False, "http_error"), (True, "passed")],
+        retry_failures=0,
+    )
+
+    assert len(calls) == 2
+    assert pack.scenarios[0].label == "pass@2"
+    assert pack.pass_at_k["k"] == 3
+    assert pack.pass_at_k["passed"] == 1
+
+
+def test_no_retry_disables_content_retries_and_pass_at_k(monkeypatch):
+    _runner, pack, calls = _runner_and_pack(
+        monkeypatch,
+        [(False, "wrong_answer")],
+        retry_failures=0,
+    )
+
+    assert len(calls) == 1
+    assert pack.scenarios[0].label == "fail"
+    assert pack.pass_at_k is None
+
+
+def test_hard_bypass_disables_infra_retries_for_posthoc_diagnostics(monkeypatch):
+    _runner, pack, calls = _runner_and_pack(
+        monkeypatch,
+        [(False, "http_error")],
+        retry_failures=0,
+        inline_retries_enabled=False,
+    )
+
+    assert len(calls) == 1
+    assert pack.scenarios[0].label is None
+    assert pack.pass_at_k is None
+
+
+def test_repeat_remains_symmetric_and_disables_nested_inline_retries(monkeypatch):
+    _runner, pack, calls = _runner_and_pack(
+        monkeypatch,
+        [(False, "wrong_answer"), (True, "passed")],
+        repeat=2,
+    )
+
+    assert len(calls) == 2
+    assert [run.repeat_index for run in pack.scenarios] == [1, 2]
+    assert all(run.retry_attempts == [] for run in pack.scenarios)
+    assert all(run.label is None for run in pack.scenarios)
+    assert pack.pass_at_k is None
+    assert pack.variance is not None
+
+
+def test_run_and_markdown_report_pass_at_one_and_pass_at_k_together(monkeypatch):
+    meta = {
+        "pack_id": "test-pack",
+        "version": "1.0.0",
+        "upstream_commit": "abc123",
+        "sampling_defaults": {"max_tokens": 32},
+    }
+    scenario = {
+        "id": "T-01",
+        "pack_id": "test-pack",
+        "messages": [{"role": "user", "content": "test"}],
+    }
+    monkeypatch.setattr(
+        "benchlocal_cli.runner.load_pack",
+        lambda _pack_id: (meta, [scenario]),
+    )
+    runner = Runner(endpoint="mock", model="mock")
+    outcomes = iter([(False, "wrong_answer"), (True, "passed")])
+
+    def fake_run_scenario(_meta, current_scenario, *, repeat_index=1):
+        passed, failure_mode = next(outcomes)
+        return _scenario_run(current_scenario, passed, failure_mode, 1 if not passed else 2)
+
+    monkeypatch.setattr(runner, "run_scenario", fake_run_scenario)
+    result = runner.run(["test-pack"])
+    rendered = _markdown(result)
+
+    assert result.totals == {"passed": 0, "total": 1, "score": 0.0}
+    assert result.pass_at_k["passed"] == 1
+    assert "Pack | Pass@1 | Pass@3 | Flaky" in rendered
+    assert "TOTAL | 0 / 1 (0%) | 1 / 1 (100%) | 1" in rendered
+    assert "test-pack/T-01 | pass@2 | 2 | yes" in rendered

--- a/tests/test_reasoning_handling.py
+++ b/tests/test_reasoning_handling.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from benchlocal_cli.runner import Runner, build_request
+from benchlocal_cli.runner import Runner, build_request, strip_reasoning_history
 from benchlocal_cli.scoring.common import content_with_source, sanitize_reasoning_tags
 
 
@@ -142,6 +142,32 @@ def test_content_fallback_reads_reasoning_content():
     response = {"choices": [{"message": {"content": "", "reasoning_content": "hello from thought"}}]}
 
     assert content_with_source(response) == ("hello from thought", "message.reasoning_content")
+
+
+def test_strip_reasoning_history_removes_only_outgoing_assistant_fields():
+    messages = [
+        {"role": "user", "content": "go", "reasoning": "user metadata"},
+        {
+            "role": "assistant",
+            "content": "calling tool",
+            "reasoning": "private",
+            "reasoning_content": "private-alt",
+            "reasoning_details": [{"signature": "opaque"}],
+            "codex_reasoning_items": [{"type": "reasoning"}],
+            "tool_calls": [{"id": "call-1"}],
+        },
+    ]
+
+    outgoing = strip_reasoning_history(messages)
+
+    assert outgoing[0]["reasoning"] == "user metadata"
+    assert outgoing[1] == {
+        "role": "assistant",
+        "content": "calling tool",
+        "tool_calls": [{"id": "call-1"}],
+    }
+    assert messages[1]["reasoning"] == "private"
+    assert messages[1]["reasoning_details"] == [{"signature": "opaque"}]
 
 
 def test_runner_json_records_thinking_state_and_response_field():

--- a/tests/test_retry_failed.py
+++ b/tests/test_retry_failed.py
@@ -63,10 +63,28 @@ def test_parser_defaults_retry_failed_to_three_and_repeat_to_zero():
 
     absent = parser.parse_args(["run"])
     bare = parser.parse_args(["run", "--retry-failed"])
+    disabled = parser.parse_args(["run", "--no-retry"])
 
     assert absent.repeat == 0
     assert absent.retry_failed is None
+    assert absent.retry_failures == 3
     assert bare.retry_failed == 3
+    assert disabled.retry_failures == 0
+
+
+def test_parser_reads_timeout_ceiling_env_and_reasoning_history_opt_in(monkeypatch):
+    monkeypatch.setenv("BENCHLOCAL_TIMEOUT_CEILING_S", "900")
+    parser = _parser()
+
+    defaults = parser.parse_args(["run"])
+    explicit = parser.parse_args(
+        ["run", "--timeout-ceiling-s", "1200", "--preserve-reasoning-history"]
+    )
+
+    assert defaults.timeout_ceiling_s == 900
+    assert defaults.preserve_reasoning_history is False
+    assert explicit.timeout_ceiling_s == 1200
+    assert explicit.preserve_reasoning_history is True
 
 
 def test_failed_selection_uses_pass_at_one_not_later_repeat_arms():

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -148,6 +148,7 @@ class FakeHTTPResponse:
 class FakeHTTPClient:
     calls = 0
     timeouts: list[float] = []
+    requests: list[dict] = []
 
     def __init__(self, timeout: float) -> None:
         self.timeout = timeout
@@ -161,6 +162,7 @@ class FakeHTTPClient:
 
     def post(self, url: str, json: dict, **_kwargs) -> FakeHTTPResponse:
         FakeHTTPClient.calls += 1
+        FakeHTTPClient.requests.append(json)
         if FakeHTTPClient.calls == 1:
             return FakeHTTPResponse(
                 {
@@ -169,6 +171,10 @@ class FakeHTTPClient:
                             "message": {
                                 "role": "assistant",
                                 "content": "",
+                                "reasoning": "private chain",
+                                "reasoning_content": "private content",
+                                "reasoning_details": [{"type": "summary", "text": "private"}],
+                                "codex_reasoning_items": [{"type": "reasoning", "id": "r1"}],
                                 "tool_calls": [
                                     {
                                         "id": "call-1",
@@ -185,13 +191,25 @@ class FakeHTTPClient:
         return FakeHTTPResponse({"choices": [{"message": {"role": "assistant", "content": "<solution verdict=\"done\"></solution>"}}], "usage": {"completion_tokens": 5}})
 
 
-def test_runner_drives_sandbox_multiturn_loop(monkeypatch):
+@pytest.mark.parametrize(
+    ("preserve_reasoning_history", "expect_replayed"),
+    [(False, False), (True, True)],
+)
+def test_runner_drives_sandbox_multiturn_loop(
+    monkeypatch, preserve_reasoning_history, expect_replayed
+):
     import benchlocal_cli.runner as runner_module
 
     FakeHTTPClient.calls = 0
     FakeHTTPClient.timeouts = []
+    FakeHTTPClient.requests = []
     monkeypatch.setattr(runner_module.httpx, "Client", FakeHTTPClient)
-    runner = Runner(endpoint="http://localhost:9999", model="fake", enable_sandboxed_packs=True)
+    runner = Runner(
+        endpoint="http://localhost:9999",
+        model="fake",
+        enable_sandboxed_packs=True,
+        preserve_reasoning_history=preserve_reasoning_history,
+    )
     fake = FakeMultiTurnSandbox()
     runner._sandbox_clients["cli-40"] = fake
     meta = {
@@ -216,6 +234,15 @@ def test_runner_drives_sandbox_multiturn_loop(monkeypatch):
     assert len(run.tool_calls) == 1
     assert fake.ended is False
     assert "model_endpoint" not in fake.start_kwargs
+    assert run.assistant_messages[0]["reasoning"] == "private chain"
+    assert run.conversation[1]["reasoning_content"] == "private content"
+    replayed_assistant = next(
+        message
+        for message in FakeHTTPClient.requests[1]["messages"]
+        if message.get("role") == "assistant"
+    )
+    for field in ("reasoning", "reasoning_content", "reasoning_details", "codex_reasoning_items"):
+        assert (field in replayed_assistant) is expect_replayed
 
 
 def test_runner_scales_timeout_budget_for_slow_measured_tps(monkeypatch):
@@ -292,6 +319,60 @@ def test_runner_explicit_timeout_per_case_disables_dynamic_scaling(monkeypatch):
     monkeypatch.setattr(runner, "_probe_decode_tps", fail_probe)
 
     assert runner._timeout_budget_for_meta({"timeout_per_case_default": 300, "timeout_reference_tps": 100}) == 45
+
+
+def test_runner_applies_timeout_ceiling_after_speed_and_token_scaling():
+    runner = Runner(
+        endpoint="http://localhost:9999",
+        model="fake",
+        measured_tps=50,
+        thinking_enabled=True,
+        thinking_max_tokens=4096,
+        timeout_ceiling_s=400,
+    )
+    meta = {
+        "timeout_per_case_default": 60,
+        "timeout_reference_tps": 100,
+        "timeout_baseline_tokens": 1024,
+        "sampling_defaults": {"max_tokens": 1024},
+    }
+
+    assert runner._timeout_budget_for_meta(meta) == 400
+    assert "scale=2.00" in runner._timeout_scaling_note
+    assert "token-budget-multiplier=4096/1024=4.00" in runner._timeout_scaling_note
+    assert "ceiling-clamped=400s" in runner._timeout_scaling_note
+
+
+def test_runner_uses_pack_timeout_ceiling_when_cli_ceiling_is_unset():
+    runner = Runner(endpoint="http://localhost:9999", model="fake")
+
+    assert runner._timeout_budget_for_meta(
+        {"timeout_per_case_default": 300, "timeout_ceiling_s": 75}
+    ) == 75
+
+
+def test_runner_cli_timeout_ceiling_overrides_pack_ceiling():
+    runner = Runner(endpoint="http://localhost:9999", model="fake", timeout_ceiling_s=45)
+
+    assert runner._timeout_budget_for_meta(
+        {"timeout_per_case_default": 300, "timeout_ceiling_s": 75}
+    ) == 45
+
+
+def test_runner_zero_timeout_ceiling_disables_pack_ceiling():
+    runner = Runner(endpoint="http://localhost:9999", model="fake", timeout_ceiling_s=0)
+
+    assert runner._timeout_budget_for_meta(
+        {"timeout_per_case_default": 300, "timeout_ceiling_s": 75}
+    ) == 300
+
+
+def test_runner_explicit_timeout_per_case_wins_over_timeout_ceiling():
+    runner = Runner(
+        endpoint="http://localhost:9999", model="fake", timeout_per_case=180, timeout_ceiling_s=45
+    )
+
+    assert runner._timeout_budget_for_meta({"timeout_per_case_default": 300}) == 180
 
 
 def test_probe_clamps_thinking_to_one_token(monkeypatch):

--- a/tests/test_sandbox_verifiers.py
+++ b/tests/test_sandbox_verifiers.py
@@ -48,6 +48,28 @@ def _load_hermes_approval_callback():
     return namespace["_build_approval_callback"]
 
 
+def _load_hermes_reasoning_policy():
+    source_path = ROOT / "vendor/HermesAgent-20/verification/agent-runner.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    selected = [
+        node for node in tree.body
+        if isinstance(node, (ast.Assign, ast.FunctionDef))
+        and (
+            (
+                isinstance(node, ast.FunctionDef)
+                and node.name == "_set_reasoning_history_policy"
+            )
+            or (
+                isinstance(node, ast.Assign)
+                and any(isinstance(target, ast.Name) and target.id == "REASONING_HISTORY_FIELDS" for target in node.targets)
+            )
+        )
+    ]
+    namespace = {"AIAgent": object}
+    exec(compile(ast.Module(body=selected, type_ignores=[]), str(source_path), "exec"), namespace)
+    return namespace["_set_reasoning_history_policy"]
+
+
 def test_bugfind_rubric_pass_and_fail():
     server = _load("bugfind_server", "sandboxes/bugfind/server.py")
     scenario = {
@@ -653,9 +675,33 @@ def test_hermes_translate_request_normalizes_endpoint_and_filters_generation():
     assert out["model"]["inferenceBaseUrl"] == "http://10.0.0.5:8001/v1"
     assert out["model"]["exposedModel"] == "qwen3.6-27b-autoround"
     assert out["model"]["apiKey"] == "sk-test"
-    assert out["generation"] == {"temperature": 0.6, "top_p": 0.95, "max_tokens": 256}
+    assert out["generation"] == {
+        "temperature": 0.6,
+        "top_p": 0.95,
+        "max_tokens": 256,
+        "preserve_reasoning_history": False,
+    }
+    assert server._translate_request(
+        {**req, "preserve_reasoning_history": True}
+    )["generation"]["preserve_reasoning_history"] is True
     assert "runId" in out and len(out["runId"]) > 0
     assert out["model"]["extraBody"] == {"enable_thinking": True, "thinking_budget": 4096}
+
+
+def test_hermes_reasoning_policy_strips_only_outgoing_api_copy():
+    class FakeAgent:
+        def _copy_reasoning_content_for_api(self, source_msg, api_msg):
+            api_msg["reasoning"] = source_msg.get("reasoning")
+
+    agent = FakeAgent()
+    _load_hermes_reasoning_policy()(agent, preserve=False)
+    stored = {"role": "assistant", "content": "tool call", "reasoning": "private"}
+    outgoing = dict(stored)
+
+    agent._copy_reasoning_content_for_api(stored, outgoing)
+
+    assert "reasoning" not in outgoing
+    assert stored["reasoning"] == "private"
 
 
 @pytest.mark.parametrize(

--- a/vendor/HermesAgent-20/verification/agent-runner.py
+++ b/vendor/HermesAgent-20/verification/agent-runner.py
@@ -16,6 +16,28 @@ from hermes_state import SessionDB
 from run_agent import AIAgent
 from tools.terminal_tool import set_approval_callback
 
+REASONING_HISTORY_FIELDS = (
+    "reasoning",
+    "reasoning_content",
+    "reasoning_details",
+    "codex_reasoning_items",
+)
+
+
+def _set_reasoning_history_policy(agent: AIAgent, preserve: bool) -> None:
+    """Strip reasoning only from Hermes' outgoing replay copy by default."""
+    if preserve:
+        return
+
+    def _strip_reasoning_for_api(_source_msg: dict, api_msg: dict) -> None:
+        for field in REASONING_HISTORY_FIELDS:
+            api_msg.pop(field, None)
+
+    # The pinned agent calls this hook after copying each stored message and
+    # before sending api_messages. Replacing the instance hook leaves its
+    # session DB and result capture untouched.
+    agent._copy_reasoning_content_for_api = _strip_reasoning_for_api
+
 
 def _read_json(path: Path) -> Dict[str, Any]:
     with path.open("r", encoding="utf-8") as handle:
@@ -254,6 +276,10 @@ def main() -> int:
             tool_start_callback=_tool_started,
             tool_complete_callback=_tool_completed,
             clarify_callback=clarify_callback,
+        )
+        _set_reasoning_history_policy(
+            agent,
+            bool((request.get("generation") or {}).get("preserve_reasoning_history")),
         )
 
         result = agent.run_conversation(str(request.get("prompt") or ""))


### PR DESCRIPTION
## Summary

- add configurable post-scaling timeout ceilings with CLI, environment, and pack metadata precedence
- add default failure-only inline retries while preserving strict pass@1 and reporting additive pass@k
- strip prior assistant reasoning fields from outgoing agent-loop history by default, with an explicit preservation flag
- document the new CLI and pack behaviors

## Validation

- 324 tests passed
- focused Ruff checks passed
- changed Python files compile cleanly
- git diff --check passed

Closes #110
Closes #111
Closes #112