### PR TITLE
docs: reasoning-pack provenance + extend-don't-regenerate convention (#121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ docs/
 ├── HERMES_V073_AB.md           # forensic notes from the Hermes A/B run
 ├── INTEGRATION.md              # how club-3090 (or other repos) consume this CLI
 ├── PACK_FORMAT.md              # JSONL schema each pack file follows
+├── REASONING_PACKS.md          # humaneval-plus-30 / lcb-v6-30 provenance, drift, extension convention
 ├── SANDBOX_PROTOCOL.md         # HTTP protocol the sandboxed packs implement
 └── VENDOR_SYNC.md              # how to bump vendored upstream pins
 ```

--- a/docs/EXTRACTOR_NOTES.md
+++ b/docs/EXTRACTOR_NOTES.md
@@ -1,6 +1,6 @@
 # Extractor notes
 
-`node tools/build-packs.js` is the canonical pack generator. It reads vendored upstream sources from `vendor/<PackName>/` and writes JSONL to `benchlocal_cli/packs/`.
+`node tools/build-packs.js` is the canonical pack generator. It reads vendored upstream sources from `vendor/<PackName>/` and writes JSONL to `benchlocal_cli/packs/`. Exception: the reasoning packs (`humaneval-plus-30`, `lcb-v6-30`) have no vendor tree and are not built by this tool — see [REASONING_PACKS.md](./REASONING_PACKS.md) for their provenance and extension rules.
 
 ## Source of truth
 

--- a/docs/PACK_FORMAT.md
+++ b/docs/PACK_FORMAT.md
@@ -56,6 +56,7 @@ Field reference:
 | `supports_sandboxed_only` | no | bool | `true` for BugFind/HermesAgent/CLI/HumanEval+/LCB/Aider; runner skips with warning unless `--enable-sandboxed-packs` |
 | `safety_policy` | no | object / null | Optional benchmark-intent metadata for packs with safety/refusal scenarios. `mode: "implicit_benchmark_local"` means the pack uses terse task-local instructions and scores operational restraint under existing workspace/tool rules; it is not an explicit policy-following test. |
 | `suite` | no | string | Logical suite label used by mode selectors; e.g. `reasoning` groups packs for `--reasoning`. |
+| `subset` | no | object | For sampled packs: `{default, full, selection}` — the shipped row count, the upstream pool size at port time, and the selection rule. ⚠️ `full` is a snapshot of upstream at port time, not a reliable extension ceiling; see [REASONING_PACKS.md](./REASONING_PACKS.md). |
 | `requires_dataset_access` | no | bool | `true` for gated datasets. Runner returns a skipped `PackResult` with `status: dataset-unavailable` instead of failing the run. |
 | `dataset_access_note` | no | string | Human-readable skip/warning text surfaced when `requires_dataset_access` prevents materializing a pack. |
 | `ported_at` | yes | ISO date | When we ported this pack |

--- a/docs/REASONING_PACKS.md
+++ b/docs/REASONING_PACKS.md
@@ -1,0 +1,70 @@
+# Reasoning packs: `humaneval-plus-30` and `lcb-v6-30`
+
+Provenance, known upstream drift, and the extension convention for the two
+out-of-band reasoning code packs. Recorded per issue #121 so this stops being
+private discipline.
+
+These are the **only two packs that route through the `code-reasoning`
+sandbox** (60 records total), and the only two with out-of-band reasoning.
+Both run `temperature: 0`, so re-running is deterministic and yields the same
+records — more `n` requires more scenarios, not more runs.
+
+## They are NOT built by `tools/build-packs.js`
+
+`tools/build-packs.js` only builds the vendored `stevibe/*` packs (see
+[VENDOR_SYNC.md](./VENDOR_SYNC.md)). The reasoning packs have no `vendor/`
+tree and no in-repo generator: they were derived once (2026-05-24, "Codex
+reasoning-pack generator") from the HuggingFace datasets
+`evalplus/humanevalplus` and `livecodebench/code_generation_lite`. Extending
+them means re-deriving the projection by hand.
+
+## The one non-obvious transformation
+
+benchlocal rewrites evalplus's assertion helper when generating each `test`:
+
+```
+np.testing.assert_allclose(out, exp     ->     assert np.allclose(out, exp, rtol=1e-07
+```
+
+applied once per `test`. With that substitution, current upstream reproduces
+28/30 byte-identically; without it, every generated row differs from the
+shipped ones **in assertion semantics rather than data** — getting it wrong
+silently changes what the verifier executes.
+
+## Known upstream drift (as of 2026-08-02 — this keeps moving)
+
+| Pack | Recorded | Upstream now | Detail |
+|---|---|---|---|
+| `lcb-v6-30` | `subset.full: 50` | **70** rows match the pack's own filter | First 30 reproduce the shipped pack exactly, in order; the extra 20 are problems added upstream since the pin. |
+| `humaneval-plus-30` | 30 shipped rows | test data added to **2 of the 30** | `prompt`/`entry_point` match exactly on all 30; only `test` moved — `HumanEval/1` 8,984 → 137,328 chars, `HumanEval/28` 118,702 → 125,238. |
+
+The LCB filter, as recorded in the pack: `release_v6`, `platform == leetcode`,
+all `public_test_cases` `testtype == functional`, `contest_date >= 2025-01-01`.
+
+Consequences:
+
+- A regenerated pack is **not** the pack that produced any previously
+  published number.
+- **`subset.full` is not a reliable ceiling** for how far a pack can be
+  extended — upstream grows.
+- The recorded provenance IDs are HF cache/snapshot ids
+  (`hf-cache-…` / `hf-snapshot-…`), **not resolved dataset snapshots**, so
+  drift cannot be checked without a content diff. New packs in this lineage
+  should record the resolved snapshot (revision + commit date) in metadata so
+  the check becomes mechanical.
+
+## Convention: extend with a SEPARATE pack — never regenerate in place
+
+When more `n` is needed on a pack that already has published results, emit the
+new rows as a **separate pack** (`humaneval-plus-ext134`, `lcb-v6-ext40`)
+rather than regenerating the original with a larger `subset.default`. Then:
+
+- the original stays **byte-identical**, so previously published records
+  remain exactly the corpus they were reported against;
+- upstream drift lands only in the new pack, where nothing has been published
+  yet, and cannot contaminate a before/after comparison;
+- the two are still trivially poolable for an aggregate count.
+
+The failure mode this avoids: regenerating `humaneval-plus-30` in place to
+reach n=164 would have silently changed the test suites for `HumanEval/1` and
+`/28` underneath a corpus that had already been discussed in public.


### PR DESCRIPTION
Documents the three findings from #121 — no code changes:

1. **Generator absence + the non-obvious transform:** `humaneval-plus-30` / `lcb-v6-30` are not built by `tools/build-packs.js`; the one transformation that must be reproduced when re-deriving them is the `np.testing.assert_allclose → np.allclose(..., rtol=1e-07)` rewrite (without it, every row differs in assertion semantics, not data).
2. **Drift record (as of 2026-08-02):** LCB pool grew 50 → 70 under the pack's own filter; humaneval added test data to `HumanEval/1` and `/28` (prompts/entry_points unchanged on all 30). `subset.full` is therefore a port-time snapshot, not an extension ceiling — noted in the PACK_FORMAT field table too. Also flags that the `hf-cache-…`/`hf-snapshot-…` provenance ids can't be checked without a content diff; future packs should record the resolved snapshot.
3. **The convention (the explicit ask):** extend with a *separate* pack (`humaneval-plus-ext134`, `lcb-v6-ext40`), never regenerate in place — published records stay byte-identical to their corpus, drift lands only where nothing is published yet, and the packs remain poolable.

Discoverability: README docs tree + `subset` row in PACK_FORMAT.md + pointer in EXTRACTOR_NOTES.md. Full suite green (docs-only).

Closes #121.