### PR TITLE
docs: failure-triage policy — model miss is the default label

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,4 +38,5 @@ benchlocal-cli run --full --enable-sandboxed-packs --endpoint http://localhost:8
 - Keep Python runtime dependencies minimal: `httpx` and `jsonschema` only.
 - Treat `vendor/` as the source of truth for pack content.
 - Document lossy callback-to-assert translations in `docs/EXTRACTOR_NOTES.md`.
+- Classify failed scenarios per `docs/FAILURE_TRIAGE.md` before calling anything a pack or runner bug — the default label is a model miss.
 - Sandbox-backed packs keep `_stub` in JSONL as the runner dispatch marker; do not hand-edit generated pack files to point at container internals.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ docs/
 ├── AIDER_POLYGLOT_30.md        # aider-polyglot-30 pack details + cross-rig run guide
 ├── DESIGN.md                   # design rationale (why these choices)
 ├── EXTRACTOR_NOTES.md          # how vendor/ → JSONL extraction works per pack
+├── FAILURE_TRIAGE.md           # classify failures: model miss (default) vs prompt gap vs harness/verifier bug
 ├── HERMES_V073_AB.md           # forensic notes from the Hermes A/B run
 ├── INTEGRATION.md              # how club-3090 (or other repos) consume this CLI
 ├── PACK_FORMAT.md              # JSONL schema each pack file follows

--- a/docs/FAILURE_TRIAGE.md
+++ b/docs/FAILURE_TRIAGE.md
@@ -1,0 +1,61 @@
+# Failure Triage — model, prompt, harness, or verifier?
+
+Every failed scenario gets one label, and the burden of proof sits on
+anyone claiming the pack or the runner is at fault. This policy exists
+because `verifier_fail` was repeatedly mis-labeled as "test case bug" or
+"verifier issue" when the model had simply interpreted the prompt
+differently (#123 / #124 went through three rounds of this before the
+policy landed).
+
+## Default: model miss
+
+If the prompt set the expectation clearly, the verifier is aligned with
+the prompt, and the model's answer still did not match — that is a
+**model miss**, not a test case failure and not grounds for a test
+redesign. Guard the verifier from suspicion arising from model
+interpretation; only escalate with evidence.
+
+## The three escalation classes
+
+| Class | Definition | Evidence bar |
+|---|---|---|
+| **Harness / environment** | Mechanical defect in runner code: response extraction, request shape, scoring plumbing | Reproducible independent of model quality; provable from code or transcript. Examples: the multi-fence extraction drop (#116/#117), the stray trailing-fence truncation (#120), the cli-40 contradictory thinking params (#129) |
+| **Verifier bug** | The prompt clearly compelled the model's answer and the verifier rejected it | Name the exact prompt text that compels the answer, weighed against the scenario's design `description`. Example: RM-04's format rules accept an answer prefix but the accepted list omitted the prefix+unit combination (#125, fixed in #132) |
+| **Prompt gap** | The prompt is silent or self-inconsistent on a dimension the verifier grades | Name the missing statement. The fix is a prompt clarification (pack bump + re-baseline), never a verifier loosening. Examples recorded in #123/#124's closure: DE-10's undeclared field types, SO-07's undeclared `user` wrapper |
+
+Everything else is a model miss — including "the model's reading is also
+reasonable." Reasonable-but-non-matching interpretations are what the
+packs exist to measure.
+
+## Method
+
+1. **Reproduce at temperature 0 with both thinking arms.** Failure in one
+   arm only → model variance, stop. Identical failure in both arms →
+   **flag the scenario for review**; this eliminates flakiness as the
+   explanation, but is **not** proof of a pack bug by itself.
+2. **Read the scenario's `raw_scenario` source and its `description`** —
+   the description documents design intent (e.g. DE-10's "return null for
+   genuinely uncertain fields" lists exactly which fields are uncertain).
+3. **Read the format contract**: system rules, schema, and the extractor
+   contract for format-based packs (`docs/EXTRACTOR_NOTES.md`).
+4. **Ask: does the prompt compel the model's answer?**
+   - Yes, and the verifier rejected it → **verifier bug**. Fix the
+     verifier or its accepted list; the model did what it was told.
+   - The prompt is silent/ambiguous on the graded dimension → **prompt
+     gap**. Optionally fix by clarifying the prompt (version bump +
+     re-baseline); never by loosening the verifier.
+   - No — the prompt supported the verifier's reading → **model miss**.
+5. Harness bugs announce themselves mechanically: the same defect bites
+   every model regardless of answer quality, and you can point at the line
+   of code or the request payload. When found, that is the first thing to
+   rule out — it invalidates the numbers entirely (#126's validity check
+   exists to catch the thinking-mode variants automatically).
+
+## Anti-patterns
+
+- Labeling `verifier_fail` a "verifier issue" because the model's
+  answer seems reasonable. Reasonable ≠ what the prompt asked for.
+- Treating identical-at-temp-0 failure as proof. It is a review flag;
+  the proof is the prompt-text/design-description analysis in step 4.
+- Fixing a model miss by widening the verifier. That turns the pack into
+  a different test and silently re-baselines every historical score.

--- a/docs/VERIFIER_FIDELITY_AUDIT.md
+++ b/docs/VERIFIER_FIDELITY_AUDIT.md
@@ -2,6 +2,8 @@
 
 This audit compares the in-process Python scorers in `benchlocal_cli/scoring/` with the vendored upstream TypeScript verifier sources under `vendor/*/lib/benchmark.ts` plus the StructOutput sandbox verifier in `vendor/StructOutput-15/verification/core.mjs`.
 
+> If you landed here because a run failed and you suspect the verifier, read [FAILURE_TRIAGE.md](./FAILURE_TRIAGE.md) first — most `verifier_fail`s are model misses, and that doc carries the burden-of-proof policy for escalation.
+
 ## Scope
 
 In scope: `tool_call.py`, `reason_math.py`, `instruct_follow.py`, `struct_output.py`, and `data_extract.py`.


### PR DESCRIPTION
Codifies the triage policy that #123/#124 needed: the default label for a failed scenario is a **model miss**, and escalation to harness/verifier/prompt-gap classes carries an explicit evidence bar.

Background: #123/#124 went through three rounds of re-adjudication because `verifier_fail` kept getting labeled "test case bug" when the model had simply interpreted the prompt differently. The policy fixes the burden of proof:

- **harness bug** — mechanical, model-independent, provable from code/transcript (#116/#117/#120/#129 precedents)
- **verifier bug** — must name the prompt text that compelled the model's answer, weighed against the scenario's design `description` (RM-04/#125 precedent)
- **prompt gap** — fixed by clarifying the prompt + bump + re-baseline, never by loosening the verifier
- identical-at-temp-0 failure in both arms is a **flag for review**, not proof

Docs-only: new `docs/FAILURE_TRIAGE.md` + links from CONTRIBUTING.md, README tree, and a pointer atop VERIFIER_FIDELITY_AUDIT.md. Suite green (387).