### PR TITLE
fix(dataextract): score content on a shape mismatch instead of reporting 0%

### DIFF
--- a/benchlocal_cli/scoring/data_extract.py
+++ b/benchlocal_cli/scoring/data_extract.py
@@ -9,6 +9,13 @@ from typing import Any
 from benchlocal_cli.scoring.common import content, get_path, parse_json_text, result
 from benchlocal_cli.types import ScenarioResult
 
+# A top-level shape mismatch is BINDING (see `_score_expected`): an object requested
+# but an array returned breaks every downstream consumer doing `result["field"]`.
+# The other compliance notes (extra / missing top-level fields) stay informational —
+# missing fields are already penalised by the field walker, and extra fields do not
+# break consumption.
+_SHAPE_MISMATCH_PREFIX = "top-level shape mismatch"
+
 _ARRAY_OBJECT_ANCHORS = {
     "DE-02.items": "name",
     "DE-07.$root": "name",
@@ -175,7 +182,7 @@ def _compliance_notes(expected: Any, actual: Any) -> list[str]:
     expected_shape = _top_level_shape(expected)
     actual_shape = _top_level_shape(actual)
     if expected_shape != actual_shape:
-        notes.append(f"top-level shape mismatch: expected {expected_shape}, received {actual_shape}")
+        notes.append(f"{_SHAPE_MISMATCH_PREFIX}: expected {expected_shape}, received {actual_shape}")
 
     if isinstance(expected, dict) and isinstance(actual, dict):
         expected_keys = set(expected)
@@ -189,18 +196,52 @@ def _compliance_notes(expected: Any, actual: Any) -> list[str]:
     return notes
 
 
+def _realign_for_scoring(expected: Any, actual: Any) -> tuple[Any, bool]:
+    """Align a singleton container with the expected top-level shape, for SCORING only.
+
+    A model that answers `[{...}]` where an object was requested has made a real
+    compliance error, and `_score_expected` still fails it for that. But the field
+    walker bails before reading the payload (`_compare_object` returns
+    `0, len(expected)` the moment `actual` is not a dict), so the reported score was
+    `0/N atomic fields correct (0%)` even when every extracted value was byte-perfect.
+    That number is a false statement about the extraction, and it hides genuine
+    content regressions behind the shape error — a run can look like a total
+    extraction failure when the model is wrapping an otherwise-correct answer.
+
+    Realigning here lets the score describe the CONTENT. The shape verdict is carried
+    separately by `_compliance_notes` and is binding, so no scenario's pass/fail
+    changes — only its reported percentage becomes honest.
+
+    Only exact singletons are realigned. Two objects where one was requested is
+    over-extraction (a genuine content miss, e.g. dataextract-15 DE-04 returning both
+    meetings from a thread) and is deliberately left to score as-is. Nested shape
+    mismatches are also left alone: this runs once, at the top level.
+    """
+    if isinstance(expected, dict) and isinstance(actual, list):
+        if len(actual) == 1 and isinstance(actual[0], dict):
+            return actual[0], True
+    if isinstance(expected, list) and isinstance(actual, dict):
+        if len(expected) == 1:
+            return [actual], True
+    return actual, False
+
+
 def _score_expected(scenario: dict, data: Any, expected: Any) -> ScenarioResult:
-    correct, total, notes = _compare_value(expected, data, str(scenario.get("id", "unknown")), "")
-    score = round((correct / total) * 100) if total else 0
+    # Compliance is judged on what the model ACTUALLY returned, never the realigned form.
     compliance = _compliance_notes(expected, data)
-    passed = score >= 85
+    scored, realigned = _realign_for_scoring(expected, data)
+    correct, total, notes = _compare_value(expected, scored, str(scenario.get("id", "unknown")), "")
+    score = round((correct / total) * 100) if total else 0
+    shape_ok = not any(note.startswith(_SHAPE_MISMATCH_PREFIX) for note in compliance)
+    passed = score >= 85 and shape_ok
     trace = {
         "upstream_style_score": score,
         "correct_fields": correct,
         "total_fields": total,
-        "status_threshold": "pass >= 85",
+        "status_threshold": "pass >= 85 and top-level shape matches",
         "compliance_notes": compliance,
         "comparison_notes": notes,
+        "scored_after_shape_realign": realigned,
     }
     note_text = " | ".join([*compliance, *notes])
     return ScenarioResult(

--- a/tests/test_scoring_smoke.py
+++ b/tests/test_scoring_smoke.py
@@ -183,6 +183,63 @@ def test_data_extract_pass_and_fail():
     assert data_extract.score_scenario(scenario, _response('{"email":"b@example.com"}')).failure_mode == "verifier_fail"
 
 
+# --- top-level shape: the verdict is binding, the SCORE must describe the content ---
+#
+# Regression guard for the reporting defect found 2026-08-14 while triaging a
+# Qwen3.8-27B run: 8 of 15 dataextract scenarios reported "0/N atomic fields correct
+# (0%)" on extractions that were byte-perfect apart from being wrapped in a 1-element
+# array. The verdict (fail) was right; the 0% was a false statement about the content,
+# and it masked three genuine content regressions in the same run.
+
+_OBJ_SCENARIO = {"id": "DE-X", "expected": {"name": "Ada", "city": "London"}}
+
+
+def test_shape_mismatch_still_fails_but_scores_the_content():
+    res = data_extract.score_scenario(_OBJ_SCENARIO, _response('[{"name":"Ada","city":"London"}]'))
+    assert not res.passed, "an array where an object was requested is a real compliance miss"
+    assert res.verifier_trace["upstream_style_score"] == 100, "the extraction was perfect — say so"
+    assert res.verifier_trace["correct_fields"] == 2
+    assert res.verifier_trace["scored_after_shape_realign"] is True
+    assert any(n.startswith("top-level shape mismatch") for n in res.verifier_trace["compliance_notes"])
+
+
+def test_shape_mismatch_does_not_mask_content_errors():
+    res = data_extract.score_scenario(_OBJ_SCENARIO, _response('[{"name":"Ada","city":"Paris"}]'))
+    assert not res.passed
+    assert res.verifier_trace["upstream_style_score"] == 50, "wrapped AND wrong must read as 50%, not 0%"
+
+
+def test_over_extraction_is_not_treated_as_a_wrapper():
+    """Two objects where one was requested is a content miss, not a formatting one."""
+    res = data_extract.score_scenario({"id": "DE-X", "expected": {"name": "Ada"}},
+                                      _response('[{"name":"Ada"},{"name":"Grace"}]'))
+    assert not res.passed
+    assert res.verifier_trace["upstream_style_score"] == 0
+    assert res.verifier_trace["scored_after_shape_realign"] is False
+
+
+def test_correct_shape_and_content_still_passes():
+    res = data_extract.score_scenario(_OBJ_SCENARIO, _response('{"name":"Ada","city":"London"}'))
+    assert res.passed
+    assert res.verifier_trace["upstream_style_score"] == 100
+    assert res.verifier_trace["scored_after_shape_realign"] is False
+
+
+def test_shape_realign_is_symmetric_for_a_bare_object():
+    """The mirror case: an array of one was requested, a bare object came back."""
+    scenario = {"id": "DE-07", "expected": [{"name": "Ada", "city": "London"}]}
+    res = data_extract.score_scenario(scenario, _response('{"name":"Ada","city":"London"}'))
+    assert not res.passed
+    assert res.verifier_trace["upstream_style_score"] == 100
+
+
+def test_shape_compliance_is_binding_not_merely_incidental():
+    """Guard the trap in the naive fix: realigning WITHOUT making shape binding would
+    silently start passing non-compliant answers, since `passed` keyed on score alone."""
+    res = data_extract.score_scenario(_OBJ_SCENARIO, _response('[{"name":"Ada","city":"London"}]'))
+    assert res.verifier_trace["upstream_style_score"] >= 85 and not res.passed
+
+
 
 def _pack_record(pack: str, scenario_id: str) -> dict:
     path = Path(__file__).resolve().parents[1] / "benchlocal_cli" / "packs" / pack


### PR DESCRIPTION
## The defect

`_compare_object` bails the moment `actual` is not a dict:

```python
def _compare_object(expected, actual, ...):
    if not isinstance(actual, dict):
        return 0, len(expected), ["expected object"]   # never reads the payload
```

So a response that wrapped an otherwise **byte-perfect** object in a 1-element array was reported as `0/N atomic fields correct (0%)`. The verdict (fail) was right. The number was a false statement about the extraction.

Separately, `passed` keyed on the score alone and never consulted `compliance_notes` — the `top-level shape mismatch` string was informational, and the case only failed *because* the walker had already forced the score to 0.

## Why it matters

Found while triaging a Qwen3.8-27B run that scored `4/15` on dataextract-15. Eight scenarios read `0%`. They were not the same failure:

| Scenario | reported | actual content accuracy |
|---|--:|--:|
| DE-01, DE-02 | 0% | **100%** — wrap only |
| DE-13 | 0% | 97% — wrap only |
| DE-06 | 0% | 93% — wrap only |
| DE-03 | 0% | 92% — wrap only |
| DE-05 | 0% | 79% — wrap **+ real content miss** |
| DE-14 | 0% | 71% — wrap **+ real content miss** |
| DE-12 | 0% | 64% — wrap **+ real content miss** |
| DE-04 | 0% | 0% — genuine over-extraction |

Three real content regressions were flattened into the same bucket as five cosmetic ones. The pack read as "this model cannot extract data" when the actual defect was a top-level shape habit — a materially different engineering signal, and the wrong one to act on.

## The fix

Two halves, both required:

1. **`_realign_for_scoring()`** — align an exact singleton container to the expected top-level shape, **for scoring only**. Compliance is still computed on what the model actually returned.
2. **Make the shape mismatch binding** — `passed = score >= 85 and shape_ok`.

Without (2), (1) would have started silently **passing** non-compliant answers, since `passed` never looked at compliance. Without (1), (2) is a no-op. Shipping either alone is a regression.

Only exact singletons are realigned. Two objects where one was requested (DE-04) is over-extraction — a content miss, not a formatting one — and is deliberately left to score as-is. Nested shape mismatches are untouched; this runs once, at the top level.

The other compliance notes stay informational: missing top-level fields are already penalised by the field walker, and extra fields don't break consumption.

## This is not a verdict dispute

Under the #136 triage policy, the array wrap is a **model miss** — the pack's system rules say "Output ONLY the JSON object or JSON array", which *permits* an array but does not *compel* one, and the scalar field list resolves it. The case should fail, and after this change it still does.

What #136 governs is adjudication. This PR is about **score fidelity**, a separate axis it doesn't cover.

## Verdict-preserving by construction

A top-level shape mismatch already forced score 0 down every branch (`_compare_object`, `_compare_object_array`, `_compare_scalar_array`), so it always failed. Making it explicitly binding cannot flip any historical verdict — it just states the gate that was already operating implicitly.

Verified by re-scoring two saved runs with the new scorer:

| Run | old | new | verdict flips | percentages corrected |
|---|--:|--:|--:|--:|
| Qwen3.8-27B | 4/15 | 4/15 | **0** | 8 |
| Qwen3.6-27B | 13/15 | 13/15 | **0** | 0 |

The second run is the control: it produced no shape mismatches, so nothing was eligible for correction — exactly as predicted.

## ⚠️ Effect on saved results

Historical **pass/fail counts and pack scores are unchanged**, so cross-run and cross-model comparisons stay valid.

But re-scoring a saved run will show **different per-scenario percentages** wherever a `top-level shape mismatch` compliance note is present. Anyone diffing stored JSON should expect that. Practical rule: a per-case `%` accompanied by a shape-mismatch note was meaningless before this change.

New trace field `scored_after_shape_realign` (bool) records whether a realign happened, so the two cases stay distinguishable in saved output. `status_threshold` now reads `pass >= 85 and top-level shape matches`.

## Tests

6 new regression tests in `tests/test_scoring_smoke.py`: perfect-but-wrapped, wrapped-and-wrong (must not read 0%), over-extraction (must **not** realign), correct shape passes, the mirror direction (bare object where a 1-element array was expected), and an explicit guard that score ≥ 85 with a bad shape still fails.

Full suite: **401 passed**.
