### PR TITLE
fix(cli-40): no-thinking arm defers to chat_template_kwargs (#129)

### DIFF
--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -397,21 +397,24 @@ def _apply_cli_thinking_controls(
             if key in sampling:
                 request[key] = sampling[key]
         return
-    if thinking_control != THINKING_CONTROL_ENABLE:
-        # Do not add a Qwen-native instruction to an effort-controlled model.
-        # The resolved effort control already owns this request.
+    if thinking_control != THINKING_CONTROL_ENABLE or not request_thinking:
+        # Effort-controlled model: the resolved effort control already owns
+        # this request. Answer-only arm (#129): do NOT send the top-level
+        # Qwen pair (enable_thinking=true + thinking_budget=1) — it
+        # contradicts the harness-level chat_template_kwargs.enable_thinking=
+        # false, and budget-honoring endpoints then run the model thinking-ON
+        # truncated to one token: reasoning leaks into content and the
+        # no-thinking arm is scored on contaminated output. Defer to
+        # chat_template_kwargs, which the other packs use cleanly for no-think.
         sampling.pop("enable_thinking", None)
         sampling.pop("thinking_budget", None)
         request.pop("enable_thinking", None)
         request.pop("thinking_budget", None)
         return
-    # Preserve CLI-40's compatibility-sensitive Qwen shape exactly: its
-    # answer-only arm is represented as enabled with a one-token budget.
+    # Thinking is enabled: preserve CLI-40's compatibility-sensitive Qwen
+    # shape (top-level enable_thinking + thinking_budget).
     sampling.setdefault("enable_thinking", True)
-    sampling.setdefault(
-        "thinking_budget",
-        max(1, int(thinking_max_tokens)) if request_thinking else 1,
-    )
+    sampling.setdefault("thinking_budget", max(1, int(thinking_max_tokens)))
     request["enable_thinking"] = sampling["enable_thinking"]
     request["thinking_budget"] = sampling["thinking_budget"]
 

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -1593,7 +1593,7 @@ def test_sandbox_model_turn_timeout_caps_large_budget_and_is_configurable():
 
 @pytest.mark.parametrize(
     ("thinking_enabled", "expected_budget", "expected_template_value"),
-    [(True, 4096, True), (False, 1, False)],
+    [(True, 4096, True), (False, None, False)],
 )
 def test_cli_multiturn_forwards_native_thinking_controls(
     monkeypatch,
@@ -1622,11 +1622,18 @@ def test_cli_multiturn_forwards_native_thinking_controls(
     assert run.result.passed is True
     assert len(CapturingHTTPClient.requests) == 2
     for request in CapturingHTTPClient.requests:
-        assert request["enable_thinking"] is True
-        assert request["thinking_budget"] == expected_budget
         assert request["chat_template_kwargs"]["enable_thinking"] is expected_template_value
-    if thinking_enabled:
-        assert all(request["max_tokens"] == 4096 for request in CapturingHTTPClient.requests)
+        if thinking_enabled:
+            assert request["enable_thinking"] is True
+            assert request["thinking_budget"] == expected_budget
+            assert request["max_tokens"] == 4096
+        else:
+            # #129: the answer-only arm defers to chat_template_kwargs. The old
+            # top-level enable_thinking=true + thinking_budget=1 pair contradicted
+            # it, and budget-honoring endpoints ran the model thinking-ON
+            # truncated to one token, contaminating the no-thinking arm.
+            assert "enable_thinking" not in request
+            assert "thinking_budget" not in request
 
 
 def test_cli_native_thinking_controls_preserve_explicit_extra_body(monkeypatch):

--- a/tests/test_thinking_control.py
+++ b/tests/test_thinking_control.py
@@ -10,6 +10,7 @@ from benchlocal_cli.runner import (
     THINKING_CONTROL_ENABLE,
     THINKING_CONTROL_NONE,
     Runner,
+    _apply_cli_thinking_controls,
     _endpoint_base,
     build_request,
     thinking_control_from_template,
@@ -305,6 +306,88 @@ def test_effort_result_json_records_resolved_control():
 
     assert result["thinking_control"] == THINKING_CONTROL_EFFORT
     assert result["reasoning_effort"] == 0.75
+
+
+def _cli40_meta() -> dict:
+    return {
+        "sampling_defaults": {
+            "temperature": 0,
+            "top_p": 1,
+            "max_tokens": 1024,
+            "chat_template_kwargs": {"enable_thinking": False},
+        },
+        "default_thinking": "off",
+    }
+
+
+def _cli40_scenario() -> dict:
+    scenario = _scenario()
+    scenario["pack_id"] = "cli-40"
+    return scenario
+
+
+def _cli40_request(thinking_enabled, thinking_control=THINKING_CONTROL_ENABLE):
+    scenario = _cli40_scenario()
+    request, sampling = build_request(
+        scenario,
+        _cli40_meta(),
+        "fake",
+        thinking_enabled=thinking_enabled,
+        thinking_max_tokens=4096,
+        thinking_control=thinking_control,
+    )
+    _apply_cli_thinking_controls(
+        scenario,
+        request,
+        sampling,
+        4096,
+        thinking_control,
+    )
+    return request
+
+
+def test_cli40_no_thinking_defers_to_template_kwargs_only():
+    """#129: the answer-only arm must not carry the top-level Qwen pair."""
+    request = _cli40_request(thinking_enabled=False)
+
+    assert request["chat_template_kwargs"] == {"enable_thinking": False}
+    assert "enable_thinking" not in request
+    assert "thinking_budget" not in request
+
+
+def test_cli40_thinking_keeps_native_qwen_shape():
+    request = _cli40_request(thinking_enabled=True)
+
+    assert request["chat_template_kwargs"] == {"enable_thinking": True}
+    assert request["enable_thinking"] is True
+    assert request["thinking_budget"] == 4096
+    assert request["max_tokens"] == 4096
+
+
+def test_cli40_effort_controlled_model_gets_no_native_pair():
+    request = _cli40_request(
+        thinking_enabled=False, thinking_control=THINKING_CONTROL_EFFORT
+    )
+
+    assert request["chat_template_kwargs"] == {"reasoning_effort": "none"}
+    assert request["reasoning_effort"] == "none"
+    assert "enable_thinking" not in request
+    assert "thinking_budget" not in request
+
+
+def test_non_cli40_pack_never_gets_native_pair():
+    scenario = _scenario()
+    request, sampling = build_request(
+        scenario,
+        _cli40_meta(),
+        "fake",
+        thinking_enabled=True,
+        thinking_max_tokens=4096,
+    )
+    _apply_cli_thinking_controls(scenario, request, sampling, 4096, THINKING_CONTROL_ENABLE)
+
+    assert "enable_thinking" not in request
+    assert "thinking_budget" not in request
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes the measured contamination from #129: in no-thinking mode cli-40 sent top-level `enable_thinking=true` + `thinking_budget=1` **alongside** `chat_template_kwargs.enable_thinking=false`. Budget-honoring endpoints obeyed the top-level pair → thinking ON truncated to one token → deliberation leaked into content → 25/40 requests affected, 16/29 failures contaminated (incl. all four safety scenarios), deterministically.

**Change:** the answer-only arm now defers to the harness-level `chat_template_kwargs` gate — the same mechanism the other seven packs use cleanly for no-think (0/110 requests affected in the same run). The native Qwen pair is still sent when thinking is enabled, where it agrees with the template kwargs. `preserve_native_controls` (`--extra-body`) path unchanged.

- Updated `test_cli_multiturn_forwards_native_thinking_controls`: the `thinking_enabled=False` arm asserted the exact contradictory shape this removes.
- Added 4 regression tests covering: no-thinking shape, thinking-ON native shape, effort-controlled model, non-cli-40 pack untouched.
- Full suite: 378 passed.

The issue's second half (per-response `reasoning_content` guard for no-thinking runs) is implemented by the #126 detector — it catches exactly this failure class at run level.

Closes #129.