### PR TITLE
Enforce network_isolated instead of only declaring it

### DIFF
--- a/benchlocal_cli/sandbox.py
+++ b/benchlocal_cli/sandbox.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -21,7 +22,13 @@ class SandboxConfig:
     pack_id: str           # e.g. "bugfind-15"
     image_name: str        # e.g. "benchlocal-sandbox-bugfind:latest"
     host_port: int         # e.g. 9001
-    network_isolated: bool # True for cli (untrusted exec); False for bugfind + hermes
+    # #108: ENFORCED, not decorative. True → `docker run --network none` (no
+    # interfaces but loopback: no egress, no DNS) and NO published port, since
+    # Docker silently discards `-p` on a container with no network. Isolated
+    # packs are driven over container loopback via `docker exec` instead — see
+    # `SandboxClient._exec_http`. False → published-port HTTP, and the pack may
+    # legitimately call out (aider/hermes reach the host model endpoint).
+    network_isolated: bool # True for cli + code-reasoning (untrusted exec)
     multi_turn: bool       # True for cli + hermes; False for bugfind
     # Optional host directories bind-mounted into the container.
     # Tuple of (host_path, container_path) entries — bound read-only.
@@ -120,6 +127,47 @@ SANDBOX_REGISTRY = {
         run_mount_env=(("BENCHLOCAL_AIDER_KEEP_JOBDIRS", "1"),),
     ),
 }
+
+
+# #108: the only packs that legitimately call out of the container. Both reach
+# the runner's host-side model endpoint, so neither can be network-isolated —
+# `_build_docker_run_argv` raises if a pack is ever listed here AND declares
+# network_isolated=True.
+_HOST_GATEWAY_PACKS = ("aider-polyglot-30", "hermesagent-20")
+
+# #108: in-container HTTP client used to drive network-isolated sandboxes.
+# They run with `--network none`, so there is no published port to talk to —
+# but the pack's server is still listening on the container's own loopback.
+# Deliberately stdlib-only: every sandbox image is Python-based, and the point
+# of an isolated container is that it cannot fetch anything extra.
+# Reads the request body from stdin (avoids argv size limits on big scenarios)
+# and writes a {"status", "body"} JSON envelope to stdout.
+_EXEC_HTTP_CLIENT = r"""
+import json, sys, urllib.error, urllib.request
+
+path = sys.argv[1]
+timeout = float(sys.argv[2])
+body = sys.stdin.buffer.read()
+url = "http://127.0.0.1:9000" + path
+if body:
+    req = urllib.request.Request(
+        url, data=body, headers={"Content-Type": "application/json"}, method="POST"
+    )
+else:
+    req = urllib.request.Request(url, method="GET")
+try:
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        out = {"status": resp.status, "body": resp.read().decode("utf-8", "replace")}
+except urllib.error.HTTPError as exc:
+    out = {"status": exc.code, "body": exc.read().decode("utf-8", "replace")}
+except Exception as exc:
+    out = {"status": 0, "body": "", "error": "%s: %s" % (type(exc).__name__, exc)}
+sys.stdout.write(json.dumps(out))
+"""
+
+# Headroom for `docker exec` process spawn on top of the in-container HTTP
+# timeout, so the outer subprocess kill never fires before the inner one.
+_EXEC_TRANSPORT_OVERHEAD_S = 30.0
 
 
 _LOOPBACK_ENDPOINT_RE = re.compile(
@@ -332,7 +380,15 @@ class SandboxClient:
     def _build_docker_run_argv(self, name: str, run_dir: str | None) -> list[str]:
         """Assemble the `docker run` argv. Pure (no side effects beyond reading
         config/env) so it can be unit-tested. `run_dir` is the host path to
-        bind-mount writable at `config.run_output_dir` (#6); None disables it."""
+        bind-mount writable at `config.run_output_dir` (#6); None disables it.
+
+        #108: `network_isolated` is honoured here. Isolated packs get
+        `--network none` and NO `-p` — Docker silently drops port bindings on a
+        container with no network (verified: NetworkSettings.Ports comes back
+        empty), so publishing one would be a lie in the argv. The runner talks
+        to those packs through `docker exec` over container loopback instead,
+        which needs no network of any kind. See `_exec_http`.
+        """
         cmd = [
             "docker",
             "run",
@@ -340,9 +396,36 @@ class SandboxClient:
             "-d",
             "--name",
             name,
-            "-p",
-            f"{self.config.host_port}:9000",
         ]
+        # v0.9.0: agentic sandboxes may need to call back to the runner's
+        # host-side model endpoint. On Linux, host.docker.internal only
+        # resolves with this --add-host flag. Both callers-out need it exactly
+        # when the endpoint is loopback — that is precisely the case
+        # resolve_endpoint_for_container() rewrites to host.docker.internal.
+        # #108: aider took this flag unconditionally, which was vestigial for
+        # the common non-loopback case (tailnet/LAN model endpoint); it is now
+        # gated on the same condition Hermes already used. The env var stays as
+        # the escape hatch for non-loopback hosts where service-name
+        # deployments are ambiguous, scoped to the packs that actually call out.
+        needs_host_gateway = self.config.pack_id in _HOST_GATEWAY_PACKS and (
+            endpoint_is_loopback(self.model_endpoint)
+            or os.environ.get("BENCHLOCAL_HERMES_RESOLVE_LOCALHOST") == "1"
+        )
+        if self.config.network_isolated:
+            # Containment and host-gateway routing are mutually exclusive by
+            # construction: a container that can resolve and reach the host is
+            # not isolated. Refuse rather than silently dropping one of them.
+            if needs_host_gateway:
+                raise ValueError(
+                    f"pack {self.config.pack_id} declares network_isolated=True but also "
+                    f"needs host.docker.internal routing to reach model endpoint "
+                    f"{self.model_endpoint!r}. These are mutually exclusive — a sandbox "
+                    f"that can reach the host's model endpoint is not isolated. Set "
+                    f"network_isolated=False for this pack (and say why in the registry)."
+                )
+            cmd.extend(["--network", "none"])
+        else:
+            cmd.extend(["-p", f"{self.config.host_port}:9000"])
         # Optional bind-mounts (Hermes maps hermes-agent install + uv python tree).
         for host_path, container_path in self.config.host_mounts:
             cmd.extend(["-v", f"{host_path}:{container_path}:ro"])
@@ -356,19 +439,66 @@ class SandboxClient:
             cmd.extend(["-v", f"{run_dir}:{self.config.run_output_dir}"])
             for key, value in self.config.run_mount_env:
                 cmd.extend(["-e", f"{key}={value}"])
-        # v0.9.0: agentic sandboxes may need to call back to the runner's
-        # host-side model endpoint. On Linux, host.docker.internal only
-        # resolves with this --add-host flag. Aider always uses the rewrite;
-        # Hermes auto-enables it for loopback endpoints and keeps the env gate
-        # for non-loopback hosts where service-name deployments are ambiguous.
-        if (
-            self.config.pack_id == "aider-polyglot-30"
-            or (self.config.pack_id == "hermesagent-20" and endpoint_is_loopback(self.model_endpoint))
-            or os.environ.get("BENCHLOCAL_HERMES_RESOLVE_LOCALHOST") == "1"
-        ):
+        if needs_host_gateway:
             cmd.extend(["--add-host", "host.docker.internal:host-gateway"])
         cmd.append(self.config.image_name)
         return cmd
+
+    def _exec_http(
+        self, path: str, payload: dict | None, *, timeout_s: float
+    ) -> tuple[int, str]:
+        """Drive a `--network none` sandbox over `docker exec` + container loopback.
+
+        #108: isolated packs have no published port, but their HTTP server is
+        still listening on the container's own 127.0.0.1:9000. `docker exec`
+        enters the container's network namespace, so this reaches the verifier
+        without granting the container a single byte of egress.
+
+        Returns (status_code, body_text). Raises RuntimeError on transport
+        failure (container gone, exec refused, malformed envelope).
+        """
+        if not self._container_id:
+            raise RuntimeError(
+                f"sandbox {self.config.pack_id} is not running (no container id)"
+            )
+        stdin = b"" if payload is None else json.dumps(payload).encode("utf-8")
+        argv = [
+            "docker", "exec", "-i", self._container_id,
+            "python3", "-c", _EXEC_HTTP_CLIENT, path, str(timeout_s),
+        ]
+        try:
+            proc = subprocess.run(
+                argv,
+                input=stdin,
+                capture_output=True,
+                timeout=timeout_s + _EXEC_TRANSPORT_OVERHEAD_S,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"sandbox {self.config.pack_id} exec transport timed out on {path}"
+            ) from exc
+        except OSError as exc:  # includes FileNotFoundError (docker not installed)
+            raise RuntimeError(
+                f"sandbox {self.config.pack_id} exec transport failed on {path}: {exc}"
+            ) from exc
+        if proc.returncode != 0:
+            stderr = proc.stderr.decode("utf-8", "replace").strip()
+            raise RuntimeError(
+                f"sandbox {self.config.pack_id} exec transport failed on {path} "
+                f"(exit {proc.returncode}): {stderr}"
+            )
+        try:
+            envelope = json.loads(proc.stdout.decode("utf-8", "replace"))
+        except ValueError as exc:
+            raise RuntimeError(
+                f"sandbox {self.config.pack_id} exec transport returned non-JSON on {path}"
+            ) from exc
+        if envelope.get("error"):
+            raise RuntimeError(
+                f"sandbox {self.config.pack_id} exec transport error on {path}: "
+                f"{envelope['error']}"
+            )
+        return int(envelope.get("status", 0)), str(envelope.get("body", ""))
 
     def start(self, *, ready_timeout_s: float = 30.0, run_dir: str | None = None) -> None:
         """Start the container; block until /health returns 200 or ready_timeout_s expires.
@@ -391,11 +521,17 @@ class SandboxClient:
         last_error = ""
         while time.monotonic() < deadline:
             try:
-                response = httpx.get(f"http://127.0.0.1:{self.config.host_port}/health", timeout=1.0)
-                if response.status_code == 200:
+                if self.config.network_isolated:
+                    # #108: no published port on an isolated container.
+                    status, _ = self._exec_http("/health", None, timeout_s=1.0)
+                else:
+                    status = httpx.get(
+                        f"http://127.0.0.1:{self.config.host_port}/health", timeout=1.0
+                    ).status_code
+                if status == 200:
                     return
-                last_error = f"HTTP {response.status_code}"
-            except httpx.HTTPError as exc:
+                last_error = f"HTTP {status}"
+            except (httpx.HTTPError, RuntimeError, OSError) as exc:
                 last_error = str(exc)
             time.sleep(0.25)
         self.stop()
@@ -518,13 +654,28 @@ class SandboxClient:
         # Callers can override per-call (e.g., /verify-turn might be shorter
         # than /verify-start for the same pack).
         timeout = timeout_s if timeout_s is not None else self.config.request_timeout_s
-        response = httpx.post(
-            f"http://127.0.0.1:{self.config.host_port}{path}",
-            json=payload,
-            timeout=timeout,
-        )
-        response.raise_for_status()
-        data = response.json()
+        if self.config.network_isolated:
+            # #108: isolated packs have no published port — go through the
+            # container's own loopback via `docker exec`.
+            status, body = self._exec_http(path, payload, timeout_s=timeout)
+            if status != 200:
+                raise RuntimeError(
+                    f"sandbox {self.config.pack_id} returned HTTP {status} for {path}"
+                )
+            try:
+                data = json.loads(body)
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"sandbox {self.config.pack_id} returned non-JSON for {path}"
+                ) from exc
+        else:
+            response = httpx.post(
+                f"http://127.0.0.1:{self.config.host_port}{path}",
+                json=payload,
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
         if not isinstance(data, dict):
             raise RuntimeError(f"sandbox {self.config.pack_id} returned non-object JSON")
         return data

--- a/docs/AIDER_POLYGLOT_30.md
+++ b/docs/AIDER_POLYGLOT_30.md
@@ -145,6 +145,21 @@ toolchains). On rigs with <30 GB free, run
   + simplest grading). Models that are stronger on `diff` or `udiff`
   formats will under-perform here. Override via
   `raw_scenario.default_edit_format` if needed.
-- **Tests run in-image**: a model-emitted edit could in principle
-  exfiltrate via the unit tests, but the image is `--rm` and exercises
-  are network-isolated by default.
+- **Tests run in-image, and this pack's network is NOT isolated**: a
+  model-emitted edit could in principle exfiltrate via the unit tests. The
+  image is `--rm`, but that is the only containment *for this pack* — do not
+  read it as network containment. `sandbox.py` sets
+  `network_isolated=False,  # aider needs to call out to model_endpoint`, and
+  that is a real requirement rather than an oversight: the exercise loop drives
+  `aider` against the runner's model endpoint from inside the container, so the
+  container must be able to reach it. The runner now honours `network_isolated`
+  — packs declaring `True` (`cli-40`, `humaneval-plus-30`, `lcb-v6-30`) run
+  under `--network none` — but aider is deliberately not one of them, and the
+  two are mutually exclusive by construction: `sandbox.py` raises if a pack
+  declares isolation while also needing
+  `--add-host host.docker.internal:host-gateway`. That flag is still added for
+  this pack, now only when the model endpoint is a loopback address (the case
+  `resolve_endpoint_for_container()` rewrites); for a LAN endpoint it was
+  vestigial and is no longer emitted. Treat exercise code here as running with
+  full outbound network access, and do not point this pack at untrusted
+  exercises or an untrusted model.

--- a/docs/SANDBOX_PROTOCOL.md
+++ b/docs/SANDBOX_PROTOCOL.md
@@ -191,7 +191,22 @@ The v0.7.1 CLI sandbox keeps the HTTP verifier on the normal mapped port so the 
 - timeout is capped at 10s
 - stdout/stderr are truncated to 64 KiB
 
-Python, Perl, and Ruby are allowed; upstream CLI is a shell-task environment with scripting languages available, not a shell-builtins-only benchmark. The local `SandboxClient` uses HTTP over a host-mapped port (Unix-domain sockets plus Docker `--network none` would be tighter; documented parity gap rather than a silent claim of full isolation).
+Python, Perl, and Ruby are allowed; upstream CLI is a shell-task environment with scripting languages available, not a shell-builtins-only benchmark.
+
+### Transport and isolation (#108)
+
+`SandboxConfig.network_isolated` is enforced, not advisory. It selects the transport:
+
+| `network_isolated` | Packs | `docker run` | Transport |
+| --- | --- | --- | --- |
+| `True` | `cli-40`, `humaneval-plus-30`, `lcb-v6-30` | `--network none`, no `-p` | `docker exec` → container loopback `127.0.0.1:9000` |
+| `False` | `bugfind-15`, `hermesagent-20`, `aider-polyglot-30` | `-p <host_port>:9000` | `httpx` → `127.0.0.1:<host_port>` |
+
+Isolated containers have no interface but `lo`: no route, no DNS, no egress. Verified by probing from inside a running container, not by reading the argv — see `test_isolated_sandbox_container_really_has_no_network`.
+
+The published port is dropped for isolated packs because Docker **silently discards `-p` on a container with no network** (`NetworkSettings.Ports` comes back empty), so publishing one would put a claim in the argv that the daemon ignores. `docker exec` enters the container's network namespace and reaches the still-listening server over its own loopback, which needs no network of any kind — so isolation costs nothing at the protocol level. This closes the parity gap this document previously recorded; note that the Unix-domain-socket alternative does *not* work on Docker Desktop for macOS (bind-mounted sockets are not connectable across the VM boundary), whereas the `docker exec` transport is portable.
+
+`hermesagent-20` and `aider-polyglot-30` are `False` because they call out to the runner's model endpoint from inside the container. Isolation and that call-out are mutually exclusive: `_build_docker_run_argv` raises `ValueError` if a pack ever declares `network_isolated=True` while also needing `--add-host host.docker.internal:host-gateway`.
 
 This mirrors the deterministic-pack `ScenarioResult` taxonomy — verifiers in sandbox containers produce the same shape as in-process verifiers, so the runner can treat them uniformly.
 

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import subprocess
+
 import pytest
 
 from benchlocal_cli.runner import Runner
@@ -914,6 +916,107 @@ def test_hermes_docker_argv_keeps_non_loopback_env_gated(monkeypatch):
     assert "host.docker.internal:host-gateway" not in argv
 
 
+# ---------------------------------------------------------------------------
+# #108: network_isolated must actually isolate.
+#
+# The registry declared `network_isolated=True` for three packs while the argv
+# builder emitted no --network flag at all, so the property was decorative.
+# These tests fail if the flag is ever dropped again.
+# ---------------------------------------------------------------------------
+
+_ISOLATED_PACKS = ["cli-40", "humaneval-plus-30", "lcb-v6-30"]
+_OPEN_PACKS = ["bugfind-15", "hermesagent-20", "aider-polyglot-30"]
+
+
+@pytest.mark.parametrize("pack_id", _ISOLATED_PACKS)
+def test_isolated_pack_docker_argv_uses_network_none(pack_id):
+    """A pack declaring network_isolated=True must get `--network none`."""
+    from benchlocal_cli.sandbox import SandboxClient, config_for_pack
+
+    config = config_for_pack(pack_id)
+    assert config.network_isolated is True, f"{pack_id} should declare isolation"
+
+    argv = SandboxClient(config)._build_docker_run_argv("test-name", None)
+
+    assert "--network" in argv, f"{pack_id} lost its --network flag"
+    assert argv[argv.index("--network") + 1] == "none"
+
+
+@pytest.mark.parametrize("pack_id", _ISOLATED_PACKS)
+def test_isolated_pack_publishes_no_port(pack_id):
+    """Docker silently discards `-p` on a `--network none` container, so
+    publishing one would put a lie in the argv. Isolated packs are driven over
+    container loopback via `docker exec` instead."""
+    from benchlocal_cli.sandbox import SandboxClient, config_for_pack
+
+    argv = SandboxClient(config_for_pack(pack_id))._build_docker_run_argv("test-name", None)
+
+    assert "-p" not in argv
+    assert "9000" not in " ".join(argv)
+
+
+@pytest.mark.parametrize("pack_id", _ISOLATED_PACKS)
+def test_isolated_pack_never_gets_host_gateway(pack_id):
+    """host.docker.internal routing would hand an 'isolated' container a route
+    to the host. It must never appear on an isolated pack, loopback endpoint
+    or not."""
+    from benchlocal_cli.sandbox import SandboxClient, config_for_pack
+
+    client = SandboxClient(config_for_pack(pack_id), model_endpoint="http://localhost:9999/v1")
+    argv = client._build_docker_run_argv("test-name", None)
+
+    assert "--add-host" not in argv
+    assert "host-gateway" not in " ".join(argv)
+
+
+@pytest.mark.parametrize("pack_id", _OPEN_PACKS)
+def test_open_pack_keeps_published_port_and_no_network_flag(pack_id):
+    """Packs that legitimately need the network are unchanged: published port,
+    no --network flag. aider/hermes call out to the model endpoint; bugfind
+    keeps the port transport."""
+    from benchlocal_cli.sandbox import SandboxClient, config_for_pack
+
+    config = config_for_pack(pack_id)
+    assert config.network_isolated is False
+
+    argv = SandboxClient(config)._build_docker_run_argv("test-name", None)
+
+    assert "--network" not in argv
+    assert "-p" in argv
+    assert f"{config.host_port}:9000" in argv
+
+
+def test_isolation_and_host_gateway_are_mutually_exclusive():
+    """Declaring isolation on a pack that needs host.docker.internal is a
+    contradiction — the builder refuses instead of silently dropping one."""
+    import dataclasses
+
+    from benchlocal_cli.sandbox import SandboxClient, config_for_pack
+
+    contradictory = dataclasses.replace(
+        config_for_pack("aider-polyglot-30"), network_isolated=True
+    )
+    client = SandboxClient(contradictory, model_endpoint="http://127.0.0.1:9999/v1")
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        client._build_docker_run_argv("test-name", None)
+
+
+def test_aider_host_gateway_is_gated_on_loopback_endpoint():
+    """#108: aider took --add-host unconditionally. It is needed only for the
+    loopback endpoints resolve_endpoint_for_container() actually rewrites; for
+    a LAN/tailnet endpoint it was vestigial."""
+    from benchlocal_cli.sandbox import SandboxClient, config_for_pack
+
+    config = config_for_pack("aider-polyglot-30")
+
+    loopback = SandboxClient(config, model_endpoint="http://127.0.0.1:9999/v1")
+    assert "--add-host" in loopback._build_docker_run_argv("n", None)
+
+    tailnet = SandboxClient(config, model_endpoint="http://100.71.129.2:8080/v1")
+    assert "--add-host" not in tailnet._build_docker_run_argv("n", None)
+
+
 def test_runner_rewrites_hermes_loopback_endpoint_without_env(monkeypatch):
     monkeypatch.delenv("BENCHLOCAL_HERMES_RESOLVE_LOCALHOST", raising=False)
     runner = Runner(
@@ -1657,3 +1760,64 @@ def test_cli_native_thinking_controls_preserve_explicit_extra_body(monkeypatch):
     assert run.result.passed is True
     assert CapturingHTTPClient.requests[0]["enable_thinking"] is False
     assert CapturingHTTPClient.requests[0]["thinking_budget"] == 17
+
+
+# ---------------------------------------------------------------------------
+# #108: real containment. The argv assertions above prove the flag is emitted;
+# this proves the flag does what it claims. Skipped unless Docker and the
+# cli-40 image are actually present.
+# ---------------------------------------------------------------------------
+
+
+def _docker_image_available(image: str) -> bool:
+    try:
+        return subprocess.run(
+            ["docker", "image", "inspect", image],
+            capture_output=True,
+            timeout=20,
+        ).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+@pytest.mark.skipif(
+    not _docker_image_available("benchlocal-sandbox-cli:latest"),
+    reason="needs Docker + benchlocal-sandbox-cli:latest",
+)
+def test_isolated_sandbox_container_really_has_no_network():
+    """Start the real cli-40 sandbox and observe, from inside the container,
+    that it cannot reach the network — while the verifier API still answers
+    over the docker-exec transport."""
+    from benchlocal_cli.sandbox import SandboxClient, config_for_pack
+
+    client = SandboxClient(config_for_pack("cli-40"))
+    client.start(ready_timeout_s=60)
+    try:
+        container_id = client._container_id
+        assert container_id
+
+        mode = subprocess.run(
+            ["docker", "inspect", container_id, "--format",
+             "{{.HostConfig.NetworkMode}}|{{len .NetworkSettings.Ports}}"],
+            capture_output=True, text=True, timeout=20,
+        ).stdout.strip()
+        assert mode == "none|0", f"expected an unnetworked container, got {mode!r}"
+
+        # The verifier API still answers — isolation did not cost us the transport.
+        status, _ = client._exec_http("/health", None, timeout_s=10)
+        assert status == 200
+
+        # ...and the container genuinely cannot get out.
+        probe = subprocess.run(
+            ["docker", "exec", container_id, "python3", "-c",
+             "import socket\n"
+             "try:\n"
+             "    socket.create_connection(('1.1.1.1', 443), timeout=5)\n"
+             "    print('REACHED')\n"
+             "except OSError as exc:\n"
+             "    print('BLOCKED', type(exc).__name__)\n"],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert "BLOCKED" in probe.stdout, f"container reached the network: {probe.stdout!r}"
+    finally:
+        client.stop()


### PR DESCRIPTION
`network_isolated` was declared on every pack but never reached `docker run`: the
argv builder emitted no `--network` flag at all, so `cli-40`, `humaneval-plus-30`
and `lcb-v6-30` each declared containment and none of them had it.

## What changed

`network_isolated=True` now emits `--network none`. Because Docker silently
discards `-p` on a network-none container, the sandbox for those packs is driven
over `docker exec` plus container loopback rather than a published port.

Packs that legitimately reach the host model endpoint — `bugfind-15`,
`hermesagent-20`, `aider-polyglot-30` — keep egress, and that is now a stated
property rather than an accident of a missing flag.

`--add-host host.docker.internal:host-gateway` turned out to be required for the
callers-out and incompatible with isolation: a container that can resolve and
reach the host is not isolated. Declaring both now raises at build time instead
of silently dropping one, and the flag is emitted only when the model endpoint
is a loopback address — for a LAN endpoint it was vestigial.

## Verification

Containment was checked by running a container, not by asserting on argv shape.
The same image reaches an external host with no flag and is blocked under
`--network none`.

The tests pin both directions per pack, so removing the flag again fails loudly
rather than silently restoring the old behaviour.

`tests/test_sandbox_runner.py`: 91 passed. The full suite is unchanged against
`master` — same 11 failures before and after, byte-identical failure sets, and
`tests/test_scoring_smoke.py` needs `jsonschema`, which is absent from my
environment on `master` too.

## Note on the docs

`docs/AIDER_POLYGLOT_30.md` said exercises "are network-isolated by default",
which was not true for that pack before this change and is still deliberately
not true after it. That bullet is rewritten to state what actually contains the
pack (`--rm`, and nothing else) and why aider is excluded from isolation by
design.

---

*Authorship: this change was written and verified by an AI agent (Claude) working
in the repository owner's local estate, and is submitted from their account. The
containment check described above was run against a real container rather than
asserted from the argv, and the full-suite comparison against `master` was run on
both trees. Happy to adjust scope, wording, or the doc hunk on request.*
