### PR TITLE
fix: resolve model-specific thinking controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Each scenario's timeout is sized by precedence (highest wins):
 2. **Auto-scaling (default)** — `timeout = base × max(1, reference_tps / measured_tps) × thinking_multiplier`:
    - `base` = the pack's `default_max_seconds` metadata.
    - `reference_tps` = the pack's `timeout_reference_tps` (the decode rate `base` assumes; override with `--reference-tps`).
-   - `measured_tps` = a one-shot startup decode-TPS probe of the endpoint (sent with `enable_thinking=false`; skip it by passing `--measured-tps N`). The probe runs a reachability preflight (`GET /v1/models`, 5s, no retry) and **fails fast** — it never hangs a run against a dead or blackholed endpoint.
+   - `measured_tps` = a one-shot startup decode-TPS probe of the endpoint (reasoning is clamped with the resolved model-specific control; skip it by passing `--measured-tps N`). The probe runs a reachability preflight (`GET /v1/models`, 5s, no retry) and **fails fast** — it never hangs a run against a dead or blackholed endpoint.
    - `thinking_multiplier` = `thinking_max_tokens / nominal_max_tokens`, applied only when thinking is enabled and the budget exceeds the nominal output. Prevents thinking-on runs from spuriously timing out (#54).
    - `max(1, …)` means a faster rig never shrinks the budget below `base`. The result deliberately **over-budgets** — a timeout is a ceiling, not a target.
 3. **Static default** — the pack's `default_max_seconds`, when no `reference_tps` is set or the probe is unavailable.
@@ -179,6 +179,10 @@ benchlocal-cli run --quick --endpoint http://localhost:8020 --model qwen3.6-27b-
 
 # force answer-only mode for every pack, ignoring pack defaults
 benchlocal-cli run --quick --endpoint http://localhost:8020 --model qwen3.6-27b-autoround --no-thinking
+
+# effort-based model/provider: off sends none; on sends high
+benchlocal-cli run --quick --endpoint http://localhost:8020 --model inkling \
+  --enable-thinking --reasoning-effort high
 
 # pass vendor-specific request body fields
 benchlocal-cli run --quick --endpoint http://localhost:8020 --model qwen3.6-27b-autoround --extra-body '{"foo":"bar"}'
@@ -277,11 +281,25 @@ Leave `--retry-on-timeout` **off** for cloud — a timeout means the token budge
 
 **What to compare.** The **deterministic** packs (`toolcall-15`, `instructfollow-15`, `structoutput-15`, `dataextract-15`, `reasonmath-15`) are the cleanest apples-to-apples — single-shot, verifier-graded, no Docker. The **sandboxed/agentic** packs run a *local* Docker agent loop that calls your endpoint over the network, so they also need the sandbox images built (`bash tools/build-sandboxes.sh` from a checkout) and are less validated over a remote endpoint — land the deterministic set first.
 
-**Reasoning state — match it explicitly.** Each pack carries `default_thinking` metadata, and benchlocal-cli signals it with `chat_template_kwargs.enable_thinking` (see [Reasoning models](#reasoning-models)). Most managed endpoints ignore that vLLM-side field, so use the provider's native controls when available. The `cli-40` and `hermesagent-20` adapters also send Qwen-compatible `enable_thinking` and `thinking_budget` fields automatically; for thinking-only endpoints, the off arm is represented as enabled with a one-token thinking budget. Other packs may still require `--extra-body` for provider-specific controls. For a fair local-vs-cloud comparison, run both `--no-thinking` and `--enable-thinking` arms and verify the saved request payloads. An unexpected p95 spike on thinking-on packs usually means the endpoint reasoned longer than intended.
+**Reasoning state — match it explicitly.** Each pack carries `default_thinking` metadata, while the request key is model/provider-specific (see [Reasoning models](#reasoning-models)). For a managed endpoint that does not expose its live template, pass `--reasoning-effort VALUE` when that is the provider's control, or opt into the tiny behavioral detector with `--probe-thinking-control`. For a fair local-vs-cloud comparison, run both `--no-thinking` and `--enable-thinking` arms and inspect the saved request payloads. An unexpected p95 spike on thinking-on packs usually means the endpoint reasoned longer than intended.
 
 ## Reasoning models
 
-`benchlocal-cli` uses each pack's `default_thinking` metadata by default. Reasoning-rewarding packs such as `reasonmath-15`, `bugfind-15`, `instructfollow-15`, `hermesagent-20`, and every `--reasoning-packs` pack run with `chat_template_kwargs.enable_thinking=true`; execution/format packs such as `toolcall-15`, `structoutput-15`, `dataextract-15`, and `cli-40` run answer-only. Use `--enable-thinking` to force thinking on for every pack, or `--no-thinking` to force it off for every pack. Whenever thinking is enabled for a pack, request `max_tokens` is raised to `--thinking-max-tokens` (default `16384`) and the request uses the recommended thinking sampler (`temperature=1.0`, `top_p=0.95`, `top_k=20`, `min_p=0.0`) instead of the deterministic pack's greedy sampler. Override it with `--thinking-sampler '{"temperature":0.7,"top_p":0.9}'`, override individual sampling keys with `--temperature`/`--top-p`/`--top-k`/`--min-p`, or use `--sampling-from-server` to omit sampler params entirely. HumanEval+ and LiveCodeBench also carry 16K scenario budgets so thinking-on code runs do not measure a 4K truncation failure; hardest LCB items may still exceed 16K, so compare against `--no-thinking` for budget-runaway diagnostics. Use `--extra-body` to pass any other OpenAI-compatible server extension fields. Saved JSON records `thinking_enabled` per pack plus the run-level `thinking_mode`.
+`benchlocal-cli` uses each pack's `default_thinking` metadata by default. Reasoning-rewarding packs such as `reasonmath-15`, `bugfind-15`, `instructfollow-15`, `hermesagent-20`, and every `--reasoning-packs` pack run thinking-on; execution/format packs such as `toolcall-15`, `structoutput-15`, `dataextract-15`, and `cli-40` run answer-only. Use `--enable-thinking` to force thinking on for every pack, or `--no-thinking` to force it off for every pack.
+
+The runner resolves the request switch once per model:
+
+| Endpoint/template | Control |
+|---|---|
+| `GET /props` template mentions `enable_thinking` | `chat_template_kwargs.enable_thinking` (compatibility default) |
+| Template mentions only `reasoning_effort` | top-level `reasoning_effort` plus a `chat_template_kwargs` copy for llama.cpp |
+| Template mentions both | `enable_thinking` wins, preserving existing request behavior |
+| No `/props` (vLLM/SGLang/managed endpoint) | compatibility default, or opt-in `--probe-thinking-control` |
+| Explicit `--reasoning-effort VALUE` | effort control without probing |
+
+The behavioral probe sends up to two real 24-token inference requests, so it is deliberately opt-in; it first checks endpoint reachability and never classifies an unreachable server as “no switch.” Accepted effort values are `none|minimal|low|medium|high|xhigh|max` or a float from `0.0` to `0.99`. Effort is guidance, not a token budget: the off arm sends `none`, the on arm sends the requested value, and `--thinking-max-tokens` remains the separate output ceiling. Provider effort labels are not necessarily comparable.
+
+Whenever thinking is enabled for a pack, request `max_tokens` is raised to `--thinking-max-tokens` (default `16384`) and the request uses the recommended thinking sampler (`temperature=1.0`, `top_p=0.95`, `top_k=20`, `min_p=0.0`) instead of the deterministic pack's greedy sampler. Override it with `--thinking-sampler '{"temperature":0.7,"top_p":0.9}'`, override individual sampling keys with `--temperature`/`--top-p`/`--top-k`/`--min-p`, or use `--sampling-from-server` to omit sampler params entirely. HumanEval+ and LiveCodeBench also carry 16K scenario budgets so thinking-on code runs do not measure a 4K truncation failure; hardest LCB items may still exceed 16K, so compare against `--no-thinking` for budget-runaway diagnostics. `--extra-body` remains the escape hatch for controls the detector does not know. Saved JSON records `thinking_enabled` per pack and adds `thinking_control`/`reasoning_effort` when the run uses the non-default effort path.
 
 In multi-turn CLI and Hermes agent loops, captured assistant reasoning stays in the saved result for inspection, but prior `reasoning`, `reasoning_content`, `reasoning_details`, and `codex_reasoning_items` fields are stripped from the next outgoing request by default. This avoids replaying provider-private or stale reasoning state. Use `--preserve-reasoning-history` only when an endpoint explicitly requires that history for signed or encrypted reasoning continuity.
 

--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -293,6 +293,26 @@ def _parser() -> argparse.ArgumentParser:
              "(default: --max-tokens if set, else 16384)",
     )
     run.add_argument(
+        "--reasoning-effort",
+        type=_parse_reasoning_effort,
+        default=None,
+        metavar="VALUE",
+        help=(
+            "use the OpenAI reasoning_effort control for the thinking axis; VALUE "
+            "is none/minimal/low/medium/high/xhigh/max or a float from 0.0 to 0.99. "
+            "The off arm always sends none; the on arm sends VALUE."
+        ),
+    )
+    run.add_argument(
+        "--probe-thinking-control",
+        action="store_true",
+        help=(
+            "when GET /props exposes no chat template, run up to two tiny inference "
+            "requests to detect enable_thinking vs reasoning_effort (default: off; "
+            "probing consumes real endpoint responses)"
+        ),
+    )
+    run.add_argument(
         "--thinking-sampler",
         help=(
             "JSON object used as the thinking-on distribution sampler "
@@ -898,6 +918,25 @@ def _load_extra_body(value: str | None) -> dict | None:
     return data
 
 
+def _parse_reasoning_effort(value: str) -> str | float:
+    raw = value.strip()
+    allowed = {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
+    if raw.lower() in allowed:
+        return raw.lower()
+    try:
+        numeric = float(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "reasoning effort must be none/minimal/low/medium/high/xhigh/max "
+            "or a float from 0.0 to 0.99"
+        ) from exc
+    if not 0.0 <= numeric <= 0.99:
+        raise argparse.ArgumentTypeError(
+            "numeric reasoning effort must be between 0.0 and 0.99"
+        )
+    return numeric
+
+
 def _load_thinking_sampler(value: str | None) -> dict | None:
     if not value:
         return None
@@ -1026,7 +1065,12 @@ def main(argv: list[str] | None = None) -> int:
                 raise ValueError("--resume restores an existing retry diagnostic; do not pass --retry-failed")
             if args.repeat != 0:
                 raise ValueError("--resume uses the original run repeat count; do not pass --repeat")
-            if args.thinking_override is not None or args.thinking_max_tokens is not None:
+            if (
+                args.thinking_override is not None
+                or args.thinking_max_tokens is not None
+                or args.reasoning_effort is not None
+                or args.probe_thinking_control
+            ):
                 raise ValueError("--resume uses the original thinking configuration")
             if any(
                 value is not None
@@ -1046,6 +1090,8 @@ def main(argv: list[str] | None = None) -> int:
             args.repeat = int(config.get("repeat") or 1)
             args.thinking_override = config.get("thinking_override")
             args.thinking_max_tokens = config.get("thinking_max_tokens")
+            args.reasoning_effort = config.get("reasoning_effort")
+            args.probe_thinking_control = bool(config.get("probe_thinking_control"))
             for key, value in (config.get("sampling_overrides") or {}).items():
                 attr = "repeat_penalty" if key == "repeat_penalty" else key.replace("-", "_")
                 if hasattr(args, attr):
@@ -1125,6 +1171,8 @@ def main(argv: list[str] | None = None) -> int:
                     args.thinking_override = True
                 elif baseline.get("thinking_mode") == "force-off":
                     args.thinking_override = False
+            if args.reasoning_effort is None:
+                args.reasoning_effort = baseline.get("reasoning_effort")
             for key, value in (baseline.get("sampling_overrides") or {}).items():
                 attr = "repeat_penalty" if key == "repeat_penalty" else key.replace("-", "_")
                 if hasattr(args, attr) and getattr(args, attr) is None:
@@ -1337,6 +1385,13 @@ def main(argv: list[str] | None = None) -> int:
                 else "pack-defaults"
             ),
             "thinking_max_tokens": effective_thinking_max,
+            "reasoning_effort": args.reasoning_effort,
+            "thinking_control": (
+                "reasoning_effort"
+                if args.reasoning_effort is not None
+                else "enable_thinking"
+            ),
+            "probe_thinking_control": args.probe_thinking_control,
             "thinking_sampler": effective_thinking_sampler,
             "sampling_overrides": sampling_overrides or None,
             "sampling_source": "server" if args.sampling_from_server else None,
@@ -1416,6 +1471,8 @@ def main(argv: list[str] | None = None) -> int:
             negative_control=args.negative_control_text if args.negative_control else None,
             thinking_enabled=args.thinking_override,
             thinking_max_tokens=effective_thinking_max,
+            reasoning_effort=args.reasoning_effort,
+            probe_thinking_control=args.probe_thinking_control,
             extra_body=effective_extra_body,
             api_key=args.api_key,
             max_total_tokens=args.max_total_tokens,

--- a/benchlocal_cli/persistence.py
+++ b/benchlocal_cli/persistence.py
@@ -260,6 +260,8 @@ def _build_result(
         totals={"passed": passed, "total": total, "score": passed / total if total else 0.0},
         thinking_enabled=bool(thinking_override),
         thinking_mode=str(config.get("thinking_mode") or "pack-defaults"),
+        thinking_control=str(config.get("thinking_control") or "enable_thinking"),
+        reasoning_effort=config.get("reasoning_effort"),
         warnings=warnings or [],
         sampling_overrides=config.get("sampling_overrides"),
         sampling_source=config.get("sampling_source"),
@@ -339,6 +341,8 @@ def _infer_config(data: dict, source: Path) -> dict:
         "repeat": repeat,
         "thinking_override": thinking_override,
         "thinking_mode": thinking_mode,
+        "thinking_control": data.get("thinking_control") or "enable_thinking",
+        "reasoning_effort": data.get("reasoning_effort"),
         "sampling_overrides": data.get("sampling_overrides"),
         "sampling_source": data.get("sampling_source"),
         "server_defaults": data.get("server_defaults"),
@@ -453,6 +457,8 @@ def merge_resume(state: ResumeState, new_result: RunResult) -> RunResult:
     config = dict(state.config)
     config["runner_version"] = new_result.runner_version
     config["server_defaults"] = new_result.server_defaults
+    config["thinking_control"] = new_result.thinking_control
+    config["reasoning_effort"] = new_result.reasoning_effort
     previous_warnings = [
         warning
         for warning in state.previous_result.get("warnings") or []

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -166,6 +166,76 @@ def thinking_mode_from_override(override: bool | None) -> str:
     return "pack-defaults"
 
 
+THINKING_CONTROL_ENABLE = "enable_thinking"
+THINKING_CONTROL_EFFORT = "reasoning_effort"
+THINKING_CONTROL_NONE = "none"
+
+
+def thinking_control_from_template(template: str) -> str:
+    """Resolve the model's reasoning switch from its live chat template.
+
+    The order is compatibility-sensitive: templates that mention both controls
+    already work with enable_thinking, so keep their existing request shape.
+    """
+    if "enable_thinking" in template:
+        return THINKING_CONTROL_ENABLE
+    if "reasoning_effort" in template:
+        return THINKING_CONTROL_EFFORT
+    return THINKING_CONTROL_NONE
+
+
+def _effort_is_enabled(value: object, fallback: bool) -> bool:
+    if value is None:
+        return fallback
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return float(value) > 0
+    return str(value).strip().lower() not in {"", "0", "0.0", "none", "off", "false"}
+
+
+def _apply_thinking_control(
+    sampling: dict,
+    control: str,
+    enabled: bool,
+    reasoning_effort: str | float,
+) -> None:
+    """Apply one resolved reasoning control while preserving unrelated kwargs."""
+    kwargs = dict(sampling.get("chat_template_kwargs") or {})
+    kwargs.pop(THINKING_CONTROL_ENABLE, None)
+    kwargs.pop(THINKING_CONTROL_EFFORT, None)
+
+    if control == THINKING_CONTROL_EFFORT:
+        value: str | float = reasoning_effort if enabled else "none"
+        kwargs[THINKING_CONTROL_EFFORT] = value
+        # OpenAI-standard location. Keep the kwargs copy because llama.cpp does
+        # not yet forward this field into templates that read reasoning_effort.
+        sampling[THINKING_CONTROL_EFFORT] = value
+    elif control == THINKING_CONTROL_ENABLE:
+        kwargs[THINKING_CONTROL_ENABLE] = enabled
+
+    sampling["chat_template_kwargs"] = kwargs
+
+
+def _request_thinking_enabled(sampling: dict, control: str, fallback: bool) -> bool:
+    kwargs = dict(sampling.get("chat_template_kwargs") or {})
+    if control == THINKING_CONTROL_EFFORT:
+        value = sampling.get(THINKING_CONTROL_EFFORT, kwargs.get(THINKING_CONTROL_EFFORT))
+        return _effort_is_enabled(value, fallback)
+    if control == THINKING_CONTROL_ENABLE:
+        return bool(kwargs.get(THINKING_CONTROL_ENABLE, fallback))
+    return fallback
+
+
+def _thinking_extra_body(sampling: dict, control: str) -> dict:
+    """Return only reasoning fields for a sandbox-owned model client."""
+    kwargs = dict(sampling.get("chat_template_kwargs") or {})
+    body: dict = {"chat_template_kwargs": kwargs}
+    if control == THINKING_CONTROL_EFFORT and THINKING_CONTROL_EFFORT in sampling:
+        body[THINKING_CONTROL_EFFORT] = sampling[THINKING_CONTROL_EFFORT]
+    return body
+
+
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
@@ -269,19 +339,25 @@ def build_request(
     sampling_overrides: dict | None = None,
     sampling_from_server: bool = False,
     thinking_sampler: dict | None = None,
+    thinking_control: str = THINKING_CONTROL_ENABLE,
+    reasoning_effort: str | float = "high",
 ) -> tuple[dict, dict]:
     sampling = dict(meta.get("sampling_defaults", {}))
     scenario_overrides = scenario.get("sampling_overrides") or {}
     if extra_body:
         sampling.update(extra_body)
     resolved_thinking = resolve_thinking_enabled(meta, thinking_enabled)
-    sampling["chat_template_kwargs"] = {
-        **dict(sampling.get("chat_template_kwargs") or {}),
-        "enable_thinking": resolved_thinking,
-    }
+    _apply_thinking_control(
+        sampling,
+        thinking_control,
+        resolved_thinking,
+        reasoning_effort,
+    )
     sampling.update(scenario_overrides)
-    request_thinking = bool(
-        dict(sampling.get("chat_template_kwargs") or {}).get("enable_thinking", resolved_thinking)
+    request_thinking = _request_thinking_enabled(
+        sampling,
+        thinking_control,
+        resolved_thinking,
     )
     if request_thinking and not sampling_from_server:
         sampling.update(_thinking_sampler_for(meta, thinking_sampler))
@@ -308,14 +384,29 @@ def _apply_cli_thinking_controls(
     request: dict,
     sampling: dict,
     thinking_max_tokens: int,
+    thinking_control: str,
+    preserve_native_controls: bool = False,
 ) -> None:
     """Add provider-native reasoning controls for CLI-40 model requests."""
     if scenario.get("pack_id") != "cli-40":
         return
 
-    request_thinking = bool(
-        dict(sampling.get("chat_template_kwargs") or {}).get("enable_thinking")
-    )
+    request_thinking = _request_thinking_enabled(sampling, thinking_control, False)
+    if preserve_native_controls:
+        for key in ("enable_thinking", "thinking_budget"):
+            if key in sampling:
+                request[key] = sampling[key]
+        return
+    if thinking_control != THINKING_CONTROL_ENABLE:
+        # Do not add a Qwen-native instruction to an effort-controlled model.
+        # The resolved effort control already owns this request.
+        sampling.pop("enable_thinking", None)
+        sampling.pop("thinking_budget", None)
+        request.pop("enable_thinking", None)
+        request.pop("thinking_budget", None)
+        return
+    # Preserve CLI-40's compatibility-sensitive Qwen shape exactly: its
+    # answer-only arm is represented as enabled with a one-token budget.
     sampling.setdefault("enable_thinking", True)
     sampling.setdefault(
         "thinking_budget",
@@ -349,6 +440,15 @@ def _negative_control_response(text: str) -> dict:
         ],
         "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
     }
+
+
+def _endpoint_base(endpoint: str) -> str:
+    """Strip supported OpenAI endpoint suffixes to the serving base URL."""
+    base = endpoint.rstrip("/")
+    for suffix in ("/v1/chat/completions", "/chat/completions", "/v1"):
+        if base.endswith(suffix):
+            return base[: -len(suffix)]
+    return base
 
 
 def _chat_url(endpoint: str) -> str:
@@ -517,6 +617,8 @@ class Runner:
         negative_control: str | None = None,
         thinking_enabled: bool | None = None,
         thinking_max_tokens: int = 16384,
+        reasoning_effort: str | float | None = None,
+        probe_thinking_control: bool = False,
         extra_body: dict | None = None,
         api_key: str | None = None,
         max_total_tokens: int | None = None,
@@ -566,6 +668,26 @@ class Runner:
         self.thinking_enabled = bool(thinking_enabled)
         self.thinking_mode = thinking_mode_from_override(thinking_enabled)
         self.thinking_max_tokens = thinking_max_tokens
+        self.reasoning_effort: str | float = (
+            reasoning_effort if reasoning_effort is not None else "high"
+        )
+        self.probe_thinking_control = bool(probe_thinking_control)
+        # An explicit effort value selects the standard effort control even when
+        # the endpoint cannot expose /props. Otherwise preserve the historical
+        # Qwen request shape until template detection or an opt-in probe proves
+        # a different control.
+        self.thinking_control = (
+            THINKING_CONTROL_EFFORT
+            if reasoning_effort is not None
+            else THINKING_CONTROL_ENABLE
+        )
+        self.thinking_control_source = (
+            "explicit --reasoning-effort"
+            if reasoning_effort is not None
+            else "compatibility default"
+        )
+        self._thinking_control_resolved = reasoning_effort is not None
+        self._thinking_control_announced = False
         self.extra_body = extra_body or {}
         self.api_key = api_key
         # Bearer auth for cloud OpenAI-compatible endpoints (OpenRouter, DashScope, …);
@@ -651,6 +773,10 @@ class Runner:
         signal.signal(signal.SIGINT, _cleanup_and_raise)
         signal.signal(signal.SIGTERM, _cleanup_and_raise)
         try:
+            # Resolve the request-level reasoning control before any pack or
+            # sandbox starts. /props is metadata-only; inference probing remains
+            # opt-in because it consumes real endpoint responses.
+            self._resolve_thinking_control(warnings)
             # --sampling-from-server (#21): read server defaults before
             # any requests so we can tag the run and record what was used.
             if self.sampling_from_server:
@@ -704,6 +830,12 @@ class Runner:
                 totals={"passed": passed, "total": total, "score": (passed / total if total else 0.0)},
                 thinking_enabled=self.thinking_enabled,
                 thinking_mode=self.thinking_mode,
+                thinking_control=self.thinking_control,
+                reasoning_effort=(
+                    self.reasoning_effort
+                    if self.thinking_control == THINKING_CONTROL_EFFORT
+                    else None
+                ),
                 warnings=warnings,
                 sampling_overrides=dict(self.sampling_overrides) if self.sampling_overrides else None,
                 sampling_source="server" if self.sampling_from_server else None,
@@ -716,6 +848,98 @@ class Runner:
             self._stop_sandboxes()
             signal.signal(signal.SIGINT, old_sigint)
             signal.signal(signal.SIGTERM, old_sigterm)
+
+    def _props_chat_template(self) -> str | None:
+        """Return llama.cpp's live chat template, or None when unavailable."""
+        base = _endpoint_base(self.endpoint)
+        try:
+            with httpx.Client(timeout=5.0) as client:
+                response = client.get(f"{base}/props", headers=self._request_headers)
+            if response.status_code != 200:
+                return None
+            template = response.json().get("chat_template")
+            return template if isinstance(template, str) and template else None
+        except (httpx.HTTPError, ValueError, TypeError):
+            return None
+
+    @staticmethod
+    def _message_content(response: dict) -> str:
+        if not isinstance(response, dict):
+            return ""
+        choices = response.get("choices") if isinstance(response, dict) else None
+        if not (isinstance(choices, list) and choices and isinstance(choices[0], dict)):
+            return ""
+        message = choices[0].get("message")
+        if not isinstance(message, dict):
+            return ""
+        content = message.get("content")
+        return content.strip() if isinstance(content, str) else ""
+
+    def _probe_thinking_control(self) -> str | None:
+        """Probe known off-switches; None means the probe was inconclusive."""
+        if not self._endpoint_reachable():
+            return None
+        saw_successful_response = False
+        for control in (THINKING_CONTROL_ENABLE, THINKING_CONTROL_EFFORT):
+            fields: dict = {}
+            _apply_thinking_control(fields, control, False, self.reasoning_effort)
+            request = {
+                "model": self.model,
+                "messages": [{"role": "user", "content": "Say OK."}],
+                "max_tokens": 24,
+                "temperature": 0.0,
+                **fields,
+            }
+            try:
+                status, response, _trace = self._post_chat(
+                    request, 90.0, max_attempts=1
+                )
+            except (httpx.HTTPError, _TransientPostFailure, TypeError, ValueError):
+                continue
+            if 200 <= status < 300:
+                saw_successful_response = True
+                if self._message_content(response):
+                    return control
+        return THINKING_CONTROL_NONE if saw_successful_response else None
+
+    def _announce_thinking_control(self, warnings: list[str]) -> None:
+        if self._thinking_control_announced or self.thinking_control == THINKING_CONTROL_ENABLE:
+            return
+        self._thinking_control_announced = True
+        print(
+            "benchlocal-cli: thinking control "
+            f"{self.thinking_control!r} ({self.thinking_control_source})",
+            file=sys.stderr,
+            flush=True,
+        )
+        if self.thinking_control == THINKING_CONTROL_NONE:
+            warnings.append(
+                "no request-level thinking control detected; thinking-on/off arms "
+                "cannot be enforced for this model"
+            )
+
+    def _resolve_thinking_control(self, warnings: list[str]) -> None:
+        if not self._thinking_control_resolved:
+            # Mock/negative-control runs must not consume or wait on an endpoint.
+            if self.mock_responses or self.negative_control is not None:
+                self._thinking_control_resolved = True
+            else:
+                template = self._props_chat_template()
+                if template is not None:
+                    self.thinking_control = thinking_control_from_template(template)
+                    self.thinking_control_source = "GET /props chat_template"
+                    self._thinking_control_resolved = True
+                elif self.probe_thinking_control:
+                    probed = self._probe_thinking_control()
+                    if probed is not None:
+                        self.thinking_control = probed
+                        self.thinking_control_source = "behavioral probe"
+                    # Inconclusive means unreachable/failed: retain the safe
+                    # compatibility default instead of misclassifying no switch.
+                    self._thinking_control_resolved = True
+                else:
+                    self._thinking_control_resolved = True
+        self._announce_thinking_control(warnings)
 
     def _read_server_defaults(self, warnings: list[str]) -> dict | None:
         """Query the server for its effective sampling defaults (#21).
@@ -1034,9 +1258,7 @@ class Runner:
         short timeout and NO transient retry; if nothing answers, the caller
         skips the decode probe and falls back to static pack budgets.
         """
-        base = self.endpoint.rstrip("/")
-        if base.endswith("/v1"):
-            base = base[: -len("/v1")]
+        base = _endpoint_base(self.endpoint)
         for suffix in ("/v1/models", "/models"):
             url = f"{base}{suffix}"
             try:
@@ -1068,12 +1290,20 @@ class Runner:
                 "temperature": 0,
                 "top_p": 1,
                 "max_tokens": 200,
-                # Probe content-decode TPS with the same universal near-off
-                # mapping as Hermes. Thinking-only endpoints reject false, while
-                # a one-token budget avoids measuring reasoning-decode rate.
-                "chat_template_kwargs": {"enable_thinking": True},
-                "thinking_budget": 1,
             }
+            if self.thinking_control == THINKING_CONTROL_ENABLE:
+                # Preserve the historical near-off shape for Qwen/thinking-only
+                # endpoints: they can reject false, while budget=1 avoids
+                # measuring full reasoning-decode rate.
+                request["chat_template_kwargs"] = {"enable_thinking": True}
+                request["thinking_budget"] = 1
+            else:
+                _apply_thinking_control(
+                    request,
+                    self.thinking_control,
+                    False,
+                    self.reasoning_effort,
+                )
             started = time.perf_counter()
             # The probe must never be the thing that hangs a run: bounded read
             # budget and NO transient retry (max_attempts=1). Combined with the
@@ -1357,12 +1587,19 @@ class Runner:
             sampling_overrides=self.sampling_overrides or None,
             sampling_from_server=self.sampling_from_server,
             thinking_sampler=self.thinking_sampler,
+            thinking_control=self.thinking_control,
+            reasoning_effort=self.reasoning_effort,
         )
         _apply_cli_thinking_controls(
             scenario,
             request,
             sampling,
             self.thinking_max_tokens,
+            self.thinking_control,
+            preserve_native_controls=any(
+                key in self.extra_body
+                for key in ("enable_thinking", "thinking_budget")
+            ),
         )
         timeout = self._timeout_budget_for_scenario(meta, scenario)
         request_timeout = self._model_request_timeout(meta, timeout)
@@ -1753,14 +1990,18 @@ class Runner:
                     # HermesAgent makes its own model calls, so the resolved
                     # thinking mode and arm budget must cross the sandbox
                     # protocol explicitly. They are not generation overrides.
-                    "enable_thinking": bool(
-                        dict(sampling.get("chat_template_kwargs") or {}).get(
-                            "enable_thinking", False
-                        )
+                    "enable_thinking": _request_thinking_enabled(
+                        sampling,
+                        self.thinking_control,
+                        False,
                     ),
                     "thinking_budget": self.thinking_max_tokens,
                     "preserve_reasoning_history": self.preserve_reasoning_history,
                 }
+                if self.thinking_control != THINKING_CONTROL_ENABLE:
+                    start_kwargs["thinking_extra_body"] = _thinking_extra_body(
+                        sampling, self.thinking_control
+                    )
             elif pack_id == "aider-polyglot-30":
                 # v0.9.0: aider needs a container-reachable URL. Apply the
                 # endpoint resolver (rewrites localhost → host.docker.internal).
@@ -1771,6 +2012,10 @@ class Runner:
                     "model_api_key": self.api_key or "benchlocal-cli-aider-polyglot",  # forward the real key for cloud endpoints; placeholder for local
                     "sampling": dict(sampling),
                 }
+                if self.thinking_control != THINKING_CONTROL_ENABLE:
+                    start_kwargs["thinking_extra_body"] = _thinking_extra_body(
+                        sampling, self.thinking_control
+                    )
             if pack_id == "aider-polyglot-30" and self._on_progress_event is not None:
                 start_payload = self._verify_aider_start_with_progress(sandbox_client, scenario, start_kwargs)
             else:

--- a/benchlocal_cli/sandbox.py
+++ b/benchlocal_cli/sandbox.py
@@ -458,6 +458,7 @@ class SandboxClient:
         sampling: dict | None = None,
         enable_thinking: bool | None = None,
         thinking_budget: int | None = None,
+        thinking_extra_body: dict | None = None,
         preserve_reasoning_history: bool | None = None,
     ) -> dict:
         """Initialize a sandbox-owned multi-turn scenario state.
@@ -483,6 +484,8 @@ class SandboxClient:
             payload["enable_thinking"] = enable_thinking
         if thinking_budget is not None:
             payload["thinking_budget"] = thinking_budget
+        if thinking_extra_body is not None:
+            payload["thinking_extra_body"] = dict(thinking_extra_body)
         if preserve_reasoning_history is not None:
             payload["preserve_reasoning_history"] = preserve_reasoning_history
         return self._post("/verify-start", payload)

--- a/benchlocal_cli/types.py
+++ b/benchlocal_cli/types.py
@@ -163,6 +163,9 @@ class RunResult:
     totals: dict[str, float | int]
     thinking_enabled: bool = False
     thinking_mode: str = "pack-defaults"
+    # Additive audit fields for model-family-specific reasoning controls.
+    thinking_control: str = "enable_thinking"
+    reasoning_effort: str | float | None = None
     warnings: list[str] = field(default_factory=list)
     # v0.8: populated when `--previous-result PATH` was passed to the run.
     # None means delta wasn't computed (the default; preserves saved-JSON
@@ -212,6 +215,10 @@ class RunResult:
             "repeat": self.repeat,
             "equivalent_score_150": equivalent_score_150,
         }
+        if self.thinking_control != "enable_thinking":
+            out["thinking_control"] = self.thinking_control
+        if self.reasoning_effort is not None:
+            out["reasoning_effort"] = self.reasoning_effort
         if self.delta is not None:
             out["delta"] = self.delta
         if self.sampling_overrides is not None:

--- a/sandboxes/aider-polyglot/server.py
+++ b/sandboxes/aider-polyglot/server.py
@@ -88,6 +88,25 @@ _LITELLM_PROVIDERS = {
 DEFAULT_EDIT_FORMAT = "whole"
 
 
+def _model_settings_text(
+    model_name: str,
+    edit_format: str,
+    thinking_extra_body: dict,
+) -> str:
+    """Render aider's model settings with a JSON-compatible inline YAML value."""
+    compact_body = json.dumps(
+        thinking_extra_body,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return (
+        f"- name: {model_name}\n"
+        f"  edit_format: {edit_format}\n"
+        "  extra_params:\n"
+        f"    extra_body: {compact_body}\n"
+    )
+
+
 # ============================================================================
 # Exercise list — canonical 30 from vendor/AiderPolyglot-30/exercises.json
 # Loaded at startup (Codex 2nd-pass #5: exact-id match, not count).
@@ -611,25 +630,24 @@ def _verify_start(req: dict) -> dict:
         # (org/model) are not litellm provider-qualified either.
         aider_model = _qualify_aider_model(model_name)
 
-        # Disable Qwen3-style thinking via per-request `extra_body`.
-        # vLLM doesn't accept --chat-template-kwargs at the CLI; the
-        # per-request mechanism is the supported path. Aider reads
-        # `.aider.model.settings.yml` from cwd (job_dir) and forwards
-        # extra_params to litellm, which forwards to vLLM as extra_body.
-        #
-        # Written for ALL models (not just Qwen):
-        #   - Gemma 4 default thinking=off already, so the kwarg is a no-op
-        #   - llama.cpp ignores unknown chat_template_kwargs
-        # If a future bench wants thinking ON, set
-        # BENCHLOCAL_AIDER_ENABLE_THINKING=1 in the runner env.
-        if os.environ.get("BENCHLOCAL_AIDER_ENABLE_THINKING") != "1":
+        # Aider reads .aider.model.settings.yml from cwd (job_dir) and
+        # forwards extra_params to litellm as extra_body. The runner resolves
+        # the model-specific reasoning switch once and sends the complete
+        # fragment here. Older callers keep the historical Qwen-off default.
+        thinking_extra_body = req.get("thinking_extra_body")
+        if isinstance(thinking_extra_body, dict):
             (job_dir / ".aider.model.settings.yml").write_text(
-                "- name: " + aider_model + "\n"
-                "  edit_format: " + edit_format + "\n"
-                "  extra_params:\n"
-                "    extra_body:\n"
-                "      chat_template_kwargs:\n"
-                "        enable_thinking: false\n"
+                _model_settings_text(aider_model, edit_format, thinking_extra_body),
+                encoding="utf-8",
+            )
+        elif os.environ.get("BENCHLOCAL_AIDER_ENABLE_THINKING") != "1":
+            (job_dir / ".aider.model.settings.yml").write_text(
+                _model_settings_text(
+                    aider_model,
+                    edit_format,
+                    {"chat_template_kwargs": {"enable_thinking": False}},
+                ),
+                encoding="utf-8",
             )
 
         argv = _build_benchmark_args(

--- a/sandboxes/hermes/server.py
+++ b/sandboxes/hermes/server.py
@@ -298,8 +298,14 @@ def _thinking_extra_body(req: dict) -> dict:
     """Build HermesAgent's provider-specific request body.
 
     Thinking controls deliberately bypass _filter_generation: the pinned
-    framework consumes them as extra_body, not generation overrides.
+    framework consumes them as extra_body, not generation overrides. New
+    runners provide the complete model-specific fragment; keep the legacy
+    budget-based shape for older callers and Qwen's existing behavior.
     """
+    resolved = req.get("thinking_extra_body")
+    if isinstance(resolved, dict):
+        return dict(resolved)
+
     enabled = req.get("enable_thinking")
     sampling = req.get("sampling") or {}
     if not isinstance(enabled, bool):
@@ -328,7 +334,8 @@ def _translate_request(req: dict) -> dict:
 
     Runner sends:
       { scenario_id, scenario, model_endpoint, model_name, model_api_key,
-        sampling, enable_thinking, thinking_budget, preserve_reasoning_history }
+        sampling, enable_thinking, thinking_budget, thinking_extra_body,
+        preserve_reasoning_history }
 
     Upstream expects:
       { scenarioId, runId, model: {id, exposedModel, providerModel,

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -1024,6 +1024,71 @@ def test_runner_uses_hermes_verify_start_early_out_and_passes_endpoint(
     assert nested_trace.get("hermes_agent_source") == "host-mount"
 
 
+def test_runner_passes_effort_control_to_hermes_owned_model_calls():
+    runner = Runner(
+        endpoint="http://10.0.0.5:8001",
+        model="inkling",
+        enable_sandboxed_packs=True,
+        thinking_enabled=False,
+        reasoning_effort="high",
+    )
+    fake = FakeHermesEarlyOutSandbox()
+    runner._sandbox_clients["hermesagent-20"] = fake
+    meta = {
+        "supports_sandboxed_only": True,
+        "default_max_seconds": 60,
+        "sampling_defaults": {"max_tokens": 256, "temperature": 0.0},
+    }
+    scenario = {
+        "id": "HA-01",
+        "pack_id": "hermesagent-20",
+        "messages": [{"role": "user", "content": "remember CockroachDB"}],
+        "raw_scenario": {"kind": "memory_replace_contradiction"},
+        "verifier": {"type": "_stub", "asserts": []},
+    }
+
+    run = runner.run_scenario(meta, scenario)
+
+    assert run.result.passed is True
+    assert fake.start_kwargs["enable_thinking"] is False
+    assert fake.start_kwargs["thinking_extra_body"] == {
+        "chat_template_kwargs": {"reasoning_effort": "none"},
+        "reasoning_effort": "none",
+    }
+
+
+def test_runner_passes_effort_control_to_aider_owned_model_calls():
+    runner = Runner(
+        endpoint="http://10.0.0.5:8001",
+        model="inkling",
+        enable_sandboxed_packs=True,
+        thinking_enabled=True,
+        reasoning_effort=0.8,
+    )
+    fake = FakeHermesEarlyOutSandbox()
+    runner._sandbox_clients["aider-polyglot-30"] = fake
+    meta = {
+        "supports_sandboxed_only": True,
+        "default_max_seconds": 60,
+        "sampling_defaults": {"max_tokens": 256, "temperature": 0.0},
+    }
+    scenario = {
+        "id": "aider-polyglot-30-batch",
+        "pack_id": "aider-polyglot-30",
+        "messages": [{"role": "user", "content": "fix the project"}],
+        "raw_scenario": {"kind": "aider-polyglot-batch"},
+        "verifier": {"type": "_stub", "asserts": []},
+    }
+
+    run = runner.run_scenario(meta, scenario)
+
+    assert run.result.passed is True
+    assert fake.start_kwargs["thinking_extra_body"] == {
+        "chat_template_kwargs": {"reasoning_effort": 0.8},
+        "reasoning_effort": 0.8,
+    }
+
+
 def test_runner_propagates_hermes_failure_mode_from_verify_start():
     runner = Runner(endpoint="http://localhost:8001", model="fake", enable_sandboxed_packs=True)
     fake = FakeHermesEarlyOutSandbox(

--- a/tests/test_sandbox_verifiers.py
+++ b/tests/test_sandbox_verifiers.py
@@ -1066,3 +1066,36 @@ def test_code_reasoning_verifier_executes_content_not_reasoning_draft():
     assert result["passed"] is True
     assert result["response_field_used"] == "message.content"
     assert result["extraction_method"] == "last_fenced"
+
+
+def test_hermes_prefers_resolved_reasoning_extra_body():
+    server = _hermes_server()
+    resolved = {
+        "chat_template_kwargs": {"reasoning_effort": "none"},
+        "reasoning_effort": "none",
+    }
+
+    assert server._thinking_extra_body({
+        "thinking_extra_body": resolved,
+        "enable_thinking": True,
+        "thinking_budget": 4096,
+    }) == resolved
+
+
+def test_aider_model_settings_accepts_effort_control():
+    server = _load(
+        "aider_polyglot_thinking_control",
+        "sandboxes/aider-polyglot/server.py",
+    )
+    rendered = server._model_settings_text(
+        "openai/inkling",
+        "whole",
+        {
+            "chat_template_kwargs": {"reasoning_effort": "none"},
+            "reasoning_effort": "none",
+        },
+    )
+
+    assert "extra_body: {" in rendered
+    assert '"chat_template_kwargs":{"reasoning_effort":"none"}' in rendered
+    assert '"reasoning_effort":"none"' in rendered

--- a/tests/test_thinking_control.py
+++ b/tests/test_thinking_control.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from benchlocal_cli.cli import _parse_reasoning_effort
+from benchlocal_cli.runner import (
+    THINKING_CONTROL_EFFORT,
+    THINKING_CONTROL_ENABLE,
+    THINKING_CONTROL_NONE,
+    Runner,
+    _endpoint_base,
+    build_request,
+    thinking_control_from_template,
+)
+from benchlocal_cli.types import RunResult
+
+
+def _meta(default_thinking: str = "off") -> dict:
+    return {
+        "sampling_defaults": {
+            "temperature": 0,
+            "max_tokens": 1024,
+            "chat_template_kwargs": {"enable_thinking": False},
+        },
+        "default_thinking": default_thinking,
+    }
+
+
+def _scenario() -> dict:
+    return {
+        "id": "x",
+        "messages": [{"role": "user", "content": "Say hello."}],
+        "verifier": {"type": "instruct_follow", "asserts": []},
+    }
+
+
+@pytest.mark.parametrize(
+    ("template", "expected"),
+    [
+        ("{% if enable_thinking %}think{% endif %}", THINKING_CONTROL_ENABLE),
+        ("Thinking effort: {{ reasoning_effort }}", THINKING_CONTROL_EFFORT),
+        (
+            "{{ reasoning_effort }} {% if enable_thinking %}think{% endif %}",
+            THINKING_CONTROL_ENABLE,
+        ),
+        ("{{ messages }}", THINKING_CONTROL_NONE),
+    ],
+)
+def test_template_detection_prefers_compatible_qwen_control(template, expected):
+    assert thinking_control_from_template(template) == expected
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "expected"),
+    [
+        ("http://host:8000", "http://host:8000"),
+        ("http://host:8000/v1", "http://host:8000"),
+        ("http://host:8000/v1/chat/completions", "http://host:8000"),
+        ("http://host:8000/chat/completions/", "http://host:8000"),
+    ],
+)
+def test_endpoint_base_normalizes_supported_endpoint_forms(endpoint, expected):
+    assert _endpoint_base(endpoint) == expected
+
+
+def test_effort_control_sends_standard_and_template_copy_when_off():
+    request, sampling = build_request(
+        _scenario(),
+        _meta(default_thinking="on"),
+        "fake",
+        thinking_enabled=False,
+        thinking_control=THINKING_CONTROL_EFFORT,
+        reasoning_effort="xhigh",
+    )
+
+    assert request["reasoning_effort"] == "none"
+    assert request["chat_template_kwargs"] == {"reasoning_effort": "none"}
+    assert "enable_thinking" not in request["chat_template_kwargs"]
+    assert sampling["reasoning_effort"] == "none"
+    assert request["max_tokens"] == 1024
+
+
+def test_effort_control_uses_configured_on_value_and_thinking_budget():
+    request, _ = build_request(
+        _scenario(),
+        _meta(),
+        "fake",
+        thinking_enabled=True,
+        thinking_max_tokens=4096,
+        thinking_control=THINKING_CONTROL_EFFORT,
+        reasoning_effort=0.75,
+    )
+
+    assert request["reasoning_effort"] == 0.75
+    assert request["chat_template_kwargs"] == {"reasoning_effort": 0.75}
+    assert request["max_tokens"] == 4096
+
+
+def test_no_detected_control_does_not_send_qwen_key():
+    request, _ = build_request(
+        _scenario(),
+        _meta(),
+        "fake",
+        thinking_enabled=False,
+        thinking_control=THINKING_CONTROL_NONE,
+    )
+
+    assert request["chat_template_kwargs"] == {}
+    assert "reasoning_effort" not in request
+
+
+def test_props_detection_selects_effort_and_announces(monkeypatch, capsys):
+    runner = Runner(endpoint="http://localhost:9999", model="fake")
+    monkeypatch.setattr(
+        runner,
+        "_props_chat_template",
+        lambda: "Thinking effort: {{ reasoning_effort }}",
+    )
+    warnings: list[str] = []
+
+    runner._resolve_thinking_control(warnings)
+
+    assert runner.thinking_control == THINKING_CONTROL_EFFORT
+    assert runner.thinking_control_source == "GET /props chat_template"
+    assert warnings == []
+    assert "thinking control 'reasoning_effort'" in capsys.readouterr().err
+
+
+def test_props_detection_reports_template_with_no_switch(monkeypatch):
+    runner = Runner(endpoint="http://localhost:9999", model="fake")
+    monkeypatch.setattr(runner, "_props_chat_template", lambda: "{{ messages }}")
+    warnings: list[str] = []
+
+    runner._resolve_thinking_control(warnings)
+
+    assert runner.thinking_control == THINKING_CONTROL_NONE
+    assert any("cannot be enforced" in warning for warning in warnings)
+
+
+def test_behavioral_probe_is_opt_in(monkeypatch):
+    runner = Runner(endpoint="http://localhost:9999", model="fake")
+    monkeypatch.setattr(runner, "_props_chat_template", lambda: None)
+    monkeypatch.setattr(
+        runner,
+        "_probe_thinking_control",
+        lambda: pytest.fail("probe must remain opt-in"),
+    )
+
+    runner._resolve_thinking_control([])
+
+    assert runner.thinking_control == THINKING_CONTROL_ENABLE
+
+
+def test_default_template_control_remains_silent(monkeypatch, capsys):
+    runner = Runner(endpoint="http://localhost:9999", model="fake")
+    monkeypatch.setattr(
+        runner,
+        "_props_chat_template",
+        lambda: "{% if enable_thinking %}think{% endif %}",
+    )
+
+    runner._resolve_thinking_control([])
+
+    assert runner.thinking_control == THINKING_CONTROL_ENABLE
+    assert capsys.readouterr().err == ""
+
+
+def test_behavioral_probe_finds_effort_and_sends_both_locations(monkeypatch):
+    runner = Runner(
+        endpoint="http://localhost:9999",
+        model="fake",
+        probe_thinking_control=True,
+    )
+    requests: list[dict] = []
+
+    monkeypatch.setattr(runner, "_endpoint_reachable", lambda: True)
+
+    def fake_post(request, timeout, *, max_attempts=None):
+        requests.append(request)
+        content = "" if len(requests) == 1 else "OK"
+        return 200, {"choices": [{"message": {"content": content}}]}, None
+
+    monkeypatch.setattr(runner, "_post_chat", fake_post)
+
+    assert runner._probe_thinking_control() == THINKING_CONTROL_EFFORT
+    assert requests[0]["chat_template_kwargs"] == {"enable_thinking": False}
+    assert requests[1]["reasoning_effort"] == "none"
+    assert requests[1]["chat_template_kwargs"] == {"reasoning_effort": "none"}
+
+
+def test_behavioral_probe_stops_when_enable_thinking_works(monkeypatch):
+    runner = Runner(
+        endpoint="http://localhost:9999",
+        model="fake",
+        probe_thinking_control=True,
+    )
+    requests: list[dict] = []
+    monkeypatch.setattr(runner, "_endpoint_reachable", lambda: True)
+
+    def fake_post(request, timeout, *, max_attempts=None):
+        requests.append(request)
+        return 200, {"choices": [{"message": {"content": "OK"}}]}, None
+
+    monkeypatch.setattr(runner, "_post_chat", fake_post)
+
+    assert runner._probe_thinking_control() == THINKING_CONTROL_ENABLE
+    assert len(requests) == 1
+    assert requests[0]["chat_template_kwargs"] == {"enable_thinking": False}
+
+
+def test_behavioral_probe_reports_no_working_switch(monkeypatch):
+    runner = Runner(
+        endpoint="http://localhost:9999",
+        model="fake",
+        probe_thinking_control=True,
+    )
+    monkeypatch.setattr(runner, "_endpoint_reachable", lambda: True)
+    monkeypatch.setattr(
+        runner,
+        "_post_chat",
+        lambda request, timeout, *, max_attempts=None: (
+            200,
+            {"choices": [{"message": {"content": ""}}]},
+            None,
+        ),
+    )
+
+    assert runner._probe_thinking_control() == THINKING_CONTROL_NONE
+
+
+def test_unreachable_behavioral_probe_is_inconclusive(monkeypatch):
+    runner = Runner(
+        endpoint="http://localhost:9999",
+        model="fake",
+        probe_thinking_control=True,
+    )
+    monkeypatch.setattr(runner, "_endpoint_reachable", lambda: False)
+
+    assert runner._probe_thinking_control() is None
+
+
+def test_inconclusive_probe_keeps_compatibility_default(monkeypatch, capsys):
+    runner = Runner(
+        endpoint="http://localhost:9999",
+        model="fake",
+        probe_thinking_control=True,
+    )
+    monkeypatch.setattr(runner, "_props_chat_template", lambda: None)
+    monkeypatch.setattr(runner, "_probe_thinking_control", lambda: None)
+
+    runner._resolve_thinking_control([])
+
+    assert runner.thinking_control == THINKING_CONTROL_ENABLE
+    assert capsys.readouterr().err == ""
+
+
+def test_explicit_effort_skips_detection(monkeypatch):
+    runner = Runner(
+        endpoint="http://localhost:9999",
+        model="fake",
+        reasoning_effort="minimal",
+    )
+    monkeypatch.setattr(
+        runner,
+        "_props_chat_template",
+        lambda: pytest.fail("explicit effort must skip detection"),
+    )
+
+    runner._resolve_thinking_control([])
+
+    assert runner.thinking_control == THINKING_CONTROL_EFFORT
+    assert runner.reasoning_effort == "minimal"
+
+
+def _result(**overrides) -> RunResult:
+    values = {
+        "schema_version": "1",
+        "runner_version": "test",
+        "endpoint": "http://localhost:8000",
+        "model": "fake",
+        "mode": "custom",
+        "started_at": "2026-08-12T00:00:00Z",
+        "finished_at": "2026-08-12T00:00:01Z",
+        "packs": [],
+        "totals": {"passed": 0, "total": 0, "score": 0.0},
+    }
+    values.update(overrides)
+    return RunResult(**values)
+
+
+def test_default_result_json_remains_compatible():
+    result = _result().to_dict()
+
+    assert "thinking_control" not in result
+    assert "reasoning_effort" not in result
+
+
+def test_effort_result_json_records_resolved_control():
+    result = _result(
+        thinking_control=THINKING_CONTROL_EFFORT,
+        reasoning_effort=0.75,
+    ).to_dict()
+
+    assert result["thinking_control"] == THINKING_CONTROL_EFFORT
+    assert result["reasoning_effort"] == 0.75
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("none", "none"),
+        ("XHIGH", "xhigh"),
+        ("0.0", 0.0),
+        ("0.99", 0.99),
+    ],
+)
+def test_reasoning_effort_cli_parser(raw, expected):
+    assert _parse_reasoning_effort(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["", "ultra", "-0.1", "1.0"])
+def test_reasoning_effort_cli_parser_rejects_invalid_values(raw):
+    with pytest.raises(argparse.ArgumentTypeError):
+        _parse_reasoning_effort(raw)


### PR DESCRIPTION
## Summary

- detect enable_thinking versus reasoning_effort from the live llama.cpp /props chat template
- add an opt-in, reachability-gated behavioral probe for endpoints without /props
- send reasoning_effort both top-level and in chat_template_kwargs for llama.cpp compatibility
- forward the resolved control through direct, Hermes, and Aider-owned model calls
- add --reasoning-effort, saved-result audit fields, documentation, and the full detector contract suite

## Compatibility

- enable_thinking wins when a template declares both controls
- behavioral probing remains opt-in and an inconclusive probe keeps the compatibility default
- the default path stays silent and preserves the existing Qwen request/result shape

## Validation

- python3 -m pytest tests/ -q: 371 passed
- affected Python modules compile successfully
- new contract test passes Ruff; the modified tree adds no diagnostics beyond the untouched baseline

Closes #130