### PR TITLE
feat(report): add native Results Card v2 output

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,15 @@ When `--repeat N` is greater than 1, the markdown table adds per-pack `Std` and 
 
 `--repeat N` is the rigorous whole-benchmark variance tool: it re-runs passes and failures, so it can detect flaky passes as well as flaky failures. The CLI default is `--repeat 0`, where `0` selects the normal failure-only inline path; `--repeat 3` disables inline retries and executes every selected scenario three times.
 
+For an issue-ready Results Card v2, opt in with `--report md`. Its stable table always includes `Std`/`CV` (shown as `—` for a single run), p50/p95 latency, the score normalized to `/150`, and a collapsed raw per-item log reconstructed from the saved scenario records:
+
+```bash
+benchlocal-cli run --full --repeat 3 --report md --report-out results.md \
+  --endpoint http://localhost:8020 --model qwen3.6-27b --save-json results.json
+```
+
+With Markdown output, the card is printed to stdout and optionally copied to `--report-out`. JSON stdout remains available with `--output json --report md --report-out results.md`; the file receives Markdown while stdout stays pure JSON. Without `--report`, the existing stdout shape is unchanged. Saved JSON adds top-level `repeat` and `equivalent_score_150` fields, alongside each pack's existing `variance` and `latency` aggregates.
+
 For the cheaper everyday question "are the failures in this saved run systematic or flaky?", retry only its failed pass@1 scenarios:
 
 ```bash

--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -157,6 +157,16 @@ def _parser() -> argparse.ArgumentParser:
     run.add_argument("--output", choices=["markdown", "json"], default="markdown", help="output format (default: markdown)")
     run.add_argument("--save-json", help="also save raw JSON results to this path")
     run.add_argument(
+        "--report",
+        choices=["md"],
+        help="emit the paste-ready Results Card v2 report (currently: md)",
+    )
+    run.add_argument(
+        "--report-out",
+        metavar="PATH",
+        help="also write the selected --report to PATH",
+    )
+    run.add_argument(
         "--resume",
         metavar="RESULTS_JSON_OR_PARTIAL_JSONL",
         help="resume missing scenarios from a saved result or per-scenario partial journal",
@@ -449,16 +459,17 @@ def _sandbox_progress_event(event: dict) -> None:
     print(f"  [{index}/{total}] {pack_id}/{exercise_id} {result_char} {mode} ({latency})", file=sys.stderr, flush=True)
 
 
-def _scenario_progress(run: ScenarioRun, index: int, total: int) -> None:
-    """Print per-scenario progress line to stderr (#23)."""
+def _scenario_progress_text(run: ScenarioRun, index: int, total: int) -> str:
+    """Format the durable per-scenario line used by live and saved reports."""
     result_char = "✓" if run.result.passed else "✗"
     latency = f"{run.result.latency_seconds:.1f}s" if run.result.latency_seconds > 0 else "?"
     label = f" {run.label}" if run.label else ""
-    print(
-        f"  [{index}/{total}] {run.id} {result_char} {run.result.failure_mode}{label} ({latency})",
-        file=sys.stderr,
-        flush=True,
-    )
+    return f"  [{index}/{total}] {run.id} {result_char} {run.result.failure_mode}{label} ({latency})"
+
+
+def _scenario_progress(run: ScenarioRun, index: int, total: int) -> None:
+    """Print per-scenario progress line to stderr (#23)."""
+    print(_scenario_progress_text(run, index, total), file=sys.stderr, flush=True)
 
 
 def _compute_partial_totals(packs: list) -> dict:
@@ -731,6 +742,83 @@ def _markdown(result: RunResult) -> str:
     return "\n".join(lines)
 
 
+def _results_card_markdown(result: RunResult) -> str:
+    """Render the stable, paste-ready Results Card v2 shape (#114)."""
+    version = result.runner_version.removeprefix("v")
+    lines = [
+        f"## Quality bench, thinking {_thinking_label(result)}, "
+        f"benchlocal-cli v{version}, repeat = {result.repeat}",
+        "",
+        "Pack | Pass / Total | Score | Std | CV | p50 latency | p95 latency | Status",
+        "---|---:|---:|---:|---:|---:|---:|---",
+    ]
+    for pack in result.packs:
+        if pack.skipped:
+            status = "skipped"
+        elif pack.status not in ("ok", "stubbed"):
+            status = pack.status
+        else:
+            status = "ok" if pack.total else pack.status
+        if (
+            pack.catalog_scenario_count is not None
+            and pack.scenario_count < pack.catalog_scenario_count
+        ):
+            status = (
+                f"{status}; partial — {pack.scenario_count} of "
+                f"{pack.catalog_scenario_count} selected"
+            )
+        score = f"{pack.score:.0%}" if pack.total else "-"
+        variance = pack.variance or {}
+        std = "—" if result.repeat == 1 or variance.get("std") is None else f"{float(variance['std']):.1%}"
+        cv = "—" if result.repeat == 1 or variance.get("cv") is None else f"{float(variance['cv']):.2f}"
+        p50 = "-" if pack.latency["p50"] is None else f"{pack.latency['p50']:.2f}s"
+        p95 = "-" if pack.latency["p95"] is None else f"{pack.latency['p95']:.2f}s"
+        lines.append(
+            f"{pack.pack_id} (v{pack.version}) | {pack.passed} / {pack.total} | "
+            f"{score} | {std} | {cv} | {p50} | {p95} | {status}"
+        )
+
+    total = int(result.totals.get("total") or 0)
+    passed = int(result.totals.get("passed") or 0)
+    equivalent_score_150 = int((passed * 150 / total) + 0.5) if total else 0
+    lines.extend(
+        [
+            "",
+            f"TOTAL | {passed} / {total} | {float(result.totals.get('score') or 0.0):.0%} |  |  |  |  |",
+            "",
+            f"Equivalent to: {equivalent_score_150}/150",
+        ]
+    )
+
+    legacy_lines = _markdown(result).splitlines()
+    raw_lines = legacy_lines[:2]
+    for pack in result.packs:
+        pack_total = len(pack.scenarios)
+        raw_lines.extend(
+            _scenario_progress_text(run, index, pack_total)
+            for index, run in enumerate(pack.scenarios, 1)
+        )
+        raw_lines.append(_pack_line(pack))
+    raw_lines.append("")
+    raw_lines.extend(legacy_lines[2:])
+    raw = "\n".join(raw_lines)
+    fence = "````" if "```" in raw else "```"
+    lines.extend(
+        [
+            "",
+            "<details>",
+            "<summary>Raw data</summary>",
+            "",
+            fence,
+            raw,
+            fence,
+            "",
+            "</details>",
+        ]
+    )
+    return "\n".join(lines)
+
+
 def _load_mock(path: str | None) -> dict[str, dict] | None:
     if not path:
         return None
@@ -883,6 +971,10 @@ def main(argv: list[str] | None = None) -> int:
 
         if args.repeat < 0:
             raise ValueError("--repeat must be 0 or greater")
+        if args.report_out and args.report is None:
+            raise ValueError("--report-out requires --report md")
+        if args.output == "json" and args.report and not args.report_out:
+            raise ValueError("--output json with --report requires --report-out")
         if args.retry_failures < 0:
             raise ValueError("--retry-failures must be 0 or greater")
         if args.timeout_ceiling_s is not None and args.timeout_ceiling_s < 0:
@@ -1382,8 +1474,13 @@ def main(argv: list[str] | None = None) -> int:
                 append_run(result_dict, history_path, allow_partial=args.allow_partial)
             except Exception as exc:
                 print(f"benchlocal-cli: warning — history append failed: {exc}", file=sys.stderr)
+        report_markdown = _results_card_markdown(result) if args.report == "md" else None
+        if args.report_out:
+            Path(args.report_out).write_text(f"{report_markdown}\n", encoding="utf-8")
         if args.output == "json":
             print(json.dumps(result_dict, indent=2, sort_keys=True))
+        elif report_markdown is not None:
+            print(report_markdown)
         else:
             print(_markdown(result))
 

--- a/benchlocal_cli/persistence.py
+++ b/benchlocal_cli/persistence.py
@@ -263,6 +263,7 @@ def _build_result(
         server_defaults=config.get("server_defaults"),
         selection=config.get("result_selection"),
         pass_at_k=_combine_pass_at_k(packs),
+        repeat=repeat,
     )
     retry_context = config.get("retry_failed")
     if retry_context is not None:

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -709,6 +709,7 @@ class Runner:
                 server_defaults=self._server_defaults if self.sampling_from_server else None,
                 selection=selection_ids,
                 pass_at_k=_combine_pass_at_k(pack_results),
+                repeat=repeat,
             )
         finally:
             self._stop_sandboxes()

--- a/benchlocal_cli/types.py
+++ b/benchlocal_cli/types.py
@@ -184,8 +184,13 @@ class RunResult:
     retry_failed: dict | None = None
     # Additive best-of-k rollup for inline retries (#111).
     pass_at_k: dict[str, float | int] | None = None
+    # Whole-benchmark repeat count. Always at least 1; additive for schema-v1 readers.
+    repeat: int = 1
 
     def to_dict(self) -> dict:
+        total = int(self.totals.get("total") or 0)
+        passed = int(self.totals.get("passed") or 0)
+        equivalent_score_150 = int((passed * 150 / total) + 0.5) if total else 0
         out = {
             "schema_version": self.schema_version,
             "runner_version": self.runner_version,
@@ -199,6 +204,8 @@ class RunResult:
             "thinking_enabled": self.thinking_enabled,
             "thinking_mode": self.thinking_mode,
             "warnings": self.warnings,
+            "repeat": self.repeat,
+            "equivalent_score_150": equivalent_score_150,
         }
         if self.delta is not None:
             out["delta"] = self.delta

--- a/tests/test_results_card.py
+++ b/tests/test_results_card.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import json
+
+from benchlocal_cli.cli import _results_card_markdown, main
+from benchlocal_cli.types import PackResult, RunResult, ScenarioResult, ScenarioRun
+
+
+def _scenario(
+    scenario_id: str,
+    *,
+    passed: bool,
+    latency: float,
+    repeat_index: int = 1,
+) -> ScenarioRun:
+    failure_mode = "passed" if passed else "wrong_answer"
+    return ScenarioRun(
+        id=scenario_id,
+        result=ScenarioResult(
+            scenario_id=scenario_id,
+            passed=passed,
+            failure_mode=failure_mode,
+            detail="correct" if passed else "expected 42",
+            latency_seconds=latency,
+        ),
+        raw_scenario={"id": scenario_id},
+        raw_response={"choices": []},
+        request={},
+        sampling_params={"temperature": 0},
+        status_code=200,
+        repeat_index=repeat_index,
+    )
+
+
+def _pack(
+    pack_id: str,
+    *,
+    passed: int,
+    total: int,
+    scenarios: list[ScenarioRun],
+    variance: dict | None,
+    latency: tuple[float, float],
+) -> PackResult:
+    return PackResult(
+        pack_id=pack_id,
+        version="1.0.0",
+        upstream_commit="abc123",
+        scenario_count=1,
+        passed=passed,
+        total=total,
+        score=passed / total,
+        latency={"p50": latency[0], "p95": latency[1]},
+        scenarios=scenarios,
+        variance=variance,
+    )
+
+
+def _result(*, repeat: int = 3) -> RunResult:
+    alpha_runs = [
+        _scenario("A-01", passed=True, latency=1.0, repeat_index=1),
+        _scenario("A-01", passed=False, latency=2.0, repeat_index=2),
+        _scenario("A-01", passed=True, latency=3.0, repeat_index=3),
+    ]
+    beta_runs = [
+        _scenario("B-01", passed=True, latency=2.0, repeat_index=index)
+        for index in range(1, 4)
+    ]
+    packs = [
+        _pack(
+            "alpha-1",
+            passed=2,
+            total=3,
+            scenarios=alpha_runs,
+            variance={"repeat": 3, "mean": 2 / 3, "std": 0.2357, "cv": 0.3536},
+            latency=(2.0, 2.9),
+        ),
+        _pack(
+            "beta-1",
+            passed=3,
+            total=3,
+            scenarios=beta_runs,
+            variance={"repeat": 3, "mean": 1.0, "std": 0.0, "cv": 0.0},
+            latency=(2.0, 2.0),
+        ),
+    ]
+    return RunResult(
+        schema_version="1",
+        runner_version="0.9.9",
+        endpoint="mock",
+        model="mock-model",
+        mode="custom",
+        started_at="2026-07-30T00:00:00Z",
+        finished_at="2026-07-30T00:01:00Z",
+        packs=packs,
+        totals={"passed": 5, "total": 6, "score": 5 / 6},
+        thinking_enabled=False,
+        thinking_mode="force-off",
+        repeat=repeat,
+    )
+
+
+def _mock_response(content: str) -> dict:
+    return {
+        "choices": [{"message": {"content": content}}],
+        "usage": {"completion_tokens": 3},
+    }
+
+
+def _mock_run_args(tmp_path) -> tuple[list[str], object, object]:
+    mock_path = tmp_path / "mock.json"
+    result_path = tmp_path / "result.json"
+    report_path = tmp_path / "results.md"
+    mock_path.write_text(
+        json.dumps(
+            {"SO-01": _mock_response('{"title":"The Great Gatsby","year":1925}')}
+        )
+    )
+    return (
+        [
+            "run",
+            "--endpoint",
+            "mock",
+            "--model",
+            "mock",
+            "--measured-tps",
+            "100",
+            "--mock-responses-from-json",
+            str(mock_path),
+            "--scenario",
+            "structoutput-15/SO-01",
+            "--save-json",
+            str(result_path),
+            "--report",
+            "md",
+            "--report-out",
+            str(report_path),
+        ],
+        result_path,
+        report_path,
+    )
+
+
+def test_results_card_repeat_three_has_stable_headline_shape_and_json_fields():
+    result = _result()
+    rendered = _results_card_markdown(result)
+    headline = rendered.split("\n\n<details>", 1)[0]
+
+    assert headline == """## Quality bench, thinking off, benchlocal-cli v0.9.9, repeat = 3
+
+Pack | Pass / Total | Score | Std | CV | p50 latency | p95 latency | Status
+---|---:|---:|---:|---:|---:|---:|---
+alpha-1 (v1.0.0) | 2 / 3 | 67% | 23.6% | 0.35 | 2.00s | 2.90s | ok
+beta-1 (v1.0.0) | 3 / 3 | 100% | 0.0% | 0.00 | 2.00s | 2.00s | ok
+
+TOTAL | 5 / 6 | 83% |  |  |  |  |
+
+Equivalent to: 125/150"""
+    payload = result.to_dict()
+    assert payload["repeat"] == 3
+    assert payload["equivalent_score_150"] == 125
+
+
+def test_results_card_repeat_one_uses_em_dashes_for_variance():
+    run = _scenario("A-01", passed=True, latency=1.25)
+    pack = _pack(
+        "alpha-1",
+        passed=1,
+        total=1,
+        scenarios=[run],
+        variance=None,
+        latency=(1.25, 1.25),
+    )
+    result = _result(repeat=1)
+    result.packs = [pack]
+    result.totals = {"passed": 1, "total": 1, "score": 1.0}
+
+    rendered = _results_card_markdown(result)
+
+    assert "alpha-1 (v1.0.0) | 1 / 1 | 100% | — | — | 1.25s | 1.25s | ok" in rendered
+    assert "Equivalent to: 150/150" in rendered
+
+
+def test_results_card_raw_block_reconstructs_all_items_and_failure_details():
+    rendered = _results_card_markdown(_result())
+
+    assert "<details>\n<summary>Raw data</summary>" in rendered
+    assert "  [1/3] A-01 ✓ passed (1.0s)" in rendered
+    assert "  [2/3] A-01 ✗ wrong_answer (2.0s)" in rendered
+    assert "Failure breakdown:" in rendered
+    assert "alpha-1 A-01: wrong_answer [fail] (expected 42)" in rendered
+    raw = rendered.split("<summary>Raw data</summary>", 1)[1]
+    assert raw.index("=== benchlocal-cli") < raw.index("[1/3] A-01")
+    assert rendered.endswith("</details>")
+
+
+def test_cli_report_stdout_matches_file_and_saves_aggregate_fields(tmp_path, capsys):
+    args, result_path, report_path = _mock_run_args(tmp_path)
+
+    assert main(args) == 0
+
+    stdout = capsys.readouterr().out
+    assert stdout == report_path.read_text()
+    assert stdout.startswith("## Quality bench, thinking off(pack-defaults),")
+    assert "repeat = 1" in stdout
+    assert " | — | — | " in stdout
+    payload = json.loads(result_path.read_text())
+    assert payload["repeat"] == 1
+    assert payload["equivalent_score_150"] == 150
+
+
+def test_cli_can_keep_json_stdout_when_report_has_file_target(tmp_path, capsys):
+    args, _result_path, report_path = _mock_run_args(tmp_path)
+    args.extend(["--output", "json"])
+
+    assert main(args) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["repeat"] == 1
+    assert payload["equivalent_score_150"] == 150
+    assert report_path.read_text().startswith("## Quality bench")
+
+
+def test_cli_rejects_ambiguous_report_output_combinations(tmp_path, capsys):
+    assert main(["run", "--report-out", str(tmp_path / "report.md")]) == 1
+    assert "--report-out requires --report md" in capsys.readouterr().err
+
+    assert main(["run", "--report", "md", "--output", "json"]) == 1
+    assert "--output json with --report requires --report-out" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- add opt-in --report md and --report-out PATH output without changing legacy no-flag Markdown
- render the #770-compatible Results Card v2 headline, stable Std/CV columns, latency percentiles, TOTAL, and /150 equivalent
- reconstruct the complete per-item log inside a collapsed Raw data block from saved scenario records
- persist additive top-level repeat and equivalent_score_150 JSON fields
- keep JSON stdout pure when the Markdown report has a file target

## Verification

- python3 -m py_compile on changed Python files and tests
- git diff --check
- pytest -q: 330 passed
- targeted report/regression suite: 41 passed

Ruff is configured but the executable is not installed in this checkout.

Refs #114