### PR TITLE
fix(sandbox): treat an unpaired trailing fence as a closer, not an opener

### DIFF
--- a/sandboxes/code-reasoning/server.py
+++ b/sandboxes/code-reasoning/server.py
@@ -69,10 +69,19 @@ def extract_code_with_info(
         return _strip_unmatched_fence(clean), _info("opening_fence", "unterminated_fence")
     match = OPENING_FENCE_ANYWHERE_RE.search(clean)
     if match:
-        return (
-            _strip_unmatched_fence(clean[match.end():]),
-            _info("opening_fence_anywhere", "prose_before_unterminated_fence"),
-        )
+        remainder = clean[match.end():]
+        if remainder.strip():
+            return (
+                _strip_unmatched_fence(remainder),
+                _info("opening_fence_anywhere", "prose_before_unterminated_fence"),
+            )
+        # Nothing after the fence, so it is a stray CLOSER, not an opener --
+        # the language group in OPENING_FENCE_ANYWHERE_RE is optional, so a
+        # bare trailing ``` satisfies the "opening" pattern. Claiming the
+        # record here would return the empty remainder AND short-circuit the
+        # CODE_START_RE / CODE_DEF_RE heuristics below, which is what recovers
+        # unfenced code. Drop the stray fence and keep going.
+        clean = clean[:match.start()].rstrip()
     label = LANGUAGE_LABEL_RE.match(clean)
     if label:
         after_label = clean[label.end():].lstrip()

--- a/tests/test_sandbox_verifiers.py
+++ b/tests/test_sandbox_verifiers.py
@@ -1024,6 +1024,60 @@ def test_code_reasoning_prefers_content_over_out_of_band_reasoning():
     assert "after_think" not in info["extraction_method"]
 
 
+def test_code_reasoning_stray_closing_fence_does_not_swallow_code():
+    """A bare trailing ``` is a CLOSER, not an opener (issue #120).
+
+    OPENING_FENCE_ANYWHERE_RE's language group is optional, so an unpaired
+    trailing fence matched the "opening" pattern; the branch then returned the
+    empty remainder and short-circuited the CODE_START_RE fallback that would
+    have recovered the code. Observed on real traffic: three complete, correct
+    solutions scored `wrong_answer` because their content ended in a stray ```.
+    """
+    server = _load("code_reasoning_stray_fence", "sandboxes/code-reasoning/server.py")
+
+    code, info = server.extract_code_with_info("def f():\n    return 1\n```")
+
+    assert code == "def f():\n    return 1"
+    assert info["extraction_method"] == "code_start"
+
+
+def test_code_reasoning_real_stray_fence_records_extract(tmp_path):
+    """Regression fixtures from the corpus in issue #120."""
+    server = _load("code_reasoning_stray_fence_real", "sandboxes/code-reasoning/server.py")
+
+    # HumanEval-75: content is a complete solution followed by a stray closer.
+    content = (
+        "def is_multiply_prime(a):\n"
+        '    """Return True iff a is the product of exactly three primes."""\n'
+        "    count = 0\n"
+        "    i = 2\n"
+        "    while a > 1:\n"
+        "        while a % i == 0:\n"
+        "            count += 1\n"
+        "            a //= i\n"
+        "        i += 1\n"
+        "    return count == 3\n"
+        "```"
+    )
+    code, info = server.extract_code_with_info(content)
+
+    assert code.startswith("def is_multiply_prime(a):")
+    assert not code.rstrip().endswith("```")
+    ast.parse(code)
+
+
+def test_code_reasoning_genuine_unterminated_fence_still_wins():
+    """A fence WITH content after it is still an opener -- unchanged behaviour."""
+    server = _load("code_reasoning_open_fence", "sandboxes/code-reasoning/server.py")
+
+    code, info = server.extract_code_with_info(
+        "Here is the answer:\n```python\ndef g():\n    return 2"
+    )
+
+    assert code == "def g():\n    return 2"
+    assert info["extraction_method"] == "opening_fence_anywhere"
+
+
 def test_code_reasoning_falls_back_only_when_content_is_empty():
     server = _load("code_reasoning_reasoning_fallback", "sandboxes/code-reasoning/server.py")
     response = {


### PR DESCRIPTION
Fixes #120.

`OPENING_FENCE_ANYWHERE_RE`'s language group is optional, so a bare trailing ` ``` ` satisfies the "opening" pattern. The branch then returns `clean[match.end():]` — everything after the last fence, which is nothing — and because it sits *above* the `CODE_START_RE` / `CODE_DEF_RE` fallbacks, it also short-circuits the heuristics that recover unfenced code.

```python
>>> extract_code_with_info('def f():\n    return 1\n```')
('', {'extraction_method': 'opening_fence_anywhere', ...})
```

## The change

The anywhere-match now claims the record only when its remainder is non-empty. An empty remainder means the match was a stray **closer**, so it is stripped and extraction continues down the chain.

This is the shape you proposed in club-3090#741; I implemented and measured it rather than guessing at the classification. I kept `opening_fence_anywhere` reporting unchanged for genuine openers, so no existing `extraction_method` value changes meaning.

## Evidence

234 block-arm records (HumanEval+ and LiveCodeBench v6, greedy, one checkpoint). 31 end in a trailing fence and parity separates them exactly:

| fence count | path | code | outcome |
|---|---|---|---|
| 28 even (paired) | `last_fenced` | kept | all 28 **PASSED** |
| 3 odd (unpaired closer) | `opening_fence_anywhere` | **dropped** | all 3 **FAILED** |

All three are complete, correct solutions — re-verified against an **unmodified** `code-reasoning` container with only the stray closer removed from `content`, so same extractor and same tests:

| record | as run | closer removed |
|---|---|---|
| `HumanEval-75` | FAIL `wrong_answer` | **PASS** |
| `HumanEval-129` | FAIL `wrong_answer` | **PASS** |
| `LCBv6-3778` | FAIL `wrong_answer` | **PASS** |

Corpus score **194/234 → 197/234**.

## Regression

Over the same 234 records, this patch leaves **231/234 extractions byte-identical** and changes only the three broken ones (0 → 414 / 2360 / 162 chars, all parsing).

## Tests

Three added to `tests/test_sandbox_verifiers.py`:

- the minimal synthetic repro
- a real fixture from the corpus (`HumanEval-75`)
- a guard that a fence **with** content after it is still treated as an opener, so the genuine `opening_fence_anywhere` path is pinned

`pytest tests/` → **338 passed, 1 failed**. The failure is `test_cli_outcome_validity_and_malformed_recovery`, which **also fails on pristine `upstream/master`** with no changes applied (verified by stashing) — it is unrelated to this patch and I have left it alone.

## Note

One checkpoint, one engine, greedy throughout. 31 trailing-fence records is a small sample for the parity claim even though it separates cleanly, and the patch is tested against this corpus at `d08ddcc` only.
