### PR TITLE
fix(sandbox): add preserve_reasoning_history to verify_multiturn_start

### DIFF
--- a/benchlocal_cli/sandbox.py
+++ b/benchlocal_cli/sandbox.py
@@ -458,6 +458,7 @@ class SandboxClient:
         sampling: dict | None = None,
         enable_thinking: bool | None = None,
         thinking_budget: int | None = None,
+        preserve_reasoning_history: bool | None = None,
     ) -> dict:
         """Initialize a sandbox-owned multi-turn scenario state.
 
@@ -482,6 +483,8 @@ class SandboxClient:
             payload["enable_thinking"] = enable_thinking
         if thinking_budget is not None:
             payload["thinking_budget"] = thinking_budget
+        if preserve_reasoning_history is not None:
+            payload["preserve_reasoning_history"] = preserve_reasoning_history
         return self._post("/verify-start", payload)
 
     def verify_multiturn_turn(self, scenario_state_id: str, model_response: dict) -> dict:


### PR DESCRIPTION
## Summary

- add `preserve_reasoning_history` to `SandboxClient.verify_multiturn_start()` signature
- forward it to the `/verify-start` payload

## Validation

- `python3 -m py_compile benchlocal_cli/sandbox.py`
- `git diff --check` passed
- Executed a `benchlocal-cli run` complete with sandbox tests