### PR TITLE
fix(release): reconcile version with v0.9.9 and guard the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,30 @@ jobs:
           fetch-depth: 0  # full history for git-cliff
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # ---- (0) Refuse a tag that disagrees with the declared version --------
+      # v0.9.9 was tagged straight onto a merge commit with pyproject still at
+      # 0.9.8, so the release shipped self-reporting 0.9.8. __version__ is
+      # stamped into every results file as `runner_version`, which made those
+      # runs indistinguishable from real v0.9.8 runs -- across a release that
+      # changed the timeout clock and hermes pinning (#105). Fail loudly here
+      # rather than publish a mislabelled artifact.
+      - name: Verify tag matches pyproject version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          proj="$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' pyproject.toml | head -1)"
+          if [ -z "$proj" ]; then
+            echo "::error::could not read version from pyproject.toml"
+            exit 1
+          fi
+          if [ "$tag" != "$proj" ]; then
+            echo "::error::tag v${tag} does not match pyproject.toml version ${proj}"
+            echo "Bump pyproject.toml and commit it BEFORE tagging."
+            echo "benchlocal_cli.__version__ derives from pyproject, so those two"
+            echo "cannot drift -- but the tag can, and that is what this checks."
+            exit 1
+          fi
+          echo "tag v${tag} matches pyproject.toml version ${proj}"
+
       # ---- (1) Generate the GitHub Release body (latest only, no header) ----
       - name: Generate release notes (latest only)
         id: cliff-release

--- a/benchlocal_cli/__init__.py
+++ b/benchlocal_cli/__init__.py
@@ -8,4 +8,38 @@ Pack data lives in `benchlocal_cli/packs/<pack-id>.jsonl`.
 Verifier modules live in `benchlocal_cli/scoring/`.
 """
 
-__version__ = "0.9.8"
+from importlib.metadata import PackageNotFoundError, version as _installed_version
+from pathlib import Path as _Path
+import re as _re
+
+
+def _version() -> str:
+    """Resolve the version. pyproject.toml is the single source of truth.
+
+    This used to be a hardcoded literal and it silently went stale: v0.9.9 was
+    tagged straight onto a merge commit with no bump, so the release shipped
+    reporting 0.9.8. Because __version__ is stamped into every results file as
+    `runner_version`, that made v0.9.9 runs indistinguishable from v0.9.8 runs --
+    across a release that changed the timeout clock and hermes pinning (#105),
+    i.e. across a scoring-relevant boundary.
+
+    ⚠️ Order matters: an ADJACENT pyproject.toml wins over installed metadata.
+    Reading metadata first looks cleaner and is wrong here -- a stale
+    `benchlocal_cli.egg-info/` left in a checkout by an older build makes
+    importlib.metadata report THAT version while you run today's source. On this
+    repo a 0.9.4 egg-info did exactly that. When there is no adjacent pyproject
+    (i.e. a real site-packages install) metadata is the right answer.
+    """
+    pyproject = _Path(__file__).resolve().parent.parent / "pyproject.toml"
+    if pyproject.is_file():
+        m = _re.search(r'^version\s*=\s*"([^"]+)"',
+                       pyproject.read_text(encoding="utf-8"), _re.M)
+        if m:
+            return m.group(1)
+    try:
+        return _installed_version("benchlocal-cli")
+    except PackageNotFoundError:
+        return "0+unknown"
+
+
+__version__ = _version()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "benchlocal-cli"
-version = "0.9.8"
+version = "0.9.9"
 description = "CLI port of BenchLocal quality bench packs — runs LLM behavioral evaluations against any OpenAI-compatible endpoint"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## The mismatch

`pyproject.toml` said **0.9.8** while **v0.9.9** is the published release.

`v0.9.7` was tagged on a proper `chore(release): v0.9.7` commit. **`v0.9.9` was tagged straight onto a merge commit** (#109) with no bump — and `git log -S'0.9.9' -- pyproject.toml` returns nothing, so the version has *never* been 0.9.9 in the tree. `release.yml` fires on tags but verifies nothing; it only regenerates the CHANGELOG.

## Why it isn't cosmetic

`__version__` is stamped into every results file as `runner_version` (`cli.py:1376`, `persistence.py:273`, `persistence.py:354`). So **every run produced by v0.9.9 is labelled `0.9.8`** and is indistinguishable from a real v0.9.8 run.

That would be harmless if nothing changed between them. Six commits did:

- `Pin hermes-agent by default; decouple timeout clock from token budget` (#105)
- `fix(cloud): span minute-window 429 throttles` (#106)
- `feat(run): add failure retry diagnostics` (#107)
- `runner.py` +114, `cli.py` +133, `sandbox.py` +30

The timeout-clock change is scoring-relevant. A stored result stamped `0.9.8` may have been produced under either timeout regime, and nothing in the file distinguishes them.

## Changes

**1. `pyproject.toml` → 0.9.9**, restoring the repo's own convention: the tree carries the released version, as it did at v0.9.7.

**2. `__version__` derives from pyproject** instead of duplicating it, so the two can't drift again.

⚠️ **The resolution order is deliberate: an adjacent `pyproject.toml` wins over installed metadata.** Reading `importlib.metadata` first looks cleaner and is wrong here — a stale `benchlocal_cli.egg-info/` left by an older build makes it report *that* version while you run today's source. A `0.9.4` egg-info in my checkout did exactly that while writing this fix, resolving `__version__` to `0.9.4` against a 0.9.9 tree. That is the same class of silent staleness the hardcoded literal had, reached by a different route. When there's no adjacent pyproject (a real site-packages install) metadata is the right answer and is used.

**3. `release.yml` refuses a mismatched tag** before publishing anything.

## Verification

- Guard tested both ways locally: `v0.9.9` accepted; `v0.9.8` / `v0.9.10` / `v1.0.0` refused.
- **Replayed against the real incident** — pyproject at 0.9.8 with tag `v0.9.9` → refused. It would have blocked the release that caused this.
- `__version__` resolves to `0.9.9` from a source checkout and falls through to metadata when no pyproject is adjacent.
- **405 tests pass.** (`tests/test_retry_failed.py` mentions `"0.9.8"`, but as baseline fixture data — it makes no assertion about the package version.)

## Not addressed

Results already on disk stay ambiguous — nothing can retroactively tell a v0.9.8 run from a v0.9.9 one. Anything from **0.9.9 onward** is trustworthy; treat pre-existing `0.9.8`-stamped results as "0.9.8 or 0.9.9" if you're attributing a behavioural delta across that boundary.
