### PR TITLE
fix(reasoning): make code sandbox scoring content-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,11 +343,11 @@ benchlocal-cli inspect results.json --logs ./sandbox-logs    # pull sandboxed-pa
 benchlocal-cli rescore results.json --pack reasonmath-15 --output rescored.json
 ```
 
-Use `rescore` when a deterministic scorer changes and the saved JSON already contains `raw_response`. It re-grades from the stored model responses without calling the endpoint again; sandbox-backed packs are skipped because their verifier state lives in Docker fixtures.
+Use `rescore` when a scorer changes and the saved JSON already contains `raw_response`. It re-grades from stored model responses without calling the endpoint again. Replayable single-turn sandbox packs (currently BugFind, HumanEval+, and LiveCodeBench) are re-run inside their pre-built verifier containers; multi-turn/workspace packs remain skipped because their destroyed filesystem or agent state cannot be reconstructed from JSON. Use `--sandbox-image-tag` when the corrected verifier was built under a non-`latest` tag.
 
 `failure_mode` is one of `verifier_fail`, `token_limit`, `timeout`, `agent_runner_timeout`, `agent_runner_crashed`, `server_error`, `http_error`, `model_endpoint_unreachable`, `result_json_malformed`, `wrong_answer`, `verifier_not_implemented`.
 
-`token_limit` (#61) means the completion hit the token cap (`finish_reason == "length"`) and was truncated mid-output — the model overthought or looped until the budget ran out, *not* a content verdict. It's reclassified from the underlying content-failure (the original verdict is kept in `detail`), so "looped / truncated" reads distinctly from "ran to completion but wrong" (`verifier_fail`). Filter it with `inspect --mode token_limit`.
+`token_limit` (#61) means a failed completion hit the token cap (`finish_reason == "length"`) and was truncated mid-output — the model overthought or looped until the budget ran out, *not* a content verdict. It's reclassified from the underlying content-failure (the original verdict is kept in `detail`), so "looped / truncated" reads distinctly from "ran to completion but wrong" (`verifier_fail`). Filter it with `inspect --mode token_limit`. The pack-level `diagnostics.finish_reasons` rollup counts `length` across every recorded completion, including successful, retry, and multi-turn responses that the failure label intentionally does not reclassify. Code-reasoning packs also expose extraction method, issue, and selected response-field distributions under `diagnostics.extraction`.
 
 ## Negative control (grader false-positive probe)
 

--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -712,6 +712,35 @@ def _markdown(result: RunResult) -> str:
                 )
         else:
             lines.append("all scenarios | pass@1 | 1 | yes")
+    diagnostic_packs = [pack for pack in result.packs if pack.diagnostics]
+    if diagnostic_packs:
+        lines.extend(
+            [
+                "",
+                "Completion and extraction diagnostics:",
+                "",
+                "Pack | finish_reason=length | extraction_method | extraction_issue | response_field_used",
+                "---|---:|---|---|---",
+            ]
+        )
+        for pack in diagnostic_packs:
+            diagnostics = pack.diagnostics or {}
+            finish = diagnostics.get("finish_reasons") or {}
+            total = int(finish.get("total") or 0)
+            length = int(finish.get("length") or 0)
+            rate = float(finish.get("length_rate") or 0.0)
+            finish_cell = f"{length} / {total} ({rate:.1%})" if total else "—"
+            extraction = diagnostics.get("extraction") or {}
+
+            def _counts(name: str) -> str:
+                values = extraction.get(name) or {}
+                return ", ".join(f"{key}={value}" for key, value in values.items()) or "—"
+
+            lines.append(
+                f"{pack.pack_id} | {finish_cell} | {_counts('methods')} | "
+                f"{_counts('issues')} | {_counts('response_fields')}"
+            )
+
     failures: list[str] = []
     for pack in result.packs:
         for scenario in pack.scenarios:

--- a/benchlocal_cli/diagnostics.py
+++ b/benchlocal_cli/diagnostics.py
@@ -1,0 +1,96 @@
+"""Aggregate completion and extraction diagnostics for saved pack results."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+def _get(value: Any, key: str, default: Any = None) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _result_value(run: Any, key: str, default: Any = None) -> Any:
+    result = _get(run, "result")
+    value = _get(result, key) if result is not None else None
+    return _get(run, key, default) if value is None else value
+
+
+def _iter_attempts(run: Any) -> Iterable[Any]:
+    yield run
+    attempts = _get(run, "retry_attempts", [])
+    if isinstance(attempts, list):
+        yield from (attempt for attempt in attempts if isinstance(attempt, Mapping))
+
+
+def _iter_responses(raw_response: Any) -> Iterable[Mapping[str, Any]]:
+    if not isinstance(raw_response, Mapping):
+        return
+    responses = raw_response.get("responses")
+    if isinstance(responses, list):
+        for response in responses:
+            yield from _iter_responses(response)
+        return
+    yield raw_response
+
+
+def _finish_reason(response: Mapping[str, Any]) -> str | None:
+    choices = response.get("choices")
+    if not (isinstance(choices, list) and choices and isinstance(choices[0], Mapping)):
+        return None
+    value = choices[0].get("finish_reason")
+    return str(value) if value not in (None, "") else "unknown"
+
+
+def _sorted_counts(values: Counter[str]) -> dict[str, int]:
+    return {key: values[key] for key in sorted(values)}
+
+
+def pack_diagnostics(runs: Iterable[Any]) -> dict[str, Any] | None:
+    """Summarize all saved completions, including nested retry/multi-turn calls."""
+
+    finish_reasons: Counter[str] = Counter()
+    extraction_methods: Counter[str] = Counter()
+    extraction_issues: Counter[str] = Counter()
+    response_fields: Counter[str] = Counter()
+
+    for run in runs:
+        for attempt in _iter_attempts(run):
+            for response in _iter_responses(_get(attempt, "raw_response")):
+                reason = _finish_reason(response)
+                if reason is not None:
+                    finish_reasons[reason] += 1
+
+            trace = _result_value(attempt, "verifier_trace")
+            if not isinstance(trace, Mapping):
+                trace = {}
+            method = trace.get("extraction_method")
+            issue = trace.get("extraction_issue")
+            source = trace.get("response_field_used") or _get(attempt, "response_field_used")
+            if method:
+                extraction_methods[str(method)] += 1
+            if issue:
+                extraction_issues[str(issue)] += 1
+            if source:
+                response_fields[str(source)] += 1
+
+    diagnostics: dict[str, Any] = {}
+    total = sum(finish_reasons.values())
+    if total:
+        length = finish_reasons.get("length", 0)
+        diagnostics["finish_reasons"] = {
+            "total": total,
+            "length": length,
+            "length_rate": length / total,
+            "counts": _sorted_counts(finish_reasons),
+        }
+    if extraction_methods or extraction_issues or response_fields:
+        diagnostics["extraction"] = {
+            "methods": _sorted_counts(extraction_methods),
+            "issues": _sorted_counts(extraction_issues),
+            "response_fields": _sorted_counts(response_fields),
+        }
+    return diagnostics or None

--- a/benchlocal_cli/persistence.py
+++ b/benchlocal_cli/persistence.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, fields
 from pathlib import Path
 
 from benchlocal_cli import __version__
+from benchlocal_cli.diagnostics import pack_diagnostics
 from benchlocal_cli.runner import (
     DEFAULT_INLINE_RETRY_ATTEMPTS,
     PACK_MODES,
@@ -171,6 +172,7 @@ def _aggregate_pack(
                 variance=_repeat_variance(runs, repeat),
                 catalog_scenario_count=catalog_scenario_count,
                 pass_at_k=_pass_at_k_summary(runs, configured_k),
+                diagnostics=pack_diagnostics(runs),
             )
 
     passed = sum(1 for run in counted if run.result.passed)
@@ -190,6 +192,7 @@ def _aggregate_pack(
         variance=_repeat_variance(runs, repeat),
         catalog_scenario_count=catalog_scenario_count,
         pass_at_k=_pass_at_k_summary(runs, configured_k),
+        diagnostics=pack_diagnostics(runs),
     )
 
 

--- a/benchlocal_cli/rescore.py
+++ b/benchlocal_cli/rescore.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import importlib
 import json
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
-from benchlocal_cli.runner import _utc_now, load_pack
+from benchlocal_cli.diagnostics import pack_diagnostics
+from benchlocal_cli.runner import Runner, _utc_now, load_pack
+from benchlocal_cli.sandbox import SANDBOX_REGISTRY, SandboxClient, config_for_pack
 from benchlocal_cli.scoring.common import content_with_source
 
 
@@ -19,13 +22,24 @@ def add_rescore_subparser(sub) -> None:
     parser.add_argument("--in-place", action="store_true", help="overwrite the input JSON with rescored results")
     parser.add_argument("--pack", help="only rescore one pack id, e.g. reasonmath-15")
     parser.add_argument(
+        "--sandbox-image-tag",
+        default="latest",
+        help="sandbox image tag for replayable execution-backed packs (default: latest)",
+    )
+    parser.add_argument(
         "--allow-partial",
         action="store_true",
         help="allow rescoring a scenario-selection result (not a canonical pack total)",
     )
 
 
-def _score_saved_scenario(pack_meta: dict, scenario_index: dict[str, dict], run: dict) -> tuple[bool, str | None]:
+def _score_saved_scenario(
+    pack_meta: dict,
+    scenario_index: dict[str, dict],
+    run: dict,
+    *,
+    sandbox_client: SandboxClient | None = None,
+) -> tuple[bool, str | None]:
     raw_response = run.get("raw_response")
     if not isinstance(raw_response, dict):
         return False, "missing raw_response"
@@ -35,17 +49,28 @@ def _score_saved_scenario(pack_meta: dict, scenario_index: dict[str, dict], run:
     if not isinstance(scenario, dict):
         return False, "missing scenario definition"
 
-    verifier_type = scenario.get("verifier", {}).get("type") or pack_meta.get("verifier_module")
-    if not verifier_type or verifier_type == "_stub":
-        return False, "sandbox/stub scorer not rescored"
-
-    module = importlib.import_module(f"benchlocal_cli.scoring.{verifier_type}")
-    result = module.score_scenario(scenario, raw_response)
+    if pack_meta.get("supports_sandboxed_only"):
+        if sandbox_client is None:
+            return False, "sandbox state not replayable"
+        request = run.get("request") if isinstance(run.get("request"), dict) else {}
+        messages = request.get("messages") if isinstance(request.get("messages"), list) else []
+        result = sandbox_client.verify(scenario, raw_response, messages)
+    else:
+        verifier_type = scenario.get("verifier", {}).get("type") or pack_meta.get("verifier_module")
+        if not verifier_type or verifier_type == "_stub":
+            return False, "sandbox/stub scorer not rescored"
+        module = importlib.import_module(f"benchlocal_cli.scoring.{verifier_type}")
+        result = module.score_scenario(scenario, raw_response)
 
     previous = run.get("result") if isinstance(run.get("result"), dict) else {}
-    result.latency_seconds = float(previous.get("latency_seconds") or run.get("latency_seconds") or 0.0)
+    latency = float(previous.get("latency_seconds") or run.get("latency_seconds") or 0.0)
     tokens = previous.get("tokens_completion", run.get("tokens_completion"))
-    result.tokens_completion = tokens if isinstance(tokens, int) else None
+    result = replace(
+        result,
+        latency_seconds=latency,
+        tokens_completion=tokens if isinstance(tokens, int) else None,
+    )
+    result = Runner._reclassify_if_truncated(result, raw_response)
 
     result_dict = result.to_dict()
     run["result"] = result_dict
@@ -66,6 +91,11 @@ def _recompute_pack(pack: dict) -> None:
     pack["passed"] = passed
     pack["total"] = total
     pack["score"] = passed / total if total else 0.0
+    diagnostics = pack_diagnostics(scenarios)
+    if diagnostics is not None:
+        pack["diagnostics"] = diagnostics
+    else:
+        pack.pop("diagnostics", None)
 
 
 def _recompute_totals(data: dict) -> None:
@@ -73,6 +103,11 @@ def _recompute_totals(data: dict) -> None:
     total = sum(int(pack.get("total") or 0) for pack in packs)
     passed = sum(int(pack.get("passed") or 0) for pack in packs)
     data["totals"] = {"passed": passed, "total": total, "score": passed / total if total else 0.0}
+
+
+def _sandbox_client_for_pack(pack_id: str, image_tag: str) -> SandboxClient:
+    """Construct a replay verifier; kept separate so unit tests need no Docker."""
+    return SandboxClient(config_for_pack(pack_id, image_tag))
 
 
 def rescore_result(path: str, args: Any) -> int:
@@ -85,6 +120,7 @@ def rescore_result(path: str, args: Any) -> int:
 
     rescored = 0
     skipped: dict[str, int] = {}
+    sandboxed_packs: list[str] = []
     for pack in data.get("packs", []):
         if not isinstance(pack, dict):
             continue
@@ -95,18 +131,39 @@ def rescore_result(path: str, args: Any) -> int:
             pack_meta, current_scenarios = load_pack(pack_id)
         except Exception:
             pack_meta, current_scenarios = {"verifier_module": None}, []
+
+        sandbox_client: SandboxClient | None = None
         if pack_meta.get("supports_sandboxed_only"):
-            skipped[pack_id] = len(pack.get("scenarios") or [])
-            continue
-        scenario_index = {str(scenario.get("id")): scenario for scenario in current_scenarios if isinstance(scenario, dict)}
-        for run in pack.get("scenarios", []):
-            if not isinstance(run, dict):
+            config = SANDBOX_REGISTRY.get(pack_id)
+            if config is None or config.multi_turn:
+                skipped[pack_id] = len(pack.get("scenarios") or [])
                 continue
-            did_score, reason = _score_saved_scenario(pack_meta, scenario_index, run)
-            if did_score:
-                rescored += 1
-            elif reason:
-                skipped[reason] = skipped.get(reason, 0) + 1
+            sandbox_client = _sandbox_client_for_pack(pack_id, args.sandbox_image_tag)
+            sandbox_client.start()
+            sandboxed_packs.append(pack_id)
+
+        scenario_index = {
+            str(scenario.get("id")): scenario
+            for scenario in current_scenarios
+            if isinstance(scenario, dict)
+        }
+        try:
+            for run in pack.get("scenarios", []):
+                if not isinstance(run, dict):
+                    continue
+                did_score, reason = _score_saved_scenario(
+                    pack_meta,
+                    scenario_index,
+                    run,
+                    sandbox_client=sandbox_client,
+                )
+                if did_score:
+                    rescored += 1
+                elif reason:
+                    skipped[reason] = skipped.get(reason, 0) + 1
+        finally:
+            if sandbox_client is not None:
+                sandbox_client.stop()
         _recompute_pack(pack)
 
     _recompute_totals(data)
@@ -115,6 +172,7 @@ def rescore_result(path: str, args: Any) -> int:
         "scenarios": rescored,
         "skipped": skipped,
         "pack_filter": args.pack,
+        "sandboxed_packs": sandboxed_packs,
     }
 
     if args.in_place and args.output:

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -18,6 +18,7 @@ from importlib import resources
 import httpx
 
 from benchlocal_cli import __version__
+from benchlocal_cli.diagnostics import pack_diagnostics
 from benchlocal_cli.sandbox import SandboxClient, config_for_pack
 from benchlocal_cli.scoring.common import content_with_source, sanitize_response_text_fields
 from benchlocal_cli.types import PackResult, RunResult, ScenarioResult, ScenarioRun
@@ -1318,6 +1319,7 @@ class Runner:
                         runs,
                         self._configured_pass_at_k(meta, repeat),
                     ),
+                    diagnostics=pack_diagnostics(runs),
                 )
 
         passed = sum(1 for run in counted if run.result.passed)
@@ -1340,6 +1342,7 @@ class Runner:
                 runs,
                 self._configured_pass_at_k(meta, repeat),
             ),
+            diagnostics=pack_diagnostics(runs),
         )
 
     def run_scenario(self, meta: dict, scenario: dict, *, repeat_index: int = 1) -> ScenarioRun:

--- a/benchlocal_cli/types.py
+++ b/benchlocal_cli/types.py
@@ -120,6 +120,9 @@ class PackResult:
     catalog_scenario_count: int | None = None
     # Additive best-of-k rollup; strict pass@1 remains in passed/total/score.
     pass_at_k: dict[str, float | int] | None = None
+    # Additive pack-level telemetry over every recorded completion, including
+    # successful finish_reason=length responses and nested retries/turns.
+    diagnostics: dict | None = None
 
     def to_dict(self) -> dict:
         out = {
@@ -142,6 +145,8 @@ class PackResult:
             out["catalog_scenario_count"] = self.catalog_scenario_count
         if self.pass_at_k is not None:
             out["pass_at_k"] = self.pass_at_k
+        if self.diagnostics is not None:
+            out["diagnostics"] = self.diagnostics
         return out
 
 

--- a/sandboxes/code-reasoning/server.py
+++ b/sandboxes/code-reasoning/server.py
@@ -12,7 +12,6 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 PORT = 9000
 
-THINK_OPEN_CLOSE_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL)
 CODE_FENCED_RE = re.compile(r"```(?:python|py)?[ \t\r]*\n?(.*?)```", re.DOTALL | re.IGNORECASE)
 CODE_DEF_RE = re.compile(r"^(def\s+\w+.*?)(?=\n\S|\Z)", re.DOTALL | re.MULTILINE)
 CODE_START_RE = re.compile(r"^(?:from\s+\S+\s+import\s+.+|import\s+.+|class\s+\w+\b.*|def\s+\w+\s*\(.*|@\w+.*)$", re.MULTILINE)
@@ -30,14 +29,15 @@ def _message(response: dict) -> dict:
     return {}
 
 
-def _response_text(response: dict) -> str:
+def _response_text(response: dict) -> tuple[str, str | None]:
+    """Resolve exactly one answer channel using the shared content-first policy."""
     msg = _message(response)
-    parts = []
-    for key in ("reasoning_content", "reasoning", "content"):
-        value = msg.get(key)
-        if isinstance(value, str) and value.strip():
-            parts.append(value)
-    return "\n".join(parts)
+    for prefix, container in (("", response), ("message.", msg)):
+        for key in ("content", "reasoning_content", "reasoning"):
+            value = container.get(key)
+            if isinstance(value, str) and value.strip():
+                return value, f"{prefix}{key}"
+    return "", None
 
 
 def _strip_unmatched_fence(code: str) -> str:
@@ -48,44 +48,51 @@ def _strip_unmatched_fence(code: str) -> str:
     return code
 
 
-def extract_code_with_info(text: str) -> tuple[str, dict]:
-    think_close_count = text.count("</think>")
-    after_think = text.rsplit("</think>", 1)[-1] if think_close_count else text
-    extraction_issue_override = "extra_think_tag_after_code" if think_close_count > 1 else None
+def extract_code_with_info(
+    text: str,
+    *,
+    response_field_used: str | None = None,
+) -> tuple[str, dict]:
+    """Extract code from one already-selected response channel."""
 
-    def _issue(default: str) -> str:
-        return extraction_issue_override or default
+    def _info(method: str, issue: str) -> dict:
+        info = {"extraction_method": method, "extraction_issue": issue}
+        if response_field_used is not None:
+            info["response_field_used"] = response_field_used
+        return info
 
-    clean_after_think = after_think.lstrip()
-    matches = CODE_FENCED_RE.findall(after_think)
-    if matches:
-        return matches[-1], {"extraction_method": "last_fenced_after_think", "extraction_issue": _issue("none")}
+    clean = text.lstrip()
     matches = CODE_FENCED_RE.findall(text)
     if matches:
-        return matches[-1], {"extraction_method": "last_fenced_anywhere", "extraction_issue": "none"}
-    stripped = after_think.lstrip()
-    if OPENING_FENCE_RE.match(stripped):
-        return _strip_unmatched_fence(stripped), {"extraction_method": "opening_fence_after_think", "extraction_issue": _issue("unterminated_fence")}
-    m = OPENING_FENCE_ANYWHERE_RE.search(clean_after_think)
-    if m:
-        return _strip_unmatched_fence(clean_after_think[m.end():]), {"extraction_method": "opening_fence_anywhere", "extraction_issue": _issue("prose_before_unterminated_fence")}
-    label = LANGUAGE_LABEL_RE.match(clean_after_think)
+        return matches[-1], _info("last_fenced", "none")
+    if OPENING_FENCE_RE.match(clean):
+        return _strip_unmatched_fence(clean), _info("opening_fence", "unterminated_fence")
+    match = OPENING_FENCE_ANYWHERE_RE.search(clean)
+    if match:
+        return (
+            _strip_unmatched_fence(clean[match.end():]),
+            _info("opening_fence_anywhere", "prose_before_unterminated_fence"),
+        )
+    label = LANGUAGE_LABEL_RE.match(clean)
     if label:
-        after_label = clean_after_think[label.end():].lstrip()
-        m = CODE_START_RE.search(after_label)
-        if m:
-            prefix = after_label[:m.start()]
+        after_label = clean[label.end():].lstrip()
+        match = CODE_START_RE.search(after_label)
+        if match:
+            prefix = after_label[:match.start()]
             issue = "language_label_before_code" if not prefix.strip() else "language_label_then_prose_before_code"
-            return _strip_unmatched_fence(after_label[m.start():]), {"extraction_method": "code_start_after_language_label", "extraction_issue": _issue(issue)}
-    m = CODE_START_RE.search(clean_after_think)
-    if m:
-        prefix = clean_after_think[:m.start()]
+            return (
+                _strip_unmatched_fence(after_label[match.start():]),
+                _info("code_start_after_language_label", issue),
+            )
+    match = CODE_START_RE.search(clean)
+    if match:
+        prefix = clean[:match.start()]
         issue = "no_fenced_block" if not prefix.strip() else "prose_before_code"
-        return _strip_unmatched_fence(clean_after_think[m.start():]), {"extraction_method": "code_start_after_think", "extraction_issue": _issue(issue)}
-    m = CODE_DEF_RE.search(clean_after_think)
-    if m:
-        return m.group(1), {"extraction_method": "def_after_think", "extraction_issue": _issue("no_fenced_block")}
-    return "", {"extraction_method": "empty", "extraction_issue": "empty_code"}
+        return _strip_unmatched_fence(clean[match.start():]), _info("code_start", issue)
+    match = CODE_DEF_RE.search(clean)
+    if match:
+        return match.group(1), _info("def", "no_fenced_block")
+    return "", _info("empty", "empty_code")
 
 
 def _run_python(source: str, timeout: int = 30) -> tuple[bool, str]:
@@ -166,8 +173,11 @@ _run()
 
 
 def verify_code(scenario_id: str, scenario: dict, response: dict) -> dict:
-    text = _response_text(response)
-    code, info = extract_code_with_info(text)
+    text, response_field_used = _response_text(response)
+    code, info = extract_code_with_info(
+        text,
+        response_field_used=response_field_used,
+    )
     if not code.strip():
         return fail(scenario_id, "wrong_answer", "no runnable-looking Python code extracted", info)
     raw = scenario.get("raw_problem") or {}

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from benchlocal_cli.diagnostics import pack_diagnostics
+
+
+def _response(reason: str | None) -> dict:
+    return {
+        "choices": [
+            {
+                "message": {"content": "answer"},
+                "finish_reason": reason,
+            }
+        ]
+    }
+
+
+def test_pack_diagnostics_counts_all_completion_shapes_and_extraction_trace():
+    runs = [
+        {
+            "raw_response": _response("length"),
+            "result": {
+                "verifier_trace": {
+                    "extraction_method": "last_fenced",
+                    "extraction_issue": "none",
+                    "response_field_used": "message.content",
+                }
+            },
+            "retry_attempts": [
+                {
+                    "raw_response": _response("stop"),
+                    "verifier_trace": {
+                        "extraction_method": "code_start",
+                        "extraction_issue": "prose_before_code",
+                    },
+                    "response_field_used": "message.reasoning_content",
+                }
+            ],
+        },
+        {
+            "raw_response": {
+                "multi_turn": True,
+                "responses": [_response("length"), _response("stop")],
+            },
+            "result": {"verifier_trace": None},
+        },
+        {
+            "raw_response": {"error": "no completion"},
+            "result": {"verifier_trace": None},
+        },
+    ]
+
+    assert pack_diagnostics(runs) == {
+        "finish_reasons": {
+            "total": 4,
+            "length": 2,
+            "length_rate": 0.5,
+            "counts": {"length": 2, "stop": 2},
+        },
+        "extraction": {
+            "methods": {"code_start": 1, "last_fenced": 1},
+            "issues": {"none": 1, "prose_before_code": 1},
+            "response_fields": {
+                "message.content": 1,
+                "message.reasoning_content": 1,
+            },
+        },
+    }
+
+
+def test_pack_diagnostics_tracks_missing_finish_reason_as_unknown():
+    diagnostics = pack_diagnostics([{"raw_response": _response(None)}])
+
+    assert diagnostics["finish_reasons"] == {
+        "total": 1,
+        "length": 0,
+        "length_rate": 0.0,
+        "counts": {"unknown": 1},
+    }

--- a/tests/test_inline_retries.py
+++ b/tests/test_inline_retries.py
@@ -247,6 +247,19 @@ def test_run_and_markdown_report_pass_at_one_and_pass_at_k_together(monkeypatch)
 
     monkeypatch.setattr(runner, "run_scenario", fake_run_scenario)
     result = runner.run(["test-pack"])
+    result.packs[0].diagnostics = {
+        "finish_reasons": {
+            "total": 2,
+            "length": 1,
+            "length_rate": 0.5,
+            "counts": {"length": 1, "stop": 1},
+        },
+        "extraction": {
+            "methods": {"last_fenced": 2},
+            "issues": {"none": 2},
+            "response_fields": {"message.content": 2},
+        },
+    }
     rendered = _markdown(result)
 
     assert result.totals == {"passed": 0, "total": 1, "score": 0.0}
@@ -254,3 +267,5 @@ def test_run_and_markdown_report_pass_at_one_and_pass_at_k_together(monkeypatch)
     assert "Pack | Pass@1 | Pass@3 | Flaky" in rendered
     assert "TOTAL | 0 / 1 (0%) | 1 / 1 (100%) | 1" in rendered
     assert "test-pack/T-01 | pass@2 | 2 | yes" in rendered
+    assert "Completion and extraction diagnostics:" in rendered
+    assert "test-pack | 1 / 2 (50.0%) | last_fenced=2 | none=2 | message.content=2" in rendered

--- a/tests/test_reasoning_packs.py
+++ b/tests/test_reasoning_packs.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import argparse
 import json
 
+from benchlocal_cli import rescore as rescore_module
 from benchlocal_cli.cli import _mode_from_args, main
 from benchlocal_cli.runner import PACK_MODES, Runner, load_pack
 from benchlocal_cli.scoring import answer_match
+from benchlocal_cli.types import ScenarioResult
 
 
 def _mode_ns(**kw) -> argparse.Namespace:
@@ -216,3 +218,120 @@ def test_cli_list_marks_gpqa_gated(capsys):
     assert main(["list"]) == 0
     out = capsys.readouterr().out
     assert "gpqa-diamond | 0.1.0 | 0 | answer_match | on | gated" in out
+
+
+class _FakeReplaySandbox:
+    def __init__(self):
+        self.started = False
+        self.stopped = False
+        self.calls = []
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+    def verify(self, scenario, response, messages):
+        self.calls.append((scenario, response, messages))
+        return ScenarioResult(
+            scenario_id=scenario["id"],
+            passed=True,
+            failure_mode="passed",
+            detail="functional tests passed",
+            verifier_trace={
+                "extraction_method": "last_fenced",
+                "extraction_issue": "none",
+                "response_field_used": "message.content",
+            },
+        )
+
+
+def test_rescore_replays_single_turn_code_sandbox_and_refreshes_diagnostics(
+    monkeypatch, tmp_path
+):
+    source = tmp_path / "code-run.json"
+    target = tmp_path / "code-rescored.json"
+    fake = _FakeReplaySandbox()
+    factory_calls = []
+
+    def factory(pack_id, image_tag):
+        factory_calls.append((pack_id, image_tag))
+        return fake
+
+    monkeypatch.setattr(rescore_module, "_sandbox_client_for_pack", factory)
+    source.write_text(json.dumps({
+        "schema_version": "1",
+        "packs": [{
+            "pack_id": "humaneval-plus-30",
+            "scenarios": [{
+                "id": "HumanEval-0",
+                "passed": False,
+                "failure_mode": "verifier_fail",
+                "detail": "legacy reasoning-first extraction",
+                "latency_seconds": 1.25,
+                "tokens_completion": 42,
+                "result": {
+                    "scenario_id": "HumanEval-0",
+                    "passed": False,
+                    "failure_mode": "verifier_fail",
+                    "detail": "legacy reasoning-first extraction",
+                    "latency_seconds": 1.25,
+                    "tokens_completion": 42,
+                    "verifier_trace": {
+                        "extraction_method": "code_start_after_think",
+                    },
+                },
+                "raw_scenario": {"id": "HumanEval-0"},
+                "raw_response": {
+                    "choices": [{
+                        "message": {
+                            "reasoning_content": "def broken(): pass",
+                            "content": "def has_close_elements(numbers, threshold): return False",
+                        },
+                        "finish_reason": "length",
+                    }]
+                },
+                "request": {"messages": [{"role": "user", "content": "solve"}]},
+            }],
+        }],
+        "totals": {"passed": 0, "total": 1, "score": 0.0},
+    }))
+
+    assert main([
+        "rescore",
+        str(source),
+        "--pack",
+        "humaneval-plus-30",
+        "--sandbox-image-tag",
+        "fixed",
+        "--output",
+        str(target),
+    ]) == 0
+
+    data = json.loads(target.read_text())
+    run = data["packs"][0]["scenarios"][0]
+    assert factory_calls == [("humaneval-plus-30", "fixed")]
+    assert fake.started is True
+    assert fake.stopped is True
+    assert len(fake.calls) == 1
+    assert run["passed"] is True
+    assert run["failure_mode"] == "passed"
+    assert run["latency_seconds"] == 1.25
+    assert run["tokens_completion"] == 42
+    assert run["response_field_used"] == "message.content"
+    assert data["packs"][0]["diagnostics"] == {
+        "finish_reasons": {
+            "total": 1,
+            "length": 1,
+            "length_rate": 1.0,
+            "counts": {"length": 1},
+        },
+        "extraction": {
+            "methods": {"last_fenced": 1},
+            "issues": {"none": 1},
+            "response_fields": {"message.content": 1},
+        },
+    }
+    assert data["totals"] == {"passed": 1, "total": 1, "score": 1.0}
+    assert data["rescored"]["sandboxed_packs"] == ["humaneval-plus-30"]

--- a/tests/test_sandbox_verifiers.py
+++ b/tests/test_sandbox_verifiers.py
@@ -999,3 +999,70 @@ console.log(JSON.stringify(captured));
     core = (ROOT / "vendor/CLI-40/verification/core.mjs").read_text(encoding="utf-8")
     for field in ("max_tokens", "enable_thinking", "thinking_budget", "chat_template_kwargs"):
         assert f"{field}: generation.{field}" in core
+
+
+def test_code_reasoning_prefers_content_over_out_of_band_reasoning():
+    server = _load("code_reasoning_content_first", "sandboxes/code-reasoning/server.py")
+    response = {
+        "choices": [{
+            "message": {
+                "reasoning_content": "def draft(x):\n    return x\nThat is it.",
+                "content": "```python\ndef final_answer(x):\n    return x + 1\n```",
+            }
+        }]
+    }
+
+    text, source = server._response_text(response)
+    code, info = server.extract_code_with_info(text, response_field_used=source)
+
+    assert code.strip() == "def final_answer(x):\n    return x + 1"
+    assert info == {
+        "extraction_method": "last_fenced",
+        "extraction_issue": "none",
+        "response_field_used": "message.content",
+    }
+    assert "after_think" not in info["extraction_method"]
+
+
+def test_code_reasoning_falls_back_only_when_content_is_empty():
+    server = _load("code_reasoning_reasoning_fallback", "sandboxes/code-reasoning/server.py")
+    response = {
+        "choices": [{
+            "message": {
+                "content": "",
+                "reasoning_content": "def fallback(x):\n    return x",
+            }
+        }]
+    }
+
+    text, source = server._response_text(response)
+    code, info = server.extract_code_with_info(text, response_field_used=source)
+
+    assert code == "def fallback(x):\n    return x"
+    assert info["extraction_method"] == "code_start"
+    assert info["response_field_used"] == "message.reasoning_content"
+
+
+def test_code_reasoning_verifier_executes_content_not_reasoning_draft():
+    server = _load("code_reasoning_functional", "sandboxes/code-reasoning/server.py")
+    scenario = {
+        "raw_problem": {
+            "dataset": "humaneval-plus",
+            "entry_point": "add",
+            "test": "def check(candidate):\n    assert candidate(2, 3) == 5",
+        }
+    }
+    response = {
+        "choices": [{
+            "message": {
+                "reasoning_content": "def add(a, b):\n    return a - b\nThis draft is wrong.",
+                "content": "```python\ndef add(a, b):\n    return a + b\n```",
+            }
+        }]
+    }
+
+    result = server.verify_code("HE-test", scenario, response)
+
+    assert result["passed"] is True
+    assert result["response_field_used"] == "message.content"
+    assert result["extraction_method"] == "last_fenced"


### PR DESCRIPTION
## Summary

- make the code-reasoning verifier select exactly one response channel using the shared content-first order (`content` → `reasoning_content` → `reasoning`)
- remove the inert `</think>` boundary inference and make extraction labels describe the match that actually occurred
- let `rescore` replay single-turn sandbox verifiers (BugFind, HumanEval+, LiveCodeBench) while continuing to skip multi-turn/workspace sandboxes whose state cannot be reconstructed
- add per-pack finish-reason and extraction distributions to saved JSON and Markdown, counting successful, retry, and multi-turn completions too
- preserve original latency/token fields and token-limit reclassification while rescoring

## Replay boundary

This deliberately does not claim that every sandbox is replayable. CLI, Hermes, and Aider depend on destroyed filesystem or agent state; only registry entries with `multi_turn=False` are driven from archived `raw_response` records.

## Validation

- `python3 -m pytest -q` — **330 passed**
- rebuilt `benchlocal-sandbox-code-reasoning:latest`
- end-to-end Docker rescore of a synthetic archived HumanEval+ response:
  - invalid out-of-band reasoning + valid `message.content`
  - corrected score **1/1**
  - trace recorded `code_start`, `message.content`
  - finish/extraction rollups refreshed
  - verifier container removed after the run
- `git diff --check`

Refs #116.

The historical 183-record delta remains an issue follow-up because those archived JSON files are not attached to #741/#116 and are not present in this checkout. This PR provides the zero-GPU command path needed to produce it once the archive files are available.
