### PR TITLE
feat(run): detect thinking arms that didn't take effect (#126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ Whenever thinking is enabled for a pack, request `max_tokens` is raised to `--th
 
 In multi-turn CLI and Hermes agent loops, captured assistant reasoning stays in the saved result for inspection, but prior `reasoning`, `reasoning_content`, `reasoning_details`, and `codex_reasoning_items` fields are stripped from the next outgoing request by default. This avoids replaying provider-private or stale reasoning state. Use `--preserve-reasoning-history` only when an endpoint explicitly requires that history for signed or encrypted reasoning continuity.
 
+**Arm validity is checked automatically (#126).** Every completed pack is inspected for whether the requested reasoning state actually took effect: a thinking arm where *no* response returned reasoning is flagged `silent` (the model may not support thinking, or the server is not parsing it — the arm is not a valid thinking arm), and a no-thinking arm where *any* response returned reasoning is flagged `contaminated` (the server is likely forcing reasoning, e.g. llama.cpp `--reasoning on`, or the off-switch sent is not the one the model's chat template reads — the arm is not a valid baseline). Reasoning counts `reasoning_content`/`reasoning` fields and `<tool_call>` markers left in `content` (thinking happened but was not extracted, so the grader scores it as answer text). Findings appear in the run-summary `Warnings:` list and in saved JSON as `thinking_validity` (per-pack `expected` / `responses` / `with_reasoning` / `status`), so the invalidity travels with the data. Add `--strict-thinking` to turn a finding into exit code 4 for CI. The check runs on the responses already collected — no extra requests — and is skipped for synthetic traffic (mocks / negative control).
+
 ## Output
 
 ```

--- a/benchlocal_cli/cli.py
+++ b/benchlocal_cli/cli.py
@@ -396,6 +396,13 @@ def _parser() -> argparse.ArgumentParser:
              "are active (non-canonical runs shouldn't gate CI).",
     )
     run.add_argument(
+        "--strict-thinking",
+        action="store_true",
+        help="exit code 4 when the thinking-validity check (#126) finds a contaminated "
+             "no-thinking arm or a thinking arm that never produced reasoning. "
+             "CI-friendly; the run summary warns either way.",
+    )
+    run.add_argument(
         "--history-file",
         help="append a summary row to this CSV after the run completes (one row "
              "per run; columns: timestamp, run_id, mode, model, total_pass, total, "
@@ -1410,6 +1417,9 @@ def main(argv: list[str] | None = None) -> int:
             "request_delay": args.request_delay,
             "retry_failed": retry_failed_context,
             "save_json": args.save_json,
+            # #126: synthetic traffic (mocks / negative control) skips the
+            # thinking-validity check; journal-recovered runs must too.
+            "synthetic_traffic": bool(args.mock_responses_from_json or args.negative_control),
         }
 
         journal_writer = None
@@ -1575,6 +1585,11 @@ def main(argv: list[str] | None = None) -> int:
 
         if args.exit_on_regression and result.delta and result.delta.get("total_regressions", 0) > 0:
             return 3  # CI-friendly regression exit code
+        if args.strict_thinking and any(
+            observation.get("status") in ("silent", "contaminated")
+            for observation in (result.thinking_validity or {}).values()
+        ):
+            return 4  # CI-friendly thinking-validity exit code (#126)
         return 0 if result.totals["total"] > 0 else 2
     except Exception as exc:
         print(f"benchlocal-cli: error: {exc}", file=sys.stderr)

--- a/benchlocal_cli/persistence.py
+++ b/benchlocal_cli/persistence.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from benchlocal_cli import __version__
 from benchlocal_cli.diagnostics import pack_diagnostics
+from benchlocal_cli.thinking_validity import thinking_validity_for_packs
 from benchlocal_cli.runner import (
     DEFAULT_INLINE_RETRY_ATTEMPTS,
     PACK_MODES,
@@ -200,6 +201,17 @@ def _unique_warnings(*groups: list[str] | None) -> list[str]:
     return list(dict.fromkeys(item for group in groups for item in (group or [])))
 
 
+def _strip_validity_warnings(warnings: list[str], pack_ids: set[str]) -> list[str]:
+    """#126: validity warnings are regenerated from the merged rows in
+    _build_result, so partial-run copies must be dropped first or a resumed
+    run carries stale counts beside the recomputed ones."""
+    return [
+        warning
+        for warning in warnings
+        if not any(warning.startswith(f"{pack_id}: thinking was") for pack_id in pack_ids)
+    ]
+
+
 def _build_result(
     config: dict,
     scenario_rows: list[tuple[str, dict]],
@@ -248,6 +260,14 @@ def _build_result(
 
     total = sum(pack.total for pack in packs)
     passed = sum(pack.passed for pack in packs)
+    # #126: regenerate the reasoning-validity observations from the assembled
+    # rows (raw_response is persisted), so resumed/journal-recovered runs carry
+    # the same check a live run does. Synthetic traffic is skipped, matching
+    # the live path.
+    if config.get("synthetic_traffic"):
+        thinking_validity, validity_warnings = None, []
+    else:
+        thinking_validity, validity_warnings = thinking_validity_for_packs(packs)
     result = RunResult(
         schema_version=str(config.get("schema_version") or "1"),
         runner_version=str(config.get("runner_version") or __version__),
@@ -262,7 +282,8 @@ def _build_result(
         thinking_mode=str(config.get("thinking_mode") or "pack-defaults"),
         thinking_control=str(config.get("thinking_control") or "enable_thinking"),
         reasoning_effort=config.get("reasoning_effort"),
-        warnings=warnings or [],
+        warnings=_unique_warnings(warnings, validity_warnings),
+        thinking_validity=thinking_validity or None,
         sampling_overrides=config.get("sampling_overrides"),
         sampling_source=config.get("sampling_source"),
         server_defaults=config.get("server_defaults"),
@@ -348,6 +369,7 @@ def _infer_config(data: dict, source: Path) -> dict:
         "server_defaults": data.get("server_defaults"),
         "retry_failures": int((data.get("pass_at_k") or {}).get("k") or 0),
         "retry_runaways": False,
+        "synthetic_traffic": bool(data.get("synthetic_traffic")),
         "save_json": str(final_path_for(source)),
     }
 
@@ -464,13 +486,17 @@ def merge_resume(state: ResumeState, new_result: RunResult) -> RunResult:
         for warning in state.previous_result.get("warnings") or []
         if warning != "partial per-scenario journal; run is incomplete"
     ]
+    validity_pack_ids = {
+        str(pack.get("pack_id") or "")
+        for pack in state.previous_result.get("packs") or []
+    } | {pack.pack_id for pack in new_result.packs}
     return _build_result(
         config,
         rows,
         finished_at=new_result.finished_at,
         warnings=_unique_warnings(
-            previous_warnings,
-            new_result.warnings,
+            _strip_validity_warnings(previous_warnings, validity_pack_ids),
+            _strip_validity_warnings(list(new_result.warnings), validity_pack_ids),
         ),
         pack_templates=templates,
     )

--- a/benchlocal_cli/runner.py
+++ b/benchlocal_cli/runner.py
@@ -19,6 +19,7 @@ import httpx
 
 from benchlocal_cli import __version__
 from benchlocal_cli.diagnostics import pack_diagnostics
+from benchlocal_cli.thinking_validity import thinking_validity_for_packs
 from benchlocal_cli.sandbox import SandboxClient, config_for_pack
 from benchlocal_cli.scoring.common import content_with_source, sanitize_response_text_fields
 from benchlocal_cli.types import PackResult, RunResult, ScenarioResult, ScenarioRun
@@ -806,6 +807,16 @@ class Runner:
                 )
             if self._timeout_scaling_note:
                 warnings.append(self._timeout_scaling_note)
+            # #126: a reasoning arm that never thought, or a no-thinking arm
+            # the server forced reasoning onto, produces plausible-but-invalid
+            # numbers. Detect both from the responses already collected and
+            # fail loudly. Synthetic traffic is skipped: its response shape is
+            # not the model's.
+            thinking_validity: dict | None = None
+            if self.negative_control is None and not self.mock_responses:
+                observations, validity_warnings = thinking_validity_for_packs(pack_results)
+                warnings.extend(validity_warnings)
+                thinking_validity = observations or None
             if self.sampling_from_server:
                 if self._server_defaults:
                     sd_desc = ", ".join(f"{k}={v}" for k, v in self._server_defaults.items())
@@ -837,6 +848,7 @@ class Runner:
                     else None
                 ),
                 warnings=warnings,
+                thinking_validity=thinking_validity,
                 sampling_overrides=dict(self.sampling_overrides) if self.sampling_overrides else None,
                 sampling_source="server" if self.sampling_from_server else None,
                 server_defaults=self._server_defaults if self.sampling_from_server else None,

--- a/benchlocal_cli/thinking_validity.py
+++ b/benchlocal_cli/thinking_validity.py
@@ -1,0 +1,152 @@
+"""Thinking-validity detection (#126).
+
+A reasoning A/B can produce plausible-but-invalid numbers with no warning.
+Two failure modes, both detectable post-hoc from the responses already
+collected (no extra requests):
+
+- thinking was REQUESTED but the model never thought — the chat template has
+  no thinking branch, or the server isn't parsing reasoning. The "thinking"
+  arm is just the no-thinking scores wearing a label.
+- thinking was DISABLED but the server thinks anyway — e.g. llama.cpp was
+  booted with ``--reasoning on`` (which overrides the request), or the
+  off-switch this harness sent is not the one the model's chat template
+  reads. Both arms are the same run; the A/B shows a clean null and reads as
+  a legitimate finding.
+
+The second is the dangerous one: it produces a believable comparison from a
+contaminated baseline and nothing downstream reveals it. Detection therefore
+fails loudly on ANY reasoning observed in a disabled arm, while a requested
+arm only warns when NO response shows reasoning (models may think
+conditionally, so partial presence is legitimate).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+# llama.cpp emits ``reasoning_content`` when ``--reasoning-format`` parsing is
+# on; ``reasoning`` appears on some providers. A ``<think>`` marker left in
+# ``content`` means thinking happened but was NOT extracted
+# (``--reasoning-format none``) — the grader then scores the reasoning text as
+# the answer, so it counts as reasoning present.
+_REASONING_FIELDS = ("reasoning_content", "reasoning")
+_THINK_MARKER = "<think>"
+
+
+def message_has_reasoning(message: Mapping[str, Any]) -> bool:
+    for field in _REASONING_FIELDS:
+        value = message.get(field)
+        if isinstance(value, str) and value.strip():
+            return True
+    content = message.get("content")
+    if isinstance(content, str) and _THINK_MARKER in content:
+        return True
+    return False
+
+
+def _iter_messages(raw_response: Any) -> Iterable[Mapping[str, Any]]:
+    """Yield assistant messages, recursing into multi-turn ``responses`` lists
+    (the same shape ``pack_diagnostics`` walks)."""
+    if not isinstance(raw_response, Mapping):
+        return
+    nested = raw_response.get("responses")
+    if isinstance(nested, list):
+        for item in nested:
+            yield from _iter_messages(item)
+        return
+    choices = raw_response.get("choices")
+    if isinstance(choices, list) and choices and isinstance(choices[0], Mapping):
+        message = choices[0].get("message")
+        if isinstance(message, Mapping):
+            yield message
+
+
+def response_has_reasoning(raw_response: Any) -> bool | None:
+    """True/False when the response carries at least one assistant message;
+    None when there is nothing to judge (timeout / HTTP failure / non-model
+    traffic), which is not evidence either way."""
+    saw_message = False
+    for message in _iter_messages(raw_response):
+        saw_message = True
+        if message_has_reasoning(message):
+            return True
+    return False if saw_message else None
+
+
+def pack_thinking_validity(pack_result: Any) -> dict | None:
+    """Inspect a finished pack's responses against what was requested.
+
+    Returns None when nothing can be judged (no pack scenarios produced a
+    model response). ``expected`` reflects the pack's resolved thinking state
+    (force-on / force-off / pack default), as recorded on the PackResult.
+    """
+    expected_on = bool(getattr(pack_result, "thinking_enabled", False))
+    inspected = 0
+    with_reasoning = 0
+    for run in getattr(pack_result, "scenarios", []) or []:
+        observed = response_has_reasoning(getattr(run, "raw_response", None))
+        if observed is None:
+            continue
+        inspected += 1
+        if observed:
+            with_reasoning += 1
+    if inspected == 0:
+        return None
+    if expected_on and with_reasoning == 0:
+        status = "silent"
+    elif not expected_on and with_reasoning > 0:
+        status = "contaminated"
+    else:
+        status = "ok"
+    return {
+        "expected": "on" if expected_on else "off",
+        "responses": inspected,
+        "with_reasoning": with_reasoning,
+        "status": status,
+    }
+
+
+def thinking_validity_for_packs(
+    packs: Iterable[Any],
+) -> tuple[dict[str, dict], list[str]]:
+    """Run the check over finished packs. Returns (observations, warnings);
+    observations maps pack_id -> the per-pack observation dict (only packs
+    where something could be judged)."""
+    observations: dict[str, dict] = {}
+    warnings: list[str] = []
+    for pack in packs:
+        if getattr(pack, "skipped", False):
+            continue
+        observation = pack_thinking_validity(pack)
+        if observation is None:
+            continue
+        pack_id = str(getattr(pack, "pack_id", "") or "?")
+        observations[pack_id] = observation
+        warning = validity_warning(pack_id, observation)
+        if warning:
+            warnings.append(warning)
+    return observations, warnings
+
+
+def validity_warning(pack_id: str, observation: Mapping[str, Any]) -> str | None:
+    status = observation.get("status")
+    responses = observation.get("responses")
+    with_reasoning = observation.get("with_reasoning")
+    if status == "silent":
+        return (
+            f"{pack_id}: thinking was requested but no reasoning output was returned "
+            f"in any of {responses} responses. The model may not support thinking, or "
+            "the server may not be parsing it (llama.cpp --reasoning-format). "
+            "These results are NOT a valid thinking arm."
+        )
+    if status == "contaminated":
+        return (
+            f"{pack_id}: thinking was disabled but {with_reasoning} of {responses} "
+            "responses returned reasoning content — the server is likely forcing it "
+            "(e.g. llama.cpp --reasoning on), or the off-switch this harness sent is "
+            "not the one this model's chat template reads (check /props for "
+            "enable_thinking vs reasoning_effort). This arm is CONTAMINATED and not "
+            "a valid baseline."
+        )
+    return None

--- a/benchlocal_cli/types.py
+++ b/benchlocal_cli/types.py
@@ -167,6 +167,11 @@ class RunResult:
     thinking_control: str = "enable_thinking"
     reasoning_effort: str | float | None = None
     warnings: list[str] = field(default_factory=list)
+    # #126: per-pack reasoning-validity observations — did a requested
+    # thinking arm actually think, did a disabled arm stay silent. None means
+    # the check didn't run (synthetic traffic); the invalidity travels with the
+    # data instead of living only in a terminal someone scrolled past.
+    thinking_validity: dict | None = None
     # v0.8: populated when `--previous-result PATH` was passed to the run.
     # None means delta wasn't computed (the default; preserves saved-JSON
     # back-compat with v0.7.x readers per Codex review #9).
@@ -219,6 +224,8 @@ class RunResult:
             out["thinking_control"] = self.thinking_control
         if self.reasoning_effort is not None:
             out["reasoning_effort"] = self.reasoning_effort
+        if self.thinking_validity:
+            out["thinking_validity"] = self.thinking_validity
         if self.delta is not None:
             out["delta"] = self.delta
         if self.sampling_overrides is not None:

--- a/tests/test_thinking_validity.py
+++ b/tests/test_thinking_validity.py
@@ -1,0 +1,254 @@
+"""Tests for #126 -- thinking-validity detection."""
+
+from __future__ import annotations
+
+import pytest
+
+from benchlocal_cli.runner import Runner
+from benchlocal_cli.thinking_validity import (
+    message_has_reasoning,
+    pack_thinking_validity,
+    response_has_reasoning,
+    thinking_validity_for_packs,
+    validity_warning,
+)
+from benchlocal_cli.types import PackResult, ScenarioResult, ScenarioRun
+
+THINK_OPEN = "<" + "think" + ">"
+THINK_CLOSE = "</" + "think" + ">"
+
+
+def _message(content="The answer is 4.", reasoning=None):
+    message = {"role": "assistant", "content": content}
+    if reasoning is not None:
+        message["reasoning_content"] = reasoning
+    return message
+
+
+def _response(content="The answer is 4.", reasoning=None):
+    return {"choices": [{"message": _message(content, reasoning), "finish_reason": "stop"}]}
+
+
+def test_message_has_reasoning_detects_parsed_and_embedded_forms():
+    assert message_has_reasoning(_message(reasoning="Let me think."))
+    assert message_has_reasoning({"reasoning": "alt field"})
+    assert message_has_reasoning({"content": f"hmm\n{THINK_OPEN}workings{THINK_CLOSE}answer"})
+    assert not message_has_reasoning(_message())
+    # Blank reasoning_content is not reasoning.
+    assert not message_has_reasoning(_message(reasoning="   "))
+
+
+def test_response_has_reasoning_shapes():
+    assert response_has_reasoning(_response(reasoning="x")) is True
+    assert response_has_reasoning(_response()) is False
+    # No message at all (timeout / HTTP failure) is not evidence either way.
+    assert response_has_reasoning(None) is None
+    assert response_has_reasoning({"choices": []}) is None
+    assert response_has_reasoning({"error": "boom"}) is None
+
+
+def test_response_has_reasoning_walks_multiturn_responses():
+    nested = {
+        "multi_turn": True,
+        "responses": [_response(), _response(reasoning="turn two thinks")],
+    }
+    assert response_has_reasoning(nested) is True
+    nested_silent = {"multi_turn": True, "responses": [_response(), _response()]}
+    assert response_has_reasoning(nested_silent) is False
+
+
+def _run(scenario_id, raw_response):
+    return ScenarioRun(
+        id=scenario_id,
+        result=ScenarioResult(scenario_id, True, "passed", "ok", 1.0),
+        raw_scenario={"id": scenario_id},
+        raw_response=raw_response,
+        request={},
+        sampling_params={},
+        status_code=200,
+    )
+
+
+def _pack(pack_id, thinking_enabled, runs, skipped=False):
+    return PackResult(
+        pack_id=pack_id,
+        version="1.0.0",
+        upstream_commit="abc",
+        scenario_count=len(runs),
+        passed=len(runs),
+        total=len(runs),
+        score=1.0,
+        latency={},
+        scenarios=runs,
+        skipped=skipped,
+        thinking_enabled=thinking_enabled,
+    )
+
+
+def test_pack_validity_statuses():
+    silent = _pack("p-on", True, [_run("a", _response()), _run("b", _response())])
+    assert pack_thinking_validity(silent) == {
+        "expected": "on", "responses": 2, "with_reasoning": 0, "status": "silent",
+    }
+
+    partial = _pack("p-on", True, [_run("a", _response()), _run("b", _response(reasoning="x"))])
+    # Models may think conditionally: partial presence is legitimate.
+    assert pack_thinking_validity(partial)["status"] == "ok"
+
+    clean_off = _pack("p-off", False, [_run("a", _response())])
+    assert pack_thinking_validity(clean_off)["status"] == "ok"
+
+    contaminated = _pack("p-off", False, [_run("a", _response()), _run("b", _response(reasoning="x"))])
+    observation = pack_thinking_validity(contaminated)
+    assert observation["status"] == "contaminated"
+    assert observation["with_reasoning"] == 1
+
+    # Errors carry no message: nothing to judge.
+    errors_only = _pack("p-err", True, [_run("a", None), _run("b", {"choices": []})])
+    assert pack_thinking_validity(errors_only) is None
+
+
+def test_validity_warning_text():
+    silent = {"status": "silent", "responses": 5, "with_reasoning": 0}
+    assert "NOT a valid thinking arm" in validity_warning("p", silent)
+    contaminated = {"status": "contaminated", "responses": 5, "with_reasoning": 2}
+    warning = validity_warning("p", contaminated)
+    assert "CONTAMINATED" in warning
+    assert "2 of 5" in warning
+    assert validity_warning("p", {"status": "ok"}) is None
+
+
+def test_thinking_validity_for_packs_skips_skipped_and_empty():
+    packs = [
+        _pack("skipped", True, [_run("a", _response())], skipped=True),
+        _pack("empty", True, []),
+        _pack("real", False, [_run("a", _response(reasoning="x"))]),
+    ]
+    observations, warnings = thinking_validity_for_packs(packs)
+    assert set(observations) == {"real"}
+    assert len(warnings) == 1
+
+
+def _meta(default_thinking):
+    return {
+        "pack_id": "test-pack",
+        "version": "1.0.0",
+        "upstream_commit": "abc123",
+        "sampling_defaults": {"max_tokens": 32},
+        "default_thinking": default_thinking,
+        "default_max_seconds": 60,
+    }
+
+
+def _scenario():
+    return {
+        "id": "T-01",
+        "pack_id": "test-pack",
+        "messages": [{"role": "user", "content": "test"}],
+        "verifier": {"type": "instruct_follow", "asserts": []},
+    }
+
+
+def _fake_run(monkeypatch, default_thinking, raw_response, **runner_kwargs):
+    monkeypatch.setattr(
+        "benchlocal_cli.runner.load_pack",
+        lambda _pack_id: (_meta(default_thinking), [_scenario()]),
+    )
+    runner = Runner(endpoint="http://localhost:1", model="mock", **runner_kwargs)
+
+    def fake_run_scenario(meta, scenario, *, repeat_index=1):
+        return _run(scenario["id"], raw_response)
+
+    monkeypatch.setattr(runner, "run_scenario", fake_run_scenario)
+    return runner.run(["test-pack"])
+
+
+def test_run_records_contaminated_no_thinking_arm(monkeypatch):
+    result = _fake_run(monkeypatch, "off", _response(reasoning="server forced this"))
+
+    assert result.thinking_validity == {
+        "test-pack": {"expected": "off", "responses": 1, "with_reasoning": 1, "status": "contaminated"},
+    }
+    assert any("CONTAMINATED" in warning for warning in result.warnings)
+
+
+def test_run_records_silent_thinking_arm(monkeypatch):
+    result = _fake_run(monkeypatch, "on", _response())
+
+    assert result.thinking_validity["test-pack"]["status"] == "silent"
+    assert any("NOT a valid thinking arm" in warning for warning in result.warnings)
+
+
+def test_run_ok_arm_has_no_validity_warning(monkeypatch):
+    result = _fake_run(monkeypatch, "on", _response(reasoning="model thought"))
+
+    assert result.thinking_validity["test-pack"]["status"] == "ok"
+    assert result.warnings == []
+
+
+def test_mock_traffic_skips_the_check(monkeypatch):
+    result = _fake_run(
+        monkeypatch,
+        "off",
+        _response(reasoning="mock"),
+        mock_responses={"T-01": _response(reasoning="mock")},
+    )
+
+    assert result.thinking_validity is None
+    assert result.warnings == []
+
+
+def test_result_json_carries_thinking_validity(monkeypatch):
+    result = _fake_run(monkeypatch, "off", _response(reasoning="x"))
+
+    assert result.to_dict()["thinking_validity"]["test-pack"]["status"] == "contaminated"
+
+
+def test_result_json_omits_field_when_check_did_not_run(monkeypatch):
+    result = _fake_run(monkeypatch, "off", _response(), mock_responses={"T-01": _response()})
+
+    assert "thinking_validity" not in result.to_dict()
+
+
+def test_strict_thinking_exit_code(monkeypatch, capsys):
+    """--strict-thinking returns 4 when an arm is contaminated (#126)."""
+    from benchlocal_cli.cli import main
+    from benchlocal_cli.types import RunResult
+
+    contaminated = RunResult(
+        schema_version="1",
+        runner_version="test",
+        endpoint="http://mock",
+        model="mock",
+        mode="custom",
+        started_at="2026-08-12T00:00:00Z",
+        finished_at="2026-08-12T00:00:01Z",
+        packs=[],
+        totals={"passed": 1, "total": 1, "score": 1.0},
+        thinking_validity={"cli-40": {"expected": "off", "responses": 40, "with_reasoning": 25, "status": "contaminated"}},
+    )
+    clean = RunResult(
+        schema_version="1",
+        runner_version="test",
+        endpoint="http://mock",
+        model="mock",
+        mode="custom",
+        started_at="2026-08-12T00:00:00Z",
+        finished_at="2026-08-12T00:00:01Z",
+        packs=[],
+        totals={"passed": 1, "total": 1, "score": 1.0},
+        thinking_validity={"cli-40": {"expected": "off", "responses": 40, "with_reasoning": 0, "status": "ok"}},
+    )
+
+    monkeypatch.setattr(Runner, "run", lambda self, *a, **k: contaminated)
+    args = [
+        "run",
+        "--scenario", "structoutput-15/SO-01",
+        "--endpoint", "http://mock",
+        "--model", "mock",
+    ]
+    assert main(args + ["--strict-thinking"]) == 4
+    assert main(args) == 0  # without the flag the warning alone does not fail the run
+
+    monkeypatch.setattr(Runner, "run", lambda self, *a, **k: clean)
+    assert main(args + ["--strict-thinking"]) == 0


### PR DESCRIPTION
Implements the #126 detector, and with it the run-level guard requested by #129.

**Problem:** a reasoning A/B can produce plausible-but-invalid numbers with no warning — a thinking arm where the model never thought, or a no-thinking arm the server forced reasoning onto (llama.cpp `--reasoning on`, wrong off-switch for the template, `--reasoning-format none` leaking `<think>` into content). Both hit for real on a community rig; the contaminated-baseline case took a `/props` inspection to find after a 2-hour run.

**Detection** (on responses already collected — no extra requests):
| requested | observed | status |
|---|---|---|
| thinking ON | no reasoning in **any** response | `silent` — not a valid thinking arm |
| thinking OFF | reasoning in **any** response | `contaminated` — not a valid baseline |
| ON | partial presence | `ok` (models think conditionally) |

Reasoning presence = `reasoning_content`/`reasoning` populated, or a `<tool_call>` marker in `content` (the #126 worst case: thinking happened but wasn't extracted, so the grader scores it as the answer). Errors/timeouts carry no message and count as no-evidence, not silence.

**Surfaces:** run-summary `Warnings:` · saved JSON `thinking_validity` (per-pack `expected/responses/with_reasoning/status`, additive, schema v1 unchanged) · `--strict-thinking` → exit code 4 for CI. Journal-recovered/resumed runs regenerate the check from persisted `raw_response`s; synthetic traffic (mocks/negative control) is skipped on every path.

**Tests:** 13 new (message/response/pack detection shapes, multi-turn walk, run-level integration incl. mock-skip, JSON round-trip, strict exit code). Full suite 387 passed.

Closes #126.